### PR TITLE
feat(ci): add gitleaks CI workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,26 @@
+name: Secrets (gitleaks)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  scan:
+    name: gitleaks scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          # GITLEAKS_LICENSE needed only for orgs; personal repos are free.


### PR DESCRIPTION
## Summary

Closes #16.

Pre-commit husky hook runs `gitleaks protect --staged` locally, but is bypassable via `--no-verify`, web-UI commits, or fork PRs. A CI-side workflow closes the gap.

## Changes

- New `.github/workflows/gitleaks.yml` pinned by commit SHA. Uses the existing `.gitleaks.toml` allowlist so stopwords / test fixtures stay suppressed consistently with the local hook.
- Runs on push to main, PR to main, and manual dispatch.

## Test plan

- [ ] CI run green (this PR's check)
- [ ] Workflow registered in the Actions tab

Part of epic #12.