### PR TITLE
docs(security): document Scorecard checks intentionally deferred

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,4 +63,47 @@ Include:
 - OpenSSF Scorecard workflow publishing results to the badge and security tab.
 - CodeQL workflow for JavaScript/TypeScript.
 - GitHub Actions pinned by commit SHA (not by tag) to prevent tag-move attacks.
-- Optional `gitleaks` scan in the pre-commit hook to catch accidental secrets.
+- Gitleaks secret scanning in CI (`.github/workflows/gitleaks.yml`) and pre-commit husky hook.
+- `pnpm.overrides` pins patched versions of transitive advisories (see `package.json`).
+
+## Scorecard checks — intentionally deferred
+
+A handful of [OpenSSF Scorecard](https://securityscorecards.dev/) checks are intentionally not being
+chased to a perfect score. Rationale documented here so the alerts don't cycle through "open →
+someone investigates → someone else re-opens" on every Scorecard run.
+
+### FuzzingID — project is not fuzzed
+
+**Deferred.** This is a pure data-conversion library with no untrusted-input parser surface worth
+fuzzing. The build pipeline already exercises every upstream theme file end-to-end through a strict
+Zod schema plus a hex → OKLCH → hex round-trip gate with ΔE2000 < 1.0 assertion. Fuzzing would
+test the same functions with random inputs that the Zod schema would reject before reaching
+conversion. See [CODING_STANDARDS.md §5](./CODING_STANDARDS.md#5-data-pipeline-standards-oklch-specific).
+
+Reference: [Scorecard Fuzzing check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#fuzzing)
+
+### CIIBestPracticesID — no OpenSSF Best Practices badge
+
+**Deferred.** The [OpenSSF Best Practices badge](https://www.bestpractices.dev/) is a community
+self-certification requiring governance processes (code of conduct enforcement history, security
+disclosure drills, public release process) disproportionate to a one-maintainer data-conversion
+library. Will revisit on GA (1.0) or on sustained external contribution.
+
+Reference: [Scorecard CII-Best-Practices check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#cii-best-practices)
+
+### MaintainedID — repo created within the last 90 days
+
+**Self-resolving.** This check looks at commit / issue activity over a 90-day trailing window.
+The repo was created in April 2026; the alert closes automatically once enough history accumulates.
+No action required.
+
+Reference: [Scorecard Maintained check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained)
+
+### CodeReviewID — 0 of 11 approved changesets
+
+**Self-resolving for solo projects.** The metric expects most commits to land via reviewed PRs.
+A single-maintainer project can't satisfy this without asking external reviewers to rubber-stamp
+changes they haven't context-shopped for. Metric improves naturally as external contributors
+review and approve PRs. All administrative merges by the owner bypass this check by design.
+
+Reference: [Scorecard Code-Review check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#code-review)


### PR DESCRIPTION
## Summary

Closes #15.

Adds a 'Scorecard checks — intentionally deferred' section to `SECURITY.md` explaining why four open Scorecard alerts are not being actioned.

## Changes

| Check | Status | Reason |
|---|---|---|
| FuzzingID | deferred | Pure data lib; Zod + ΔE gate covers every upstream file |
| CIIBestPracticesID | deferred | Self-certification overhead disproportionate at this scale |
| MaintainedID | self-resolves | 90-day trailing window; repo is new |
| CodeReviewID | self-resolves | Solo-maintained; improves with external contributors |

Also refreshes the 'Hardening already in place' list to mention the CI gitleaks workflow (#16) and the `pnpm.overrides` transitive-patch pattern.

## Test plan

- [x] `pnpm lint:md` clean
- [x] `pnpm format:check` clean
- [ ] CI green

Part of epic #12.