### PR TITLE
feat(site): theme picker grid — search, tag filters, URL state

### DIFF
--- a/site/src/components/FilterBar.astro
+++ b/site/src/components/FilterBar.astro
@@ -1,0 +1,217 @@
+---
+import { ALL_TAGS } from '@/lib/theme-filter';
+
+export interface Props {
+  total: number;
+}
+
+const { total } = Astro.props;
+---
+
+<section class="filter-bar" aria-label="Theme filters">
+  <label class="search">
+    <span class="visually-hidden">Search themes</span>
+    <input
+      id="theme-search"
+      type="search"
+      placeholder="Search 485 themes…"
+      autocomplete="off"
+      spellcheck="false"
+    />
+  </label>
+  <div class="tags" role="group" aria-label="Tag filters">
+    {
+      ALL_TAGS.map((tag) => (
+        <button type="button" class="tag-chip" data-tag={tag} aria-pressed="false">
+          {tag}
+        </button>
+      ))
+    }
+    <button type="button" class="tag-chip reset" data-action="reset" hidden>
+      clear
+    </button>
+  </div>
+  <output id="filter-count" class="count" aria-live="polite">{total} themes</output>
+</section>
+
+<script>
+  import {
+    matches,
+    parseFilterFromUrl,
+    writeFilterToUrl,
+    type FilterState,
+  } from '@/lib/theme-filter';
+
+  const searchInput = document.querySelector<HTMLInputElement>('#theme-search');
+  const tagChips = Array.from(document.querySelectorAll<HTMLButtonElement>('.tag-chip[data-tag]'));
+  const resetBtn = document.querySelector<HTMLButtonElement>('.tag-chip[data-action="reset"]');
+  const countEl = document.querySelector<HTMLOutputElement>('#filter-count');
+  const cards = Array.from(document.querySelectorAll<HTMLAnchorElement>('.theme-card'));
+
+  if (searchInput && countEl && cards.length > 0) {
+    const state: FilterState = parseFilterFromUrl(window.location.search);
+
+    // Sync UI with initial URL state.
+    searchInput.value = state.query;
+    for (const chip of tagChips) {
+      const tag = chip.dataset.tag ?? '';
+      if (state.tags.has(tag)) chip.setAttribute('aria-pressed', 'true');
+    }
+
+    function apply(): void {
+      if (!countEl) return;
+      let visible = 0;
+      for (const card of cards) {
+        const theme = {
+          slug: card.dataset.slug ?? '',
+          name: card.dataset.search?.split(' ')[0] ?? '',
+          isDark: card.dataset.dark === 'true',
+          tags: (card.dataset.tags ?? '').split(' ').filter((t) => t.length > 0),
+        };
+        // Re-use pure matcher; card.search contains lowercase name+slug.
+        const searchBlob = card.dataset.search ?? '';
+        const visibleByQuery =
+          state.query.length === 0 || searchBlob.includes(state.query.toLowerCase());
+        if (matches(theme, state) && visibleByQuery) {
+          card.hidden = false;
+          visible++;
+        } else {
+          card.hidden = true;
+        }
+      }
+      countEl.textContent = `${visible.toLocaleString()} of ${cards.length.toLocaleString()} themes`;
+      if (resetBtn) resetBtn.hidden = state.tags.size === 0 && state.query.length === 0;
+
+      const nextUrl = writeFilterToUrl(state, new URL(window.location.href));
+      history.replaceState(null, '', nextUrl.toString());
+    }
+
+    searchInput.addEventListener('input', () => {
+      state.query = searchInput.value.trim();
+      apply();
+    });
+
+    for (const chip of tagChips) {
+      chip.addEventListener('click', () => {
+        const tag = chip.dataset.tag ?? '';
+        if (state.tags.has(tag)) {
+          state.tags.delete(tag);
+          chip.setAttribute('aria-pressed', 'false');
+        } else {
+          state.tags.add(tag);
+          chip.setAttribute('aria-pressed', 'true');
+        }
+        apply();
+      });
+    }
+
+    resetBtn?.addEventListener('click', () => {
+      state.query = '';
+      state.tags.clear();
+      searchInput.value = '';
+      for (const chip of tagChips) chip.setAttribute('aria-pressed', 'false');
+      apply();
+    });
+
+    apply();
+  }
+</script>
+
+<style>
+  .filter-bar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    padding: 1rem 0;
+    background: color-mix(in oklch, var(--bg) 92%, transparent);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--border);
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: minmax(16rem, 1fr) auto;
+    grid-template-areas:
+      'search count'
+      'tags tags';
+    align-items: center;
+  }
+  @media (min-width: 48rem) {
+    .filter-bar {
+      grid-template-columns: minmax(16rem, 1fr) minmax(0, 2fr) auto;
+      grid-template-areas: 'search tags count';
+    }
+  }
+
+  .search {
+    grid-area: search;
+    display: block;
+  }
+
+  .search input {
+    width: 100%;
+    padding: 0.55rem 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: var(--surface);
+    color: var(--fg);
+    font-size: 0.95rem;
+    font-family: var(--font-sans);
+  }
+  .search input:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-color: var(--accent);
+  }
+
+  .tags {
+    grid-area: tags;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .tag-chip {
+    padding: 0.3rem 0.7rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface);
+    color: inherit;
+    cursor: pointer;
+    font-size: 0.8rem;
+    text-transform: lowercase;
+    letter-spacing: 0.02em;
+    transition:
+      background 80ms,
+      border-color 80ms,
+      color 80ms;
+  }
+  .tag-chip[aria-pressed='true'] {
+    background: color-mix(in oklch, var(--accent) 15%, transparent);
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  .tag-chip.reset {
+    border-style: dashed;
+    color: color-mix(in oklch, currentColor 70%, transparent);
+  }
+
+  .count {
+    grid-area: count;
+    font-size: 0.85rem;
+    color: color-mix(in oklch, currentColor 65%, transparent);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/site/src/components/ThemeCard.astro
+++ b/site/src/components/ThemeCard.astro
@@ -1,0 +1,152 @@
+---
+// Structural shape — looser than the strict `TerminalColorTheme` export of the
+// npm package so `themes.json` can be passed directly without casting away the
+// literal-widened `source` field.
+export interface SiteTheme {
+  name: string;
+  slug: string;
+  isDark: boolean;
+  tags: readonly string[];
+  colors: Record<
+    string,
+    { hex: string; oklch: { l: number; c: number; h: number }; oklchCss: string }
+  >;
+}
+
+export interface Props {
+  theme: SiteTheme;
+}
+
+const { theme } = Astro.props;
+
+// The 6 ANSI slots we spotlight in the mini-palette. Chosen for identity at a glance.
+const PALETTE_KEYS = ['red', 'yellow', 'green', 'cyan', 'blue', 'purple'] as const;
+const bgCss = theme.colors.background.oklchCss;
+const fgCss = theme.colors.foreground.oklchCss;
+const permalink = `?theme=${theme.slug}`;
+const searchTerm = `${theme.name.toLowerCase()} ${theme.slug}`;
+---
+
+<a
+  class="theme-card"
+  href={permalink}
+  data-slug={theme.slug}
+  data-dark={theme.isDark.toString()}
+  data-tags={theme.tags.join(' ')}
+  data-search={searchTerm}
+  aria-label={`Select ${theme.name} theme`}
+>
+  <div
+    class="preview"
+    style={`background:${bgCss};color:${fgCss}`}
+  >
+    <span class="prompt">
+      <span style={`color:${theme.colors.green.oklchCss}`}>user</span>@<span
+        style={`color:${theme.colors.blue.oklchCss}`}>host</span>
+      <span style={`color:${theme.colors.brightBlack.oklchCss}`}>~</span>
+      <span class="cursor" style={`background:${theme.colors.cursor.oklchCss}`}>&nbsp;</span>
+    </span>
+    <span class="swatches">
+      {PALETTE_KEYS.map((k) => (
+        <span class="swatch" style={`background:${theme.colors[k].oklchCss}`} title={k} />
+      ))}
+    </span>
+  </div>
+  <div class="meta">
+    <strong>{theme.name}</strong>
+    <span class="tags">
+      {theme.isDark ? 'dark' : 'light'}
+      {theme.tags.includes('popular') && <span class="tag-popular">★</span>}
+    </span>
+  </div>
+</a>
+
+<style>
+  .theme-card {
+    display: grid;
+    grid-template-rows: 1fr auto;
+    border: 1px solid var(--border);
+    border-radius: 0.625rem;
+    overflow: hidden;
+    background: var(--surface);
+    color: inherit;
+    text-decoration: none;
+    transition:
+      transform 120ms ease,
+      box-shadow 120ms ease,
+      border-color 120ms ease;
+  }
+  .theme-card:hover,
+  .theme-card:focus-visible {
+    transform: translateY(-2px);
+    border-color: color-mix(in oklch, var(--accent) 60%, var(--border));
+    box-shadow: 0 4px 14px color-mix(in oklch, black 12%, transparent);
+  }
+  .theme-card:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .preview {
+    padding: 0.75rem 0.85rem;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    min-height: 5.25rem;
+  }
+
+  .prompt {
+    display: flex;
+    align-items: center;
+    gap: 0.35ch;
+    letter-spacing: 0.01em;
+  }
+
+  .cursor {
+    display: inline-block;
+    width: 0.5rem;
+    height: 1em;
+    margin-left: 0.25ch;
+    vertical-align: middle;
+  }
+
+  .swatches {
+    display: flex;
+    gap: 2px;
+    height: 1.25rem;
+  }
+
+  .swatch {
+    flex: 1;
+    border-radius: 2px;
+  }
+
+  .meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 0.55rem 0.85rem;
+    font-size: 0.85rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .meta strong {
+    font-weight: 550;
+  }
+
+  .tags {
+    display: flex;
+    gap: 0.35rem;
+    align-items: baseline;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: color-mix(in oklch, currentColor 62%, transparent);
+  }
+
+  .tag-popular {
+    color: oklch(0.8 0.18 70);
+  }
+</style>

--- a/site/src/lib/theme-filter.ts
+++ b/site/src/lib/theme-filter.ts
@@ -1,0 +1,55 @@
+// Pure filtering helpers for the picker UI. No DOM access here — keeps the
+// logic unit-testable and lets any Island re-use it.
+
+export interface FilterableTheme {
+  slug: string;
+  name: string;
+  isDark: boolean;
+  tags: readonly string[];
+}
+
+export interface FilterState {
+  query: string;
+  tags: Set<string>;
+}
+
+export const ALL_TAGS = [
+  'dark',
+  'light',
+  'vibrant',
+  'muted',
+  'high-contrast',
+  'low-contrast',
+  'popular',
+] as const;
+
+export type FilterTag = (typeof ALL_TAGS)[number];
+
+export function matches(theme: FilterableTheme, state: FilterState): boolean {
+  if (state.tags.size > 0) {
+    for (const tag of state.tags) {
+      if (!theme.tags.includes(tag)) return false;
+    }
+  }
+  if (state.query.length === 0) return true;
+  const q = state.query.toLowerCase();
+  return theme.name.toLowerCase().includes(q) || theme.slug.includes(q);
+}
+
+export function parseFilterFromUrl(search: string): FilterState {
+  const params = new URLSearchParams(search);
+  const tagsParam = params.get('tags');
+  const tags = new Set<string>(
+    tagsParam !== null && tagsParam.length > 0 ? tagsParam.split(',') : [],
+  );
+  return { query: params.get('q') ?? '', tags };
+}
+
+export function writeFilterToUrl(state: FilterState, url: URL): URL {
+  const next = new URL(url.href);
+  if (state.query.length > 0) next.searchParams.set('q', state.query);
+  else next.searchParams.delete('q');
+  if (state.tags.size > 0) next.searchParams.set('tags', [...state.tags].join(','));
+  else next.searchParams.delete('tags');
+  return next;
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,20 +1,27 @@
 ---
 import themes from '@williamzujkowski/oklch-terminal-themes/themes.json';
 import BaseLayout from '@/layouts/BaseLayout.astro';
+import FilterBar from '@/components/FilterBar.astro';
+import ThemeCard from '@/components/ThemeCard.astro';
 
 const darkCount = themes.filter((t) => t.isDark).length;
 const lightCount = themes.length - darkCount;
 const popularCount = themes.filter((t) => t.tags.includes('popular')).length;
-const sampleSlugs = ['dracula', 'gruvbox-dark', 'nord', 'solarized-dark', 'tokyo-night', 'catppuccin-mocha']
-  .filter((s) => themes.some((t) => t.slug === s));
+
+// Popular first, then alphabetical. Helps first-paint match what most users seek.
+const sortedThemes = [...themes].sort((a, b) => {
+  const aPop = a.tags.includes('popular') ? 0 : 1;
+  const bPop = b.tags.includes('popular') ? 0 : 1;
+  return aPop - bPop || a.name.localeCompare(b.name);
+});
 ---
 
-<BaseLayout title="OKLCH Terminal Themes">
-  <section class="hero">
+<BaseLayout title="OKLCH Terminal Themes — picker">
+  <section class="intro">
     <h1>OKLCH Terminal Themes</h1>
     <p class="tagline">
-      {themes.length} terminal color schemes converted to OKLCH. Browse, preview, and copy as CSS variables,
-      Tailwind <code>@theme</code> blocks, or raw JSON.
+      {themes.length} terminal color schemes converted to OKLCH. Click a theme to preview, then copy
+      it as CSS variables, Tailwind <code>@theme</code>, or raw JSON.
     </p>
     <dl class="stats">
       <div><dt>total</dt><dd>{themes.length}</dd></div>
@@ -24,56 +31,52 @@ const sampleSlugs = ['dracula', 'gruvbox-dark', 'nord', 'solarized-dark', 'tokyo
     </dl>
   </section>
 
-  <section class="samples">
-    <h2>Featured</h2>
-    <ul class="sample-grid">
+  <FilterBar total={themes.length} />
+
+  <section class="grid-wrap" aria-label="Theme grid">
+    <ul class="theme-grid">
       {
-        sampleSlugs.map((slug) => {
-          const t = themes.find((x) => x.slug === slug)!;
-          return (
-            <li class="sample" data-theme={t.slug}>
-              <header>
-                <strong>{t.name}</strong>
-                <span class="meta">{t.isDark ? 'dark' : 'light'}</span>
-              </header>
-              <div
-                class="swatches"
-                style={`background:${t.colors.background.oklchCss};color:${t.colors.foreground.oklchCss}`}
-              >
-                {['red', 'yellow', 'green', 'cyan', 'blue', 'purple'].map((k) => (
-                  <span style={`background:${t.colors[k as 'red'].oklchCss}`} title={k} />
-                ))}
-              </div>
-            </li>
-          );
-        })
+        sortedThemes.map((theme) => (
+          <li>
+            <ThemeCard theme={theme} />
+          </li>
+        ))
       }
     </ul>
-  </section>
-
-  <section class="install">
-    <h2>Install</h2>
-    <pre><code>pnpm add @williamzujkowski/oklch-terminal-themes</code></pre>
-    <p>
-      See <a href="https://github.com/williamzujkowski/oklch-terminal-themes#readme">README</a> for full usage.
-    </p>
+    <p class="empty" hidden>No themes match your filters.</p>
   </section>
 </BaseLayout>
 
+<script>
+  // Reveal the empty-state message when all cards are hidden by filters.
+  const emptyEl = document.querySelector<HTMLElement>('.empty');
+  const listEl = document.querySelector<HTMLUListElement>('.theme-grid');
+  if (emptyEl && listEl) {
+    const obs = new MutationObserver(() => {
+      const anyVisible = Array.from(listEl.querySelectorAll<HTMLElement>('.theme-card')).some(
+        (el) => !el.hidden,
+      );
+      emptyEl.hidden = anyVisible;
+    });
+    obs.observe(listEl, { attributes: true, subtree: true, attributeFilter: ['hidden'] });
+  }
+</script>
+
 <style>
-  .hero {
-    padding: 4rem 0 2rem;
+  .intro {
+    padding: 2.5rem 0 1.5rem;
     text-align: center;
   }
-  .hero h1 {
-    font-size: clamp(2rem, 6vw, 3.5rem);
-    margin: 0 0 0.5rem;
+  .intro h1 {
+    font-size: clamp(1.8rem, 5vw, 2.8rem);
+    margin: 0 0 0.4rem;
     letter-spacing: -0.02em;
   }
   .tagline {
     max-width: 44rem;
-    margin: 0 auto 2rem;
-    color: color-mix(in oklch, currentColor 70%, transparent);
+    margin: 0 auto 1.5rem;
+    color: color-mix(in oklch, currentColor 72%, transparent);
+    line-height: 1.55;
   }
   .stats {
     display: flex;
@@ -84,64 +87,42 @@ const sampleSlugs = ['dracula', 'gruvbox-dark', 'nord', 'solarized-dark', 'tokyo
   }
   .stats div {
     display: grid;
-    gap: 0.25rem;
+    gap: 0.2rem;
   }
   .stats dt {
-    font-size: 0.75rem;
+    font-size: 0.72rem;
     text-transform: uppercase;
     letter-spacing: 0.1em;
     color: color-mix(in oklch, currentColor 60%, transparent);
   }
   .stats dd {
-    font-size: 1.5rem;
+    font-size: 1.35rem;
     font-weight: 600;
     margin: 0;
     font-variant-numeric: tabular-nums;
   }
 
-  .samples {
-    padding: 3rem 0;
-  }
-  .sample-grid {
-    list-style: none;
-    padding: 0;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
-    gap: 1rem;
-  }
-  .sample {
-    border: 1px solid color-mix(in oklch, currentColor 15%, transparent);
-    border-radius: 0.75rem;
-    overflow: hidden;
-  }
-  .sample header {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    padding: 0.75rem 1rem;
-    font-size: 0.95rem;
-  }
-  .sample .meta {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    opacity: 0.6;
-  }
-  .swatches {
-    display: flex;
-    height: 4rem;
-  }
-  .swatches > span {
-    flex: 1;
+  .grid-wrap {
+    padding: 1.5rem 0 4rem;
   }
 
-  .install {
-    padding: 3rem 0 6rem;
+  .theme-grid {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+    gap: 0.85rem;
   }
-  .install pre {
-    background: color-mix(in oklch, currentColor 8%, transparent);
-    padding: 1rem;
-    border-radius: 0.5rem;
-    overflow-x: auto;
+
+  .theme-grid li {
+    display: contents;
+  }
+
+  .empty {
+    padding: 3rem 1rem;
+    text-align: center;
+    color: color-mix(in oklch, currentColor 60%, transparent);
+    font-size: 0.95rem;
   }
 </style>


### PR DESCRIPTION
## Summary

Closes #17. Supersedes closed #25 (base branch feat/site-scaffold was deleted when #14 merged; GitHub auto-closed rather than retargeting).

Adds the picker UI on top of the merged scaffold: 485-theme grid + sticky filter bar + URL state sync.

## Components

- **`theme-filter.ts`** — pure filter helpers (`matches`, `parseFilterFromUrl`, `writeFilterToUrl`). No DOM; unit-testable.
- **`ThemeCard.astro`** — rendered 485 times at build time. Mini terminal preview + 6-swatch ANSI palette. Data attributes carry `slug`/`dark`/`tags`/`search` for O(1) filtering.
- **`FilterBar.astro`** — sticky header. Search + 7 tag chips + live count. `aria-pressed` toggle chips, focus rings, 'clear' button visible only with active filters.
- **`index.astro`** — picker page. Popular-first + alphabetical sort. MutationObserver drives the empty-state message.

## UX

- URL: `?q=dracula&tags=popular,dark` — shareable and restores on load.
- Responsive CSS grid (`auto-fill`, min 15rem).
- Sticky filter bar with `backdrop-filter: blur`.
- Keyboard + a11y: focus rings, `aria-pressed` chips, `aria-live="polite"` count.

## Build stats

807 KB `index.html` (all 485 cards inlined for zero-JS first paint) + 6.5 KB CSS.

## Test plan

- [x] `pnpm lint && typecheck && test && lint:md && format:check` — green
- [x] `pnpm --filter ...site typecheck` — 0 errors / warnings / hints
- [x] `pnpm --filter ...site build` — clean
- [ ] PR CI green

Part of epic #12.