### PR TITLE
feat(site): dual-pane preview — terminal + website mocks

### DIFF
--- a/site/src/components/PreviewPane.astro
+++ b/site/src/components/PreviewPane.astro
@@ -1,0 +1,173 @@
+---
+import TerminalMock from './TerminalMock.astro';
+import WebsiteMock from './WebsiteMock.astro';
+---
+
+<section id="preview-pane" class="preview-pane" hidden aria-label="Theme preview">
+  <header class="preview-head">
+    <div>
+      <span class="eyebrow">Preview</span>
+      <h2 id="preview-name" class="theme-name">—</h2>
+      <p id="preview-meta" class="meta">—</p>
+    </div>
+    <a id="preview-close" class="close" href="./" aria-label="Close preview">×</a>
+  </header>
+  <div class="mocks">
+    <TerminalMock />
+    <WebsiteMock />
+  </div>
+</section>
+
+<script>
+  type SlimTheme = {
+    name: string;
+    slug: string;
+    isDark: boolean;
+    colors: Record<string, string>;
+  };
+
+  // The index page inlines `themes-slim.json` as JSON; look it up by id.
+  function readThemes(): Record<string, SlimTheme> {
+    const el = document.querySelector<HTMLScriptElement>('#themes-data');
+    if (!el) return {};
+    const arr = JSON.parse(el.textContent ?? '[]') as SlimTheme[];
+    const map: Record<string, SlimTheme> = {};
+    for (const t of arr) map[t.slug] = t;
+    return map;
+  }
+
+  const themes = readThemes();
+  const pane = document.querySelector<HTMLElement>('#preview-pane');
+  const nameEl = document.querySelector<HTMLElement>('#preview-name');
+  const metaEl = document.querySelector<HTMLElement>('#preview-meta');
+  const terminal = document.querySelector<HTMLElement>('.terminal-mock');
+  const webmock = document.querySelector<HTMLElement>('.web-mock');
+
+  // camelCase (colors.brightRed) → kebab (--tt-bright-red)
+  function toCssVar(key: string): string {
+    return '--tt-' + key.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+  }
+
+  function applyTheme(slug: string | null): void {
+    if (!pane || !nameEl || !metaEl || !terminal || !webmock) return;
+    if (slug === null || !(slug in themes)) {
+      pane.hidden = true;
+      return;
+    }
+    const theme = themes[slug];
+    if (!theme) {
+      pane.hidden = true;
+      return;
+    }
+    nameEl.textContent = theme.name;
+    metaEl.textContent = `${theme.isDark ? 'dark' : 'light'} · ${theme.slug}`;
+    for (const [k, v] of Object.entries(theme.colors)) {
+      const variable = toCssVar(k);
+      terminal.style.setProperty(variable, v);
+      webmock.style.setProperty(variable, v);
+    }
+    pane.hidden = false;
+  }
+
+  function currentSlug(): string | null {
+    return new URLSearchParams(window.location.search).get('theme');
+  }
+
+  applyTheme(currentSlug());
+
+  // Cards use `?theme=<slug>` hrefs. Intercept to avoid full page reload.
+  document.addEventListener('click', (ev) => {
+    const target = ev.target;
+    if (!(target instanceof Element)) return;
+    const card = target.closest<HTMLAnchorElement>('a.theme-card');
+    if (!card) return;
+    ev.preventDefault();
+    const url = new URL(card.href, window.location.origin);
+    const slug = url.searchParams.get('theme');
+    if (slug === null) return;
+    const next = new URL(window.location.href);
+    next.searchParams.set('theme', slug);
+    history.pushState(null, '', next.toString());
+    applyTheme(slug);
+    pane?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+
+  // Close button returns to no-theme state.
+  document.querySelector<HTMLAnchorElement>('#preview-close')?.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    const next = new URL(window.location.href);
+    next.searchParams.delete('theme');
+    history.pushState(null, '', next.toString());
+    applyTheme(null);
+  });
+
+  window.addEventListener('popstate', () => applyTheme(currentSlug()));
+</script>
+
+<style>
+  .preview-pane {
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+    overflow: hidden;
+    background: var(--surface);
+    margin: 1.5rem 0;
+  }
+
+  .preview-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 0.9rem 1.1rem;
+    border-bottom: 1px solid var(--border);
+    background: color-mix(in oklch, var(--fg) 4%, transparent);
+  }
+  .preview-head .eyebrow {
+    display: block;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: color-mix(in oklch, var(--fg) 60%, transparent);
+  }
+  .preview-head .theme-name {
+    margin: 0;
+    font-size: 1.35rem;
+    font-family: var(--font-mono);
+    letter-spacing: -0.01em;
+  }
+  .preview-head .meta {
+    margin: 0;
+    font-size: 0.78rem;
+    color: color-mix(in oklch, var(--fg) 65%, transparent);
+  }
+  .close {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    background: color-mix(in oklch, var(--fg) 6%, transparent);
+    color: var(--fg);
+    text-decoration: none;
+    display: grid;
+    place-items: center;
+    font-size: 1.3rem;
+    line-height: 1;
+    transition:
+      background 100ms,
+      color 100ms;
+  }
+  .close:hover,
+  .close:focus-visible {
+    background: color-mix(in oklch, var(--accent) 35%, transparent);
+    color: var(--fg);
+  }
+
+  .mocks {
+    display: grid;
+    gap: 0.9rem;
+    padding: 0.9rem;
+  }
+  @media (min-width: 58rem) {
+    .mocks {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+</style>

--- a/site/src/components/TerminalMock.astro
+++ b/site/src/components/TerminalMock.astro
@@ -1,0 +1,85 @@
+---
+// Server-rendered terminal-widget skeleton. Client JS later paints the colors
+// by setting CSS custom properties on .terminal-mock from the selected theme.
+---
+
+<pre class="terminal-mock" aria-hidden="true">
+  <span class="line"><span class="ansi-green">user</span>@<span class="ansi-blue">host</span> <span class="ansi-bright-black">~/oklch-terminal-themes</span> <span class="ansi-bright-black">$</span> <span class="ansi-fg">ls</span></span>
+  <span class="line"><span class="ansi-blue">data/</span>  <span class="ansi-blue">dist/</span>  <span class="ansi-bright-magenta">package.json</span>  <span class="ansi-fg">README.md</span>  <span class="ansi-bright-green">scripts/</span></span>
+  <span class="line"><span class="ansi-green">user</span>@<span class="ansi-blue">host</span> <span class="ansi-bright-black">~/oklch-terminal-themes</span> <span class="ansi-bright-black">$</span> <span class="ansi-fg">git diff src/convert.ts</span></span>
+  <span class="line"><span class="ansi-bright-black">diff --git a/src/convert.ts b/src/convert.ts</span></span>
+  <span class="line"><span class="ansi-red">-  if (ok === undefined) throw new Error('fail');</span></span>
+  <span class="line"><span class="ansi-green">+  // trust culori non-nullable return type</span></span>
+  <span class="line"><span class="ansi-green">user</span>@<span class="ansi-blue">host</span> <span class="ansi-bright-black">~/oklch-terminal-themes</span> <span class="ansi-bright-black">$</span> <span class="ansi-fg">cat convert.ts</span></span>
+  <span class="line"><span class="ansi-bright-black">// convert hex → OKLCH via culori</span></span>
+  <span class="line"><span class="ansi-magenta">import</span> <span class="ansi-fg">&lbrace; converter &rbrace;</span> <span class="ansi-magenta">from</span> <span class="ansi-yellow">'culori'</span><span class="ansi-fg">;</span></span>
+  <span class="line"><span class="ansi-magenta">const</span> <span class="ansi-cyan">toOklch</span> <span class="ansi-fg">=</span> <span class="ansi-cyan">converter</span><span class="ansi-fg">(</span><span class="ansi-yellow">'oklch'</span><span class="ansi-fg">);</span></span>
+  <span class="line"><span class="ansi-magenta">export</span> <span class="ansi-magenta">function</span> <span class="ansi-cyan">convert</span><span class="ansi-fg">(hex:</span> <span class="ansi-yellow">string</span><span class="ansi-fg">):</span> <span class="ansi-yellow">string</span> <span class="ansi-fg">&lbrace;</span></span>
+  <span class="line">  <span class="ansi-magenta">return</span> <span class="ansi-cyan">toOklch</span><span class="ansi-fg">(hex)?.mode </span><span class="ansi-fg">??</span> <span class="ansi-yellow">''</span><span class="ansi-fg">;</span></span>
+  <span class="line"><span class="ansi-fg">&rbrace;</span></span>
+  <span class="line"><span class="ansi-green">user</span>@<span class="ansi-blue">host</span> <span class="ansi-bright-black">~/oklch-terminal-themes</span> <span class="ansi-bright-black">$</span> <span class="cursor">▎</span></span>
+</pre>
+
+<style>
+  .terminal-mock {
+    background: var(--tt-bg, oklch(0.2 0.02 260));
+    color: var(--tt-fg, oklch(0.9 0.02 260));
+    padding: 1rem 1.1rem;
+    border-radius: 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    line-height: 1.55;
+    margin: 0;
+    overflow-x: auto;
+    white-space: pre;
+    box-shadow: 0 2px 20px color-mix(in oklch, black 18%, transparent);
+  }
+  .terminal-mock .line {
+    display: block;
+    white-space: pre;
+  }
+  .terminal-mock .ansi-fg {
+    color: var(--tt-fg);
+  }
+  .terminal-mock .ansi-red {
+    color: var(--tt-red);
+  }
+  .terminal-mock .ansi-green {
+    color: var(--tt-green);
+  }
+  .terminal-mock .ansi-yellow {
+    color: var(--tt-yellow);
+  }
+  .terminal-mock .ansi-blue {
+    color: var(--tt-blue);
+  }
+  .terminal-mock .ansi-magenta {
+    color: var(--tt-purple);
+  }
+  .terminal-mock .ansi-cyan {
+    color: var(--tt-cyan);
+  }
+  .terminal-mock .ansi-bright-black {
+    color: var(--tt-bright-black);
+  }
+  .terminal-mock .ansi-bright-green {
+    color: var(--tt-bright-green);
+  }
+  .terminal-mock .ansi-bright-magenta {
+    color: var(--tt-bright-purple);
+  }
+  .terminal-mock .cursor {
+    color: var(--tt-cursor, var(--tt-fg));
+    animation: blink 1.1s steps(2) infinite;
+  }
+  @keyframes blink {
+    50% {
+      opacity: 0;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .terminal-mock .cursor {
+      animation: none;
+    }
+  }
+</style>

--- a/site/src/components/WebsiteMock.astro
+++ b/site/src/components/WebsiteMock.astro
@@ -1,0 +1,184 @@
+---
+// Mock web-page chrome that paints itself from the active theme's bg/fg/accents.
+// Semantic mapping: blue → link, green → success, red → danger, purple → accent.
+---
+
+<article class="web-mock" aria-hidden="true">
+  <header class="wm-nav">
+    <span class="wm-brand">remarque</span>
+    <nav>
+      <a href="#">Posts</a>
+      <a href="#">Projects</a>
+      <a href="#">About</a>
+    </nav>
+  </header>
+
+  <section class="wm-hero">
+    <h2>Distraction-free canvas.</h2>
+    <p>
+      A preview page painted with this theme's palette. The nav brand uses the accent
+      color, code snippets render with the full ANSI mapping, and status chips exercise
+      success and danger slots.
+    </p>
+    <div class="wm-cta-row">
+      <button class="wm-cta">Read more</button>
+      <span class="wm-chip wm-success">deployed</span>
+      <span class="wm-chip wm-danger">3 alerts</span>
+    </div>
+  </section>
+
+  <section class="wm-cards">
+    <div class="wm-card">
+      <h3>Color tokens</h3>
+      <p>Background, foreground, and 16 ANSI slots wired as CSS custom properties.</p>
+    </div>
+    <div class="wm-card">
+      <h3>Tailwind v4</h3>
+      <p>One <code>@theme</code> block and you're done.</p>
+    </div>
+  </section>
+
+  <pre class="wm-code"><span class="k">const</span> <span class="v">dracula</span> <span class="p">=</span> <span class="s">'oklch(0.28 0.04 278)'</span><span class="p">;</span>
+<span class="k">export</span> <span class="k">default</span> <span class="v">dracula</span><span class="p">;</span>
+<span class="c">// 484 more available</span></pre>
+</article>
+
+<style>
+  .web-mock {
+    --wm-pad: 1.2rem;
+    background: var(--tt-bg, oklch(0.98 0 0));
+    color: var(--tt-fg, oklch(0.2 0 0));
+    border-radius: 0.5rem;
+    padding: 0;
+    font-family: var(--font-sans);
+    font-size: 0.88rem;
+    overflow: hidden;
+    box-shadow: 0 2px 20px color-mix(in oklch, black 10%, transparent);
+    display: grid;
+    gap: 0.9rem;
+  }
+
+  .wm-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem var(--wm-pad);
+    border-bottom: 1px solid color-mix(in oklch, var(--tt-fg) 12%, transparent);
+  }
+  .wm-brand {
+    color: var(--tt-purple, var(--tt-fg));
+    font-weight: 650;
+    font-family: var(--font-mono);
+    letter-spacing: -0.01em;
+  }
+  .wm-nav nav {
+    display: flex;
+    gap: 0.9rem;
+  }
+  .wm-nav a {
+    color: var(--tt-blue, var(--tt-fg));
+    text-decoration: none;
+    font-size: 0.82rem;
+  }
+
+  .wm-hero {
+    padding: 0 var(--wm-pad);
+  }
+  .wm-hero h2 {
+    margin: 0 0 0.4rem;
+    font-size: 1.25rem;
+    letter-spacing: -0.015em;
+  }
+  .wm-hero p {
+    margin: 0 0 0.75rem;
+    line-height: 1.55;
+    color: color-mix(in oklch, var(--tt-fg) 82%, transparent);
+  }
+
+  .wm-cta-row {
+    display: flex;
+    gap: 0.55rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .wm-cta {
+    background: var(--tt-purple, var(--tt-fg));
+    color: var(--tt-bg);
+    border: none;
+    border-radius: 0.35rem;
+    padding: 0.4rem 0.9rem;
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+  .wm-chip {
+    padding: 0.15rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .wm-success {
+    background: color-mix(in oklch, var(--tt-green) 22%, transparent);
+    color: var(--tt-green);
+  }
+  .wm-danger {
+    background: color-mix(in oklch, var(--tt-red) 22%, transparent);
+    color: var(--tt-red);
+  }
+
+  .wm-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    gap: 0.55rem;
+    padding: 0 var(--wm-pad);
+  }
+  .wm-card {
+    background: color-mix(in oklch, var(--tt-fg) 6%, transparent);
+    border: 1px solid color-mix(in oklch, var(--tt-fg) 12%, transparent);
+    border-radius: 0.35rem;
+    padding: 0.75rem;
+  }
+  .wm-card h3 {
+    margin: 0 0 0.25rem;
+    font-size: 0.92rem;
+  }
+  .wm-card p {
+    margin: 0;
+    font-size: 0.78rem;
+    color: color-mix(in oklch, var(--tt-fg) 72%, transparent);
+  }
+  .wm-card code {
+    font-family: var(--font-mono);
+    background: color-mix(in oklch, var(--tt-fg) 8%, transparent);
+    padding: 0 0.25rem;
+    border-radius: 0.2rem;
+  }
+
+  .wm-code {
+    margin: 0;
+    padding: 0.85rem var(--wm-pad);
+    background: color-mix(in oklch, var(--tt-fg) 4%, transparent);
+    border-top: 1px solid color-mix(in oklch, var(--tt-fg) 12%, transparent);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--tt-fg);
+    overflow-x: auto;
+    white-space: pre;
+  }
+  .wm-code .k {
+    color: var(--tt-purple, var(--tt-fg));
+  }
+  .wm-code .v {
+    color: var(--tt-cyan, var(--tt-fg));
+  }
+  .wm-code .s {
+    color: var(--tt-yellow, var(--tt-fg));
+  }
+  .wm-code .p {
+    color: var(--tt-fg);
+  }
+  .wm-code .c {
+    color: var(--tt-bright-black, color-mix(in oklch, var(--tt-fg) 50%, transparent));
+  }
+</style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,7 +1,9 @@
 ---
 import themes from '@williamzujkowski/oklch-terminal-themes/themes.json';
+import slim from '@williamzujkowski/oklch-terminal-themes/themes-slim.json';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import FilterBar from '@/components/FilterBar.astro';
+import PreviewPane from '@/components/PreviewPane.astro';
 import ThemeCard from '@/components/ThemeCard.astro';
 
 const darkCount = themes.filter((t) => t.isDark).length;
@@ -14,6 +16,11 @@ const sortedThemes = [...themes].sort((a, b) => {
   const bPop = b.tags.includes('popular') ? 0 : 1;
   return aPop - bPop || a.name.localeCompare(b.name);
 });
+
+// Slim dataset — each color is a ready-to-paste `oklch(...)` string. Embedded
+// below so the preview script can look up any theme by slug without another
+// network hit.
+const slimJson = JSON.stringify(slim);
 ---
 
 <BaseLayout title="OKLCH Terminal Themes — picker">
@@ -33,6 +40,8 @@ const sortedThemes = [...themes].sort((a, b) => {
 
   <FilterBar total={themes.length} />
 
+  <PreviewPane />
+
   <section class="grid-wrap" aria-label="Theme grid">
     <ul class="theme-grid">
       {
@@ -45,6 +54,8 @@ const sortedThemes = [...themes].sort((a, b) => {
     </ul>
     <p class="empty" hidden>No themes match your filters.</p>
   </section>
+
+  <script is:inline id="themes-data" type="application/json" set:html={slimJson} />
 </BaseLayout>
 
 <script>


### PR DESCRIPTION
## Summary

Closes #18. Stacks on #26 (picker). Merge #26 first, then this retargets to main.

Adds the live preview: click a theme card → `?theme=<slug>` → two painted panes.

## Components

- **`TerminalMock.astro`** — shell prompt + `git diff` + syntax-highlighted `culori` code block. Exercises all 16 ANSI slots + cursor + fg. `prefers-reduced-motion` aware.
- **`WebsiteMock.astro`** — mini page chrome (nav / hero / CTA / chips / card grid / code block). Semantic mapping: `blue`→links, `green`→success, `red`→danger, `purple`→accent.
- **`PreviewPane.astro`** — orchestrator. Reads `?theme=<slug>`. Close button + back/forward via `popstate`.

## Client wiring

- `themes-slim.json` embedded inline as `<script type="application/json">` (0 network hits).
- Click delegation on `.theme-card` intercepts the href; updates URL + pane in place.
- Color keys mapped to `--tt-<kebab>` CSS custom props on each mock.

## Layout

- Stacked on mobile, side-by-side ≥ 58rem.
- A11y: `aria-label`, descriptive close button, `aria-hidden="true"` on decorative mock content.

## Test plan

- [x] lint / typecheck / test / lint:md / format:check — green
- [x] `pnpm --filter ...site typecheck` — 0 / 0 / 0
- [x] `pnpm --filter ...site build` — clean
- [ ] PR CI green
- [ ] After deploy: click several cards and verify paint (chrome-review #22)

Part of epic #12.