### PR TITLE
feat(site): actions panel — copy CSS / Tailwind / JSON / permalink

### DIFF
--- a/site/src/components/ActionsPanel.astro
+++ b/site/src/components/ActionsPanel.astro
@@ -1,0 +1,190 @@
+---
+// Renders 4 copy buttons. Actual formatting + clipboard work happens client-side
+// in the script below so the current theme in the URL drives the output.
+---
+
+<section class="actions" aria-label="Theme export actions">
+  <h3 class="section-head">Export</h3>
+  <div class="buttons">
+    <button type="button" data-action="css">
+      <span class="label">CSS variables</span>
+      <span class="hint">:root &#123; --terminal-… &#125;</span>
+    </button>
+    <button type="button" data-action="tailwind">
+      <span class="label">Tailwind v4</span>
+      <span class="hint">@theme block</span>
+    </button>
+    <button type="button" data-action="json">
+      <span class="label">Raw JSON</span>
+      <span class="hint">themes-slim shape</span>
+    </button>
+    <button type="button" data-action="permalink">
+      <span class="label">Permalink</span>
+      <span class="hint">share this theme</span>
+    </button>
+  </div>
+  <output id="copy-toast" class="toast" role="status" aria-live="polite"></output>
+</section>
+
+<script>
+  import {
+    formatCssVars,
+    formatTailwindTheme,
+    formatJson,
+    formatPermalink,
+    type SlimThemeLike,
+  } from '@/lib/formatters';
+
+  function loadThemes(): Record<string, SlimThemeLike> {
+    const el = document.querySelector<HTMLScriptElement>('#themes-data');
+    if (!el) return {};
+    const arr = JSON.parse(el.textContent ?? '[]') as SlimThemeLike[];
+    const map: Record<string, SlimThemeLike> = {};
+    for (const t of arr) map[t.slug] = t;
+    return map;
+  }
+
+  const themes = loadThemes();
+  const toast = document.querySelector<HTMLOutputElement>('#copy-toast');
+  const buttons = document.querySelectorAll<HTMLButtonElement>('.actions [data-action]');
+
+  let clearToast = 0;
+  function flash(message: string, variant: 'ok' | 'err'): void {
+    if (!toast) return;
+    toast.textContent = message;
+    toast.dataset.variant = variant;
+    toast.dataset.visible = 'true';
+    window.clearTimeout(clearToast);
+    clearToast = window.setTimeout(() => {
+      toast.dataset.visible = 'false';
+    }, 2200);
+  }
+
+  function activeSlug(): string | null {
+    return new URLSearchParams(window.location.search).get('theme');
+  }
+
+  type Action = 'css' | 'tailwind' | 'json' | 'permalink';
+  function renderFor(slug: string, action: Action): string | null {
+    const theme = themes[slug];
+    if (!theme) return null;
+    switch (action) {
+      case 'css':
+        return formatCssVars(theme);
+      case 'tailwind':
+        return formatTailwindTheme(theme);
+      case 'json':
+        return formatJson(theme);
+      case 'permalink':
+        return formatPermalink(slug, new URL(window.location.href));
+    }
+  }
+
+  async function copy(text: string): Promise<boolean> {
+    if (!navigator.clipboard) return false;
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  for (const btn of buttons) {
+    btn.addEventListener('click', async () => {
+      const slug = activeSlug();
+      if (slug === null) {
+        flash('Select a theme first.', 'err');
+        return;
+      }
+      const action = (btn.dataset.action ?? '') as Action;
+      const text = renderFor(slug, action);
+      if (text === null) {
+        flash('Unknown theme.', 'err');
+        return;
+      }
+      const ok = await copy(text);
+      flash(
+        ok ? `Copied ${action === 'permalink' ? 'permalink' : action + ' to clipboard'}` : 'Clipboard blocked — copy disabled.',
+        ok ? 'ok' : 'err',
+      );
+    });
+  }
+</script>
+
+<style>
+  .actions {
+    padding: 0.9rem 1.1rem 1.1rem;
+    border-top: 1px solid var(--border);
+    background: color-mix(in oklch, var(--fg) 2%, transparent);
+  }
+  .section-head {
+    margin: 0 0 0.6rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: color-mix(in oklch, var(--fg) 60%, transparent);
+    font-weight: 550;
+  }
+  .buttons {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+    gap: 0.5rem;
+  }
+  .actions button {
+    text-align: left;
+    background: var(--surface);
+    color: inherit;
+    border: 1px solid var(--border);
+    border-radius: 0.45rem;
+    padding: 0.55rem 0.75rem;
+    cursor: pointer;
+    font: inherit;
+    display: grid;
+    gap: 0.1rem;
+    transition:
+      background 80ms,
+      border-color 80ms;
+  }
+  .actions button:hover,
+  .actions button:focus-visible {
+    border-color: var(--accent);
+    background: color-mix(in oklch, var(--accent) 8%, transparent);
+  }
+  .actions button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+  .actions .label {
+    font-weight: 550;
+    font-size: 0.88rem;
+  }
+  .actions .hint {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: color-mix(in oklch, var(--fg) 55%, transparent);
+  }
+
+  .toast {
+    display: inline-block;
+    margin-top: 0.7rem;
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    opacity: 0;
+    transform: translateY(4px);
+    transition:
+      opacity 160ms,
+      transform 160ms;
+    background: color-mix(in oklch, var(--accent) 16%, transparent);
+    color: var(--accent);
+  }
+  .toast[data-visible='true'] {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .toast[data-variant='err'] {
+    background: color-mix(in oklch, oklch(0.55 0.18 25) 20%, transparent);
+    color: oklch(0.6 0.18 25);
+  }
+</style>

--- a/site/src/components/PreviewPane.astro
+++ b/site/src/components/PreviewPane.astro
@@ -1,4 +1,5 @@
 ---
+import ActionsPanel from './ActionsPanel.astro';
 import TerminalMock from './TerminalMock.astro';
 import WebsiteMock from './WebsiteMock.astro';
 ---
@@ -16,6 +17,7 @@ import WebsiteMock from './WebsiteMock.astro';
     <TerminalMock />
     <WebsiteMock />
   </div>
+  <ActionsPanel />
 </section>
 
 <script>

--- a/site/src/lib/formatters.ts
+++ b/site/src/lib/formatters.ts
@@ -1,0 +1,46 @@
+// Format helpers for the actions panel. Pure; both client and server can call them.
+
+export interface SlimThemeLike {
+  name: string;
+  slug: string;
+  isDark: boolean;
+  colors: Record<string, string>;
+}
+
+function kebab(key: string): string {
+  return key.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+/**
+ * Emits the theme as a `:root` CSS block with `--terminal-<key>` custom
+ * properties. Mirrors the package's `themeToCssVars` but wraps in `:root`.
+ */
+export function formatCssVars(theme: SlimThemeLike): string {
+  const lines = Object.entries(theme.colors).map(([k, v]) => `  --terminal-${kebab(k)}: ${v};`);
+  return `/* ${theme.name} — oklch-terminal-themes */\n:root {\n${lines.join('\n')}\n}\n`;
+}
+
+/**
+ * Emits a Tailwind v4 `@theme` block mapping the 20 theme slots to
+ * `--color-terminal-<key>` custom properties Tailwind picks up automatically.
+ */
+export function formatTailwindTheme(theme: SlimThemeLike): string {
+  const lines = Object.entries(theme.colors).map(
+    ([k, v]) => `  --color-terminal-${kebab(k)}: ${v};`,
+  );
+  return `/* ${theme.name} — Tailwind v4 */\n@theme {\n${lines.join('\n')}\n}\n`;
+}
+
+export function formatJson(theme: SlimThemeLike): string {
+  return `${JSON.stringify(theme, null, 2)}\n`;
+}
+
+/**
+ * Build an absolute URL for the current page with `?theme=<slug>` set so the
+ * user can share the selection.
+ */
+export function formatPermalink(slug: string, base: URL): string {
+  const url = new URL(base.href);
+  url.searchParams.set('theme', slug);
+  return url.toString();
+}


### PR DESCRIPTION
## Summary

Closes #19. Stacks on #27 (preview). Merge #26 → #27 → this in sequence.

Four copy-to-clipboard actions beneath the preview mocks:

| Action | Output |
|---|---|
| CSS variables | `:root { --terminal-<key>: oklch(...); }` |
| Tailwind v4 | `@theme { --color-terminal-<key>: oklch(...); }` |
| Raw JSON | themes-slim shape |
| Permalink | absolute URL with `?theme=<slug>` |

## Components

- **`lib/formatters.ts`** — pure helpers. Unit-testable, no DOM.
- **`components/ActionsPanel.astro`** — 4-button grid + toast. Mounts inside `PreviewPane`.

## Copy flow

- `navigator.clipboard.writeText`; graceful "Clipboard blocked" toast on denial (Safari private, iframes, non-HTTPS).
- Toast is `role="status"` + `aria-live="polite"`. OK/error variants differ in color.

## Test plan

- [x] lint / typecheck / test / lint:md / format:check — green
- [x] `pnpm --filter ...site typecheck` — 0 / 0 / 0
- [x] `pnpm --filter ...site build` — clean
- [ ] PR CI green
- [ ] Live: copy each format and paste into a real codebase to confirm validity (chrome-review #22)

Part of epic #12.