### PR TITLE
fix(site): preview CSS var mismatch + terminal mock double-spacing

### DIFF
--- a/site/src/components/TerminalMock.astro
+++ b/site/src/components/TerminalMock.astro
@@ -22,8 +22,8 @@
 
 <style>
   .terminal-mock {
-    background: var(--tt-bg, oklch(0.2 0.02 260));
-    color: var(--tt-fg, oklch(0.9 0.02 260));
+    background: var(--tt-background, oklch(0.2 0.02 260));
+    color: var(--tt-foreground, oklch(0.9 0.02 260));
     padding: 1rem 1.1rem;
     border-radius: 0.5rem;
     font-family: var(--font-mono);
@@ -34,12 +34,10 @@
     white-space: pre;
     box-shadow: 0 2px 20px color-mix(in oklch, black 18%, transparent);
   }
-  .terminal-mock .line {
-    display: block;
-    white-space: pre;
-  }
+  /* Each line is inline — the `<pre>` preserves literal newlines in the
+     source, so `display: block` would double-space every row. */
   .terminal-mock .ansi-fg {
-    color: var(--tt-fg);
+    color: var(--tt-foreground);
   }
   .terminal-mock .ansi-red {
     color: var(--tt-red);
@@ -69,7 +67,7 @@
     color: var(--tt-bright-purple);
   }
   .terminal-mock .cursor {
-    color: var(--tt-cursor, var(--tt-fg));
+    color: var(--tt-cursor, var(--tt-foreground));
     animation: blink 1.1s steps(2) infinite;
   }
   @keyframes blink {

--- a/site/src/components/WebsiteMock.astro
+++ b/site/src/components/WebsiteMock.astro
@@ -46,8 +46,8 @@
 <style>
   .web-mock {
     --wm-pad: 1.2rem;
-    background: var(--tt-bg, oklch(0.98 0 0));
-    color: var(--tt-fg, oklch(0.2 0 0));
+    background: var(--tt-background, oklch(0.98 0 0));
+    color: var(--tt-foreground, oklch(0.2 0 0));
     border-radius: 0.5rem;
     padding: 0;
     font-family: var(--font-sans);
@@ -63,10 +63,10 @@
     justify-content: space-between;
     align-items: center;
     padding: 0.75rem var(--wm-pad);
-    border-bottom: 1px solid color-mix(in oklch, var(--tt-fg) 12%, transparent);
+    border-bottom: 1px solid color-mix(in oklch, var(--tt-foreground) 12%, transparent);
   }
   .wm-brand {
-    color: var(--tt-purple, var(--tt-fg));
+    color: var(--tt-purple, var(--tt-foreground));
     font-weight: 650;
     font-family: var(--font-mono);
     letter-spacing: -0.01em;
@@ -76,7 +76,7 @@
     gap: 0.9rem;
   }
   .wm-nav a {
-    color: var(--tt-blue, var(--tt-fg));
+    color: var(--tt-blue, var(--tt-foreground));
     text-decoration: none;
     font-size: 0.82rem;
   }
@@ -92,7 +92,7 @@
   .wm-hero p {
     margin: 0 0 0.75rem;
     line-height: 1.55;
-    color: color-mix(in oklch, var(--tt-fg) 82%, transparent);
+    color: color-mix(in oklch, var(--tt-foreground) 82%, transparent);
   }
 
   .wm-cta-row {
@@ -102,8 +102,8 @@
     flex-wrap: wrap;
   }
   .wm-cta {
-    background: var(--tt-purple, var(--tt-fg));
-    color: var(--tt-bg);
+    background: var(--tt-purple, var(--tt-foreground));
+    color: var(--tt-background);
     border: none;
     border-radius: 0.35rem;
     padding: 0.4rem 0.9rem;
@@ -134,8 +134,8 @@
     padding: 0 var(--wm-pad);
   }
   .wm-card {
-    background: color-mix(in oklch, var(--tt-fg) 6%, transparent);
-    border: 1px solid color-mix(in oklch, var(--tt-fg) 12%, transparent);
+    background: color-mix(in oklch, var(--tt-foreground) 6%, transparent);
+    border: 1px solid color-mix(in oklch, var(--tt-foreground) 12%, transparent);
     border-radius: 0.35rem;
     padding: 0.75rem;
   }
@@ -146,11 +146,11 @@
   .wm-card p {
     margin: 0;
     font-size: 0.78rem;
-    color: color-mix(in oklch, var(--tt-fg) 72%, transparent);
+    color: color-mix(in oklch, var(--tt-foreground) 72%, transparent);
   }
   .wm-card code {
     font-family: var(--font-mono);
-    background: color-mix(in oklch, var(--tt-fg) 8%, transparent);
+    background: color-mix(in oklch, var(--tt-foreground) 8%, transparent);
     padding: 0 0.25rem;
     border-radius: 0.2rem;
   }
@@ -158,27 +158,27 @@
   .wm-code {
     margin: 0;
     padding: 0.85rem var(--wm-pad);
-    background: color-mix(in oklch, var(--tt-fg) 4%, transparent);
-    border-top: 1px solid color-mix(in oklch, var(--tt-fg) 12%, transparent);
+    background: color-mix(in oklch, var(--tt-foreground) 4%, transparent);
+    border-top: 1px solid color-mix(in oklch, var(--tt-foreground) 12%, transparent);
     font-family: var(--font-mono);
     font-size: 0.78rem;
-    color: var(--tt-fg);
+    color: var(--tt-foreground);
     overflow-x: auto;
     white-space: pre;
   }
   .wm-code .k {
-    color: var(--tt-purple, var(--tt-fg));
+    color: var(--tt-purple, var(--tt-foreground));
   }
   .wm-code .v {
-    color: var(--tt-cyan, var(--tt-fg));
+    color: var(--tt-cyan, var(--tt-foreground));
   }
   .wm-code .s {
-    color: var(--tt-yellow, var(--tt-fg));
+    color: var(--tt-yellow, var(--tt-foreground));
   }
   .wm-code .p {
-    color: var(--tt-fg);
+    color: var(--tt-foreground);
   }
   .wm-code .c {
-    color: var(--tt-bright-black, color-mix(in oklch, var(--tt-fg) 50%, transparent));
+    color: var(--tt-bright-black, color-mix(in oklch, var(--tt-foreground) 50%, transparent));
   }
 </style>


### PR DESCRIPTION
## Summary

Two bugs caught during the chrome live-site review (#22):

### 1. Preview color application was broken for `background`/`foreground`

`PreviewPane` script sets `--tt-background` and `--tt-foreground` (derived from color keys), but the mock CSS used abbreviated `--tt-bg`/`--tt-fg`. With fallback values (`oklch(0.2 0.02 260)` dark purple), every theme rendered with the same fallback shade instead of its actual palette.

**Fix:** rename the custom properties to match the applied keys end-to-end.

### 2. TerminalMock lines double-spaced

The root `<pre>` preserves literal `\n` newlines between `<span class="line">` elements; adding `display: block` stacked a second break on top of the preserved newline.

**Fix:** remove the `display: block` — `<pre>` already provides the line breaks.

## Found via

`mcp__claude-in-chrome__javascript_tool` on the live site after deploying the actions-panel PR. Caught via:

```js
document.querySelector('.terminal-mock').style.getPropertyValue('--tt-bg')
// "" — never set
```

Fixing now so subsequent chrome-review findings land against the corrected rendering.

## Test plan

- [x] `pnpm --filter ...site typecheck` — 0 / 0 / 0
- [x] `pnpm --filter ...site build` — clean
- [x] Root gates — green
- [ ] PR CI green
- [ ] Post-deploy: verify on live site that `--tt-background` / `--tt-foreground` are actually applied (they were empty before)

Part of epic #12.