### PR TITLE
feat(site): site-chrome dark-mode toggle

### DIFF
--- a/site/src/components/ThemeToggle.astro
+++ b/site/src/components/ThemeToggle.astro
@@ -1,0 +1,100 @@
+---
+// Site-chrome dark-mode toggle. Distinct from the theme preview below —
+// this only affects the outer page (header, grid background, typography).
+---
+
+<button
+  id="site-theme-toggle"
+  class="site-theme-toggle"
+  type="button"
+  aria-label="Toggle site dark mode"
+  aria-pressed="false"
+  title="Toggle site dark mode"
+>
+  <span class="icon icon-light" aria-hidden="true">☀</span>
+  <span class="icon icon-dark" aria-hidden="true">☾</span>
+</button>
+
+<script is:inline>
+  // Inline so the script runs before first paint — prevents a flash of the
+  // wrong chrome if the stored preference differs from the OS preference.
+  (() => {
+    const stored = localStorage.getItem('site-theme');
+    const osPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initial = stored === 'light' || stored === 'dark' ? stored : osPrefersDark ? 'dark' : 'light';
+    document.documentElement.dataset.siteTheme = initial;
+  })();
+</script>
+
+<script>
+  const toggle = document.querySelector<HTMLButtonElement>('#site-theme-toggle');
+  const root = document.documentElement;
+
+  function sync(): void {
+    if (!toggle) return;
+    const mode = root.dataset.siteTheme ?? 'light';
+    toggle.setAttribute('aria-pressed', String(mode === 'dark'));
+  }
+
+  sync();
+
+  toggle?.addEventListener('click', () => {
+    const next = (root.dataset.siteTheme ?? 'light') === 'dark' ? 'light' : 'dark';
+    root.dataset.siteTheme = next;
+    localStorage.setItem('site-theme', next);
+    sync();
+  });
+
+  // React to OS preference changes if the user hasn't explicitly set one.
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (ev) => {
+    if (localStorage.getItem('site-theme') !== null) return;
+    root.dataset.siteTheme = ev.matches ? 'dark' : 'light';
+    sync();
+  });
+</script>
+
+<style>
+  .site-theme-toggle {
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    cursor: pointer;
+    color: inherit;
+    padding: 0.35rem;
+    width: 2rem;
+    height: 2rem;
+    display: grid;
+    place-items: center;
+    font-size: 0.95rem;
+    position: relative;
+    transition:
+      border-color 120ms,
+      background 120ms;
+  }
+  .site-theme-toggle:hover,
+  .site-theme-toggle:focus-visible {
+    border-color: var(--accent);
+    background: color-mix(in oklch, var(--accent) 12%, transparent);
+  }
+  .site-theme-toggle:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .site-theme-toggle .icon {
+    position: absolute;
+    transition: opacity 120ms;
+  }
+  .site-theme-toggle .icon-light {
+    opacity: 1;
+  }
+  .site-theme-toggle .icon-dark {
+    opacity: 0;
+  }
+  :global(:root[data-site-theme='dark']) .site-theme-toggle .icon-light {
+    opacity: 0;
+  }
+  :global(:root[data-site-theme='dark']) .site-theme-toggle .icon-dark {
+    opacity: 1;
+  }
+</style>

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -1,4 +1,6 @@
 ---
+import ThemeToggle from '@/components/ThemeToggle.astro';
+
 export interface Props {
   title: string;
   description?: string;
@@ -28,6 +30,7 @@ const { title, description = 'Canonical OKLCH conversions of 485+ terminal color
         <a href="https://www.npmjs.com/package/@williamzujkowski/oklch-terminal-themes" rel="noopener">
           npm
         </a>
+        <ThemeToggle />
       </nav>
     </header>
     <main>
@@ -51,6 +54,11 @@ const { title, description = 'Canonical OKLCH conversions of 485+ terminal color
       system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
     --font-mono:
       ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  }
+
+  /* Light (default + explicit override). */
+  :root,
+  :root[data-site-theme='light'] {
     --bg: oklch(0.98 0.005 250);
     --fg: oklch(0.2 0.02 250);
     --accent: oklch(0.55 0.18 260);
@@ -59,8 +67,9 @@ const { title, description = 'Canonical OKLCH conversions of 485+ terminal color
     color-scheme: light;
   }
 
+  /* Dark via OS preference (no explicit override). */
   @media (prefers-color-scheme: dark) {
-    :root {
+    :root:not([data-site-theme='light']) {
       --bg: oklch(0.15 0.015 250);
       --fg: oklch(0.95 0.005 250);
       --accent: oklch(0.75 0.15 260);
@@ -68,6 +77,16 @@ const { title, description = 'Canonical OKLCH conversions of 485+ terminal color
       --border: oklch(1 1 0 / 0.12);
       color-scheme: dark;
     }
+  }
+
+  /* Dark via explicit override (wins over OS preference). */
+  :root[data-site-theme='dark'] {
+    --bg: oklch(0.15 0.015 250);
+    --fg: oklch(0.95 0.005 250);
+    --accent: oklch(0.75 0.15 260);
+    --surface: oklch(1 0 0 / 0.05);
+    --border: oklch(1 1 0 / 0.12);
+    color-scheme: dark;
   }
 
   *,
@@ -129,7 +148,8 @@ const { title, description = 'Canonical OKLCH conversions of 485+ terminal color
 
   .site-header nav {
     display: flex;
-    gap: 1.5rem;
+    gap: 1.25rem;
+    align-items: center;
   }
 
   .site-header nav a {


### PR DESCRIPTION
## Summary

Closes #21 (the GitHub-tracked polish subset). Part of #18 (comprehensive polish).

Adds a toggle button to the site header that overrides the OS `prefers-color-scheme` preference for the outer page chrome. Distinct from the theme preview mocks — those continue to paint from the selected terminal theme's palette.

## Behavior

- **Default**: follows `prefers-color-scheme` media query (same as before).
- **User clicks the toggle**: overrides OS, writes to `localStorage`, sticks across reloads.
- **User never clicks**: OS changes propagate live via `matchMedia('change')`.
- **FOUC prevention**: inline `<script is:inline>` runs before first paint to apply the stored/OS-matched mode.

## Accessibility

- Sun/moon icons swap via CSS opacity on `data-site-theme` — no DOM swap, no flash.
- `aria-pressed` reflects state for screen readers.
- Button is focusable, has `:focus-visible` outline.

## Test plan

- [x] Astro typecheck — 0 / 0 / 0
- [x] Astro build — clean
- [x] Root lint + format — green
- [ ] PR CI green
- [ ] Live site: toggle persists across reload; OS change propagates when no explicit preference set.

Part of epic #12.