### PR TITLE
docs(changelog): unreleased notes for site + hardening sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-### Added
+### Added — governance + quality
 
-- AGENTS.md, CODING_STANDARDS.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md — repo governance adapted from nexus-agents v2.2.0 standards.
+- AGENTS.md, CODING_STANDARDS.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md — repo governance adapted from nexus-agents v2.2.0 standards. SECURITY.md documents four Scorecard checks intentionally deferred (Fuzzing, CIIBestPractices, Maintained, CodeReview) with rationale.
 - Prettier, ESLint strict ruleset, markdownlint, commitlint, Husky hooks, gitleaks config, lychee link-check config.
-- `.github/`: CodeQL workflow, OpenSSF Scorecard, link-check workflow, Dependabot config, PR and issue templates, CODEOWNERS, FUNDING.
+- `.github/`: CodeQL workflow, OpenSSF Scorecard, link-check workflow, gitleaks workflow (CI-side, in addition to the husky hook), Dependabot config, PR + issue templates, CODEOWNERS, FUNDING.
 - `.editorconfig`, `.gitattributes` for consistent line endings and indentation across editors.
 - `pnpm.overrides` in `package.json` to force patched versions of transitive advisories (`js-yaml >= 4.1.1`, `markdown-it >= 14.1.1`, `smol-toml >= 1.6.1`).
 
+### Added — GitHub Pages theme-picker site
+
+- `site/` — Astro 5 project deployed to https://williamzujkowski.github.io/oklch-terminal-themes/ via `.github/workflows/pages.yml`. Dogfoods the npm package via `workspace:*` — no re-parsing of upstream iTerm schemes.
+- **Picker grid**: 485 theme cards (popular-first + alphabetical), responsive CSS grid.
+- **Filters**: search by name/slug + 7 tag chips (dark / light / vibrant / muted / high-contrast / low-contrast / popular). URL state round-trips (`?q=...&tags=...`).
+- **Dual-pane preview**: selecting a card sets `?theme=<slug>` and renders two live mocks painted from the theme's palette — a terminal widget covering all 16 ANSI slots + cursor + fg, and a mini web-page chrome (nav / hero / CTA / success/danger chips / card grid / code block) mapping `blue`→links, `green`→success, `red`→danger, `purple`→accent.
+- **Actions panel**: copy `:root` CSS vars, Tailwind v4 `@theme` block, raw JSON, or shareable permalink. Graceful "Clipboard blocked" toast when the Clipboard API is denied.
+- **Site-chrome dark-mode toggle** (separate from the theme preview). Inline pre-paint script prevents FOUC; explicit preference persists via `localStorage`; OS changes still propagate when no explicit choice has been made.
+- **A11y**: `aria-pressed` tag chips and toggle; `aria-live` filter count; `role="status"` copy toast; descriptive `aria-label`s on interactive affordances; full keyboard tabbing.
+- **Performance**: single static HTML page (no JS bundle — all interactive scripts inlined). Themes-slim data embedded as inline JSON for zero-roundtrip preview lookups.
+
 ### Changed
 
-- CI workflow now runs commitlint (on PRs), ESLint, Prettier format check, typecheck, tests, and the full build-and-validate pipeline.
-- Upgraded all dev-dependencies to latest stable majors: eslint 9 → 10, typescript 5.9 → 6.0, @commitlint/\* 19 → 20, lint-staged 15 → 16, markdownlint-cli2 0.15 → 0.22. Held back: `@types/node` (tracks Node 22 LTS), `vite` (vitest 4 peer constraint).
-- Upgraded all GitHub Actions to latest majors: `pnpm/action-setup@v6`, `github/codeql-action@v4`, `actions/upload-artifact@v7`, `actions/cache@v5`, `peter-evans/create-pull-request@v8`.
-- Dependabot config now groups minor/patch npm updates, groups dev-dep majors, and groups all action bumps — green CI is the gate, not manual triage of each tag.
+- CI workflow now runs commitlint (on PRs), ESLint, Prettier format check, markdownlint, typecheck, tests, full build-and-validate pipeline, site build+typecheck, and pnpm audit.
+- Upgraded dev dependencies: eslint 9 → 10, @commitlint/\* 19 → 20, lint-staged 15 → 16, markdownlint-cli2 0.15 → 0.22. Held back: `@types/node` (tracks Node 22 LTS), `vite` (vitest 4 peer constraint), `typescript` (kept on 5.9.x — Astro 5 ecosystem's peer range excludes TS 6).
+- Upgraded all GitHub Actions to latest releases and **pinned every `uses:` line by commit SHA** with a `# v<tag>` comment (closes Scorecard PinnedDependenciesID alerts). `pnpm/action-setup` held on v4 — v6 regressed `ERR_PNPM_BROKEN_LOCKFILE` under `--frozen-lockfile` on a single-document YAML lockfile.
+- Dependabot config groups minor/patch npm updates, groups dev-dep majors (ignoring `@types/node` majors — tracks LTS runtime), and groups all action bumps — green CI is the gate, not manual triage of each tag.
+- `lint:md` command uses inline negation globs (`!**/node_modules/**`) instead of markdownlint-cli2's `#` ignore syntax — the latter expanded the full glob first on a workspace-scale \`node_modules\` and hit a 4 GB heap ceiling.
+- Added `ci.yml` job to verify site build + typecheck on every PR. `CI Success` gate job aggregates all required checks.
+
+### Deferred
+
+- **Side-by-side compare mode.** Tracked in [issue #20](https://github.com/williamzujkowski/oklch-terminal-themes/issues/20) with a path-forward write-up. Requires parameterising `PreviewPane.astro`'s hard-coded element IDs so two instances can coexist.
+- **Lighthouse + axe-core automated a11y gate.** Tracked in [issue #18](https://github.com/williamzujkowski/oklch-terminal-themes/issues/18). Manual chrome-automation audit was clean (zero console errors, 1 HTTP resource, keyboard tabbing verified) but an automated check in CI would prevent regressions.
 
 ## [0.1.0] — 2026-04-14
 


### PR DESCRIPTION
## Summary

Replaces the terse bullet list under `## [Unreleased]` with a structured summary of everything that has landed on `main` since v0.1.0. Reviewable at a glance before we cut the first tagged release.

## Sections

- **Added — governance + quality**: scaffolding, SHA-pinned workflows, CI-side gitleaks, SECURITY.md Scorecard deferrals, `pnpm.overrides` for transitive advisories.
- **Added — GitHub Pages theme-picker site**: picker grid, dual-pane preview, actions panel, dark-mode toggle, full a11y wiring.
- **Changed**: CI expansion, dev-dep upgrades, action SHA pinning, `pnpm/action-setup` held on v4 with documented reason, Dependabot grouping, `lint:md` glob fix.
- **Deferred**: compare mode (#20), automated Lighthouse/axe (#18).

## Test plan

- [x] `pnpm lint:md` — clean
- [x] `pnpm format:check` — clean
- [ ] PR CI green

Part of epic #12.