### PR TITLE
feat(site): side-by-side compare mode

### DIFF
--- a/site/src/components/FilterBar.astro
+++ b/site/src/components/FilterBar.astro
@@ -46,7 +46,7 @@ const { total } = Astro.props;
   const tagChips = Array.from(document.querySelectorAll<HTMLButtonElement>('.tag-chip[data-tag]'));
   const resetBtn = document.querySelector<HTMLButtonElement>('.tag-chip[data-action="reset"]');
   const countEl = document.querySelector<HTMLOutputElement>('#filter-count');
-  const cards = Array.from(document.querySelectorAll<HTMLAnchorElement>('.theme-card'));
+  const cards = Array.from(document.querySelectorAll<HTMLElement>('.theme-card-wrap'));
 
   if (searchInput && countEl && cards.length > 0) {
     const state: FilterState = parseFilterFromUrl(window.location.search);

--- a/site/src/components/PreviewController.astro
+++ b/site/src/components/PreviewController.astro
@@ -1,0 +1,119 @@
+---
+// Centralized controller for all `.preview-pane` instances on the page.
+// Handles URL-param-driven theme application, close buttons, card clicks,
+// and the "vs" / compare affordance so one consistent implementation drives
+// both the primary preview and the compare pane.
+---
+
+<script>
+  type SlimTheme = {
+    name: string;
+    slug: string;
+    isDark: boolean;
+    colors: Record<string, string>;
+  };
+
+  function readThemes(): Record<string, SlimTheme> {
+    const el = document.querySelector<HTMLScriptElement>('#themes-data');
+    if (!el) return {};
+    const arr = JSON.parse(el.textContent ?? '[]') as SlimTheme[];
+    const map: Record<string, SlimTheme> = {};
+    for (const t of arr) map[t.slug] = t;
+    return map;
+  }
+
+  // camelCase (colors.brightRed) → kebab (--tt-bright-red)
+  function toCssVar(key: string): string {
+    return '--tt-' + key.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+  }
+
+  const themes = readThemes();
+  const panes = Array.from(document.querySelectorAll<HTMLElement>('.preview-pane[data-pane-id]'));
+
+  type PaneApplyFn = () => void;
+  const applyFns: PaneApplyFn[] = [];
+
+  function setupPane(pane: HTMLElement): void {
+    const paramName = pane.dataset.urlParam ?? 'theme';
+    const nameEl = pane.querySelector<HTMLElement>('[data-theme-name]');
+    const metaEl = pane.querySelector<HTMLElement>('[data-theme-meta]');
+    const terminal = pane.querySelector<HTMLElement>('.terminal-mock');
+    const webmock = pane.querySelector<HTMLElement>('.web-mock');
+    const closeBtn = pane.querySelector<HTMLAnchorElement>('[data-close]');
+    if (!nameEl || !metaEl || !terminal || !webmock || !closeBtn) return;
+    // Capture into const references so the nested closures preserve narrowing.
+    const name = nameEl;
+    const meta = metaEl;
+    const term = terminal;
+    const web = webmock;
+
+    function paint(slug: string | null): void {
+      if (slug === null) {
+        pane.hidden = true;
+        return;
+      }
+      const theme = themes[slug];
+      if (!theme) {
+        pane.hidden = true;
+        return;
+      }
+      name.textContent = theme.name;
+      meta.textContent = `${theme.isDark ? 'dark' : 'light'} · ${theme.slug}`;
+      for (const [k, v] of Object.entries(theme.colors)) {
+        const variable = toCssVar(k);
+        term.style.setProperty(variable, v);
+        web.style.setProperty(variable, v);
+      }
+      pane.hidden = false;
+    }
+
+    function apply(): void {
+      paint(new URLSearchParams(window.location.search).get(paramName));
+    }
+
+    closeBtn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      const next = new URL(window.location.href);
+      next.searchParams.delete(paramName);
+      history.pushState(null, '', next.toString());
+      paint(null);
+    });
+
+    apply();
+    applyFns.push(apply);
+  }
+
+  for (const pane of panes) setupPane(pane);
+
+  function updateParam(paramName: string, slug: string): void {
+    const next = new URL(window.location.href);
+    next.searchParams.set(paramName, slug);
+    history.pushState(null, '', next.toString());
+    for (const fn of applyFns) fn();
+    const pane = document.querySelector<HTMLElement>(
+      `.preview-pane[data-url-param="${paramName}"]`,
+    );
+    pane?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  document.addEventListener('click', (ev) => {
+    const target = ev.target;
+    if (!(target instanceof Element)) return;
+    const vs = target.closest<HTMLAnchorElement>('a.compare-link');
+    if (vs) {
+      ev.preventDefault();
+      const slug = vs.dataset.slug ?? '';
+      if (slug.length > 0) updateParam('compare', slug);
+      return;
+    }
+    const card = target.closest<HTMLAnchorElement>('a.theme-card');
+    if (!card) return;
+    ev.preventDefault();
+    const slug = card.dataset.slug ?? '';
+    if (slug.length > 0) updateParam('theme', slug);
+  });
+
+  window.addEventListener('popstate', () => {
+    for (const fn of applyFns) fn();
+  });
+</script>

--- a/site/src/components/PreviewPane.astro
+++ b/site/src/components/PreviewPane.astro
@@ -2,109 +2,43 @@
 import ActionsPanel from './ActionsPanel.astro';
 import TerminalMock from './TerminalMock.astro';
 import WebsiteMock from './WebsiteMock.astro';
+
+export interface Props {
+  /**
+   * Identifies the pane so the page can mount more than one. Pane "a" is the
+   * primary preview (reads `?theme=<slug>`); pane "b" is the compare slot
+   * (reads `?compare=<slug>`).
+   */
+  paneId?: 'a' | 'b';
+}
+
+const { paneId = 'a' } = Astro.props;
+const urlParam = paneId === 'a' ? 'theme' : 'compare';
+const eyebrow = paneId === 'a' ? 'Preview' : 'Compare';
+const label = paneId === 'a' ? 'Theme preview' : 'Compare preview';
 ---
 
-<section id="preview-pane" class="preview-pane" hidden aria-label="Theme preview">
+<section
+  class="preview-pane"
+  data-pane-id={paneId}
+  data-url-param={urlParam}
+  hidden
+  aria-label={label}
+>
   <header class="preview-head">
     <div>
-      <span class="eyebrow">Preview</span>
-      <h2 id="preview-name" class="theme-name">—</h2>
-      <p id="preview-meta" class="meta">—</p>
+      <span class="eyebrow">{eyebrow}</span>
+      <h2 class="theme-name" data-theme-name>—</h2>
+      <p class="meta" data-theme-meta>—</p>
     </div>
-    <a id="preview-close" class="close" href="./" aria-label="Close preview">×</a>
+    <a class="close" href="." data-close aria-label="Close preview">×</a>
   </header>
   <div class="mocks">
     <TerminalMock />
     <WebsiteMock />
   </div>
-  <ActionsPanel />
+  {paneId === 'a' && <ActionsPanel />}
 </section>
-
-<script>
-  type SlimTheme = {
-    name: string;
-    slug: string;
-    isDark: boolean;
-    colors: Record<string, string>;
-  };
-
-  // The index page inlines `themes-slim.json` as JSON; look it up by id.
-  function readThemes(): Record<string, SlimTheme> {
-    const el = document.querySelector<HTMLScriptElement>('#themes-data');
-    if (!el) return {};
-    const arr = JSON.parse(el.textContent ?? '[]') as SlimTheme[];
-    const map: Record<string, SlimTheme> = {};
-    for (const t of arr) map[t.slug] = t;
-    return map;
-  }
-
-  const themes = readThemes();
-  const pane = document.querySelector<HTMLElement>('#preview-pane');
-  const nameEl = document.querySelector<HTMLElement>('#preview-name');
-  const metaEl = document.querySelector<HTMLElement>('#preview-meta');
-  const terminal = document.querySelector<HTMLElement>('.terminal-mock');
-  const webmock = document.querySelector<HTMLElement>('.web-mock');
-
-  // camelCase (colors.brightRed) → kebab (--tt-bright-red)
-  function toCssVar(key: string): string {
-    return '--tt-' + key.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
-  }
-
-  function applyTheme(slug: string | null): void {
-    if (!pane || !nameEl || !metaEl || !terminal || !webmock) return;
-    if (slug === null || !(slug in themes)) {
-      pane.hidden = true;
-      return;
-    }
-    const theme = themes[slug];
-    if (!theme) {
-      pane.hidden = true;
-      return;
-    }
-    nameEl.textContent = theme.name;
-    metaEl.textContent = `${theme.isDark ? 'dark' : 'light'} · ${theme.slug}`;
-    for (const [k, v] of Object.entries(theme.colors)) {
-      const variable = toCssVar(k);
-      terminal.style.setProperty(variable, v);
-      webmock.style.setProperty(variable, v);
-    }
-    pane.hidden = false;
-  }
-
-  function currentSlug(): string | null {
-    return new URLSearchParams(window.location.search).get('theme');
-  }
-
-  applyTheme(currentSlug());
-
-  // Cards use `?theme=<slug>` hrefs. Intercept to avoid full page reload.
-  document.addEventListener('click', (ev) => {
-    const target = ev.target;
-    if (!(target instanceof Element)) return;
-    const card = target.closest<HTMLAnchorElement>('a.theme-card');
-    if (!card) return;
-    ev.preventDefault();
-    const url = new URL(card.href, window.location.origin);
-    const slug = url.searchParams.get('theme');
-    if (slug === null) return;
-    const next = new URL(window.location.href);
-    next.searchParams.set('theme', slug);
-    history.pushState(null, '', next.toString());
-    applyTheme(slug);
-    pane?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  });
-
-  // Close button returns to no-theme state.
-  document.querySelector<HTMLAnchorElement>('#preview-close')?.addEventListener('click', (ev) => {
-    ev.preventDefault();
-    const next = new URL(window.location.href);
-    next.searchParams.delete('theme');
-    history.pushState(null, '', next.toString());
-    applyTheme(null);
-  });
-
-  window.addEventListener('popstate', () => applyTheme(currentSlug()));
-</script>
 
 <style>
   .preview-pane {
@@ -114,7 +48,6 @@ import WebsiteMock from './WebsiteMock.astro';
     background: var(--surface);
     margin: 1.5rem 0;
   }
-
   .preview-head {
     display: flex;
     justify-content: space-between;
@@ -161,7 +94,6 @@ import WebsiteMock from './WebsiteMock.astro';
     background: color-mix(in oklch, var(--accent) 35%, transparent);
     color: var(--fg);
   }
-
   .mocks {
     display: grid;
     gap: 0.9rem;

--- a/site/src/components/ThemeCard.astro
+++ b/site/src/components/ThemeCard.astro
@@ -24,44 +24,58 @@ const PALETTE_KEYS = ['red', 'yellow', 'green', 'cyan', 'blue', 'purple'] as con
 const bgCss = theme.colors.background.oklchCss;
 const fgCss = theme.colors.foreground.oklchCss;
 const permalink = `?theme=${theme.slug}`;
+const comparelink = `?compare=${theme.slug}`;
 const searchTerm = `${theme.name.toLowerCase()} ${theme.slug}`;
 ---
 
-<a
-  class="theme-card"
-  href={permalink}
+<div
+  class="theme-card-wrap"
   data-slug={theme.slug}
   data-dark={theme.isDark.toString()}
   data-tags={theme.tags.join(' ')}
   data-search={searchTerm}
-  aria-label={`Select ${theme.name} theme`}
 >
-  <div
-    class="preview"
-    style={`background:${bgCss};color:${fgCss}`}
+  <a class="theme-card" href={permalink} aria-label={`Select ${theme.name} theme`}>
+    <div class="preview" style={`background:${bgCss};color:${fgCss}`}>
+      <span class="prompt">
+        <span style={`color:${theme.colors.green.oklchCss}`}>user</span>@<span
+          style={`color:${theme.colors.blue.oklchCss}`}>host</span>
+        <span style={`color:${theme.colors.brightBlack.oklchCss}`}>~</span>
+        <span class="cursor" style={`background:${theme.colors.cursor.oklchCss}`}>&nbsp;</span>
+      </span>
+      <span class="swatches">
+        {
+          PALETTE_KEYS.map((k) => (
+            <span class="swatch" style={`background:${theme.colors[k].oklchCss}`} title={k} />
+          ))
+        }
+      </span>
+    </div>
+    <div class="meta">
+      <strong>{theme.name}</strong>
+      <span class="tags">
+        {theme.isDark ? 'dark' : 'light'}
+        {theme.tags.includes('popular') && <span class="tag-popular">★</span>}
+      </span>
+    </div>
+  </a>
+  <a
+    class="compare-link"
+    href={comparelink}
+    data-slug={theme.slug}
+    aria-label={`Compare with ${theme.name}`}
+    title="Compare with this theme"
   >
-    <span class="prompt">
-      <span style={`color:${theme.colors.green.oklchCss}`}>user</span>@<span
-        style={`color:${theme.colors.blue.oklchCss}`}>host</span>
-      <span style={`color:${theme.colors.brightBlack.oklchCss}`}>~</span>
-      <span class="cursor" style={`background:${theme.colors.cursor.oklchCss}`}>&nbsp;</span>
-    </span>
-    <span class="swatches">
-      {PALETTE_KEYS.map((k) => (
-        <span class="swatch" style={`background:${theme.colors[k].oklchCss}`} title={k} />
-      ))}
-    </span>
-  </div>
-  <div class="meta">
-    <strong>{theme.name}</strong>
-    <span class="tags">
-      {theme.isDark ? 'dark' : 'light'}
-      {theme.tags.includes('popular') && <span class="tag-popular">★</span>}
-    </span>
-  </div>
-</a>
+    vs
+  </a>
+</div>
 
 <style>
+  .theme-card-wrap {
+    position: relative;
+    display: block;
+  }
+
   .theme-card {
     display: grid;
     grid-template-rows: 1fr auto;
@@ -96,14 +110,12 @@ const searchTerm = `${theme.name.toLowerCase()} ${theme.slug}`;
     gap: 0.55rem;
     min-height: 5.25rem;
   }
-
   .prompt {
     display: flex;
     align-items: center;
     gap: 0.35ch;
     letter-spacing: 0.01em;
   }
-
   .cursor {
     display: inline-block;
     width: 0.5rem;
@@ -111,13 +123,11 @@ const searchTerm = `${theme.name.toLowerCase()} ${theme.slug}`;
     margin-left: 0.25ch;
     vertical-align: middle;
   }
-
   .swatches {
     display: flex;
     gap: 2px;
     height: 1.25rem;
   }
-
   .swatch {
     flex: 1;
     border-radius: 2px;
@@ -131,11 +141,9 @@ const searchTerm = `${theme.name.toLowerCase()} ${theme.slug}`;
     font-size: 0.85rem;
     border-top: 1px solid var(--border);
   }
-
   .meta strong {
     font-weight: 550;
   }
-
   .tags {
     display: flex;
     gap: 0.35rem;
@@ -145,8 +153,48 @@ const searchTerm = `${theme.name.toLowerCase()} ${theme.slug}`;
     letter-spacing: 0.08em;
     color: color-mix(in oklch, currentColor 62%, transparent);
   }
-
   .tag-popular {
     color: oklch(0.8 0.18 70);
+  }
+
+  /* Compare-mode affordance — small secondary link over the card's top-right. */
+  .compare-link {
+    position: absolute;
+    top: 0.45rem;
+    right: 0.45rem;
+    z-index: 2;
+    padding: 0.15rem 0.45rem;
+    border-radius: 999px;
+    font-size: 0.65rem;
+    font-weight: 550;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    text-decoration: none;
+    color: var(--fg);
+    background: color-mix(in oklch, var(--bg) 85%, transparent);
+    border: 1px solid var(--border);
+    opacity: 0;
+    transform: translateY(-2px);
+    transition:
+      opacity 120ms ease,
+      transform 120ms ease,
+      background 120ms ease,
+      border-color 120ms ease;
+  }
+  .theme-card-wrap:hover .compare-link,
+  .theme-card-wrap:focus-within .compare-link,
+  .compare-link:focus-visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .compare-link:hover,
+  .compare-link:focus-visible {
+    border-color: var(--accent);
+    background: color-mix(in oklch, var(--accent) 18%, var(--bg));
+    color: var(--accent);
+  }
+  .compare-link:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
   }
 </style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -3,6 +3,7 @@ import themes from '@williamzujkowski/oklch-terminal-themes/themes.json';
 import slim from '@williamzujkowski/oklch-terminal-themes/themes-slim.json';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import FilterBar from '@/components/FilterBar.astro';
+import PreviewController from '@/components/PreviewController.astro';
 import PreviewPane from '@/components/PreviewPane.astro';
 import ThemeCard from '@/components/ThemeCard.astro';
 
@@ -40,7 +41,9 @@ const slimJson = JSON.stringify(slim);
 
   <FilterBar total={themes.length} />
 
-  <PreviewPane />
+  <PreviewPane paneId="a" />
+  <PreviewPane paneId="b" />
+  <PreviewController />
 
   <section class="grid-wrap" aria-label="Theme grid">
     <ul class="theme-grid">
@@ -64,7 +67,7 @@ const slimJson = JSON.stringify(slim);
   const listEl = document.querySelector<HTMLUListElement>('.theme-grid');
   if (emptyEl && listEl) {
     const obs = new MutationObserver(() => {
-      const anyVisible = Array.from(listEl.querySelectorAll<HTMLElement>('.theme-card')).some(
+      const anyVisible = Array.from(listEl.querySelectorAll<HTMLElement>('.theme-card-wrap')).some(
         (el) => !el.hidden,
       );
       emptyEl.hidden = anyVisible;


### PR DESCRIPTION
## Summary

Closes #20. Re-opens the feature that was deferred in the prior loop iteration.

Lets users preview two themes at once. Click the small "vs" affordance (visible on hover/focus) on any card → `?compare=<slug>` is set alongside `?theme=<slug>` → a second preview pane appears below the primary one.

## Architecture

- **`PreviewPane.astro` parameterised on `paneId` prop** (`a` or `b`). Pane `a` reads `?theme=`, pane `b` reads `?compare=`. Pane `a` hosts `ActionsPanel`; pane `b` is preview-only so the primary theme drives copy/share output.
- **Scoped attrs replace global IDs** — `[data-theme-name]`, `[data-theme-meta]`, `[data-close]` — so two instances coexist without collisions.
- **New `PreviewController.astro`** is a page-level script that discovers every `.preview-pane[data-pane-id]`, sets up paint + close handlers per pane, and centrally handles card + `.compare-link` clicks. A single `popstate` keeps every pane in sync with the URL.

## UX

- `.theme-card-wrap` wraps each card with an absolutely-positioned "vs" link in the top-right. Hidden by default, reveals on hover or focus-within.
- Keyboard: tab from card → "vs" link naturally; "vs" has its own focus ring.
- FilterBar toggles `hidden` on the wrap (not the inner card), so search + tag filters dim the card + its affordance together. No orphaned buttons when filtered.

## Test plan

- [x] `pnpm --filter ...site typecheck` — 0 / 0 / 0
- [x] `pnpm --filter ...site build` — clean
- [x] Root lint / format:check — green
- [ ] PR CI green
- [ ] Live verification: `?theme=dracula&compare=nord` paints both panes; URL round-trip survives reload; "vs" link reveals on hover / focus; filters hide both card + affordance together.

Removes the deferral on epic #12.