### PR TITLE
docs(readme): link to live demo + correct theme count

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # oklch-terminal-themes
 
-Canonical dataset of 450+ terminal color schemes converted to [OKLCH](https://oklch.com/), sourced from [`mbadolato/iTerm2-Color-Schemes`](https://github.com/mbadolato/iTerm2-Color-Schemes) and republished as an npm package + JSON API.
+Canonical dataset of 485 terminal color schemes converted to [OKLCH](https://oklch.com/), sourced from [`mbadolato/iTerm2-Color-Schemes`](https://github.com/mbadolato/iTerm2-Color-Schemes) and republished as an npm package + JSON API.
 
 Designed for consumption by Astro sites, theme pickers, Tailwind v4 `@theme` blocks, and any tooling that wants a clean OKLCH palette without parsing iTerm XML or Alacritty TOML.
+
+**Live demo + picker:** https://williamzujkowski.github.io/oklch-terminal-themes/
+
+Browse all 485 themes, filter by tag, preview on a terminal mock + website mock, copy as CSS variables / Tailwind `@theme` / raw JSON, or compare two themes side-by-side.
 
 ## Install
 


### PR DESCRIPTION
## Summary

README was written before the picker deployed + before the exact theme count was final.

## Changes

- **450+ → 485.** The dataset shipped with 485 themes; the rounded-up number is stale.
- **New intro line:** links to https://williamzujkowski.github.io/oklch-terminal-themes/ with a one-sentence summary of picker features (browse / filter / preview / copy / compare).

Reaches users who install from npm without requiring them to check the GitHub tab to find the demo.

## Test plan

- [x] `pnpm lint:md` — green
- [x] `pnpm format:check` — green
- [ ] PR CI green