### PR TITLE
test(site): unit tests for theme-filter and formatters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         run: pnpm build:ts
 
   site:
-    name: Site (build + typecheck)
+    name: Site (build + typecheck + test)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -104,6 +104,8 @@ jobs:
         run: pnpm build:ts
       - name: Typecheck site
         run: pnpm --filter @williamzujkowski/oklch-terminal-themes-site typecheck
+      - name: Test site lib
+        run: pnpm --filter @williamzujkowski/oklch-terminal-themes-site test
       - name: Build site
         run: pnpm --filter @williamzujkowski/oklch-terminal-themes-site build
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -3895,6 +3898,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@4.1.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/mocker@4.1.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
@@ -5973,6 +5984,34 @@ snapshots:
   vitefu@1.1.3(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  vitest@4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:

--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,9 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "typecheck": "astro check"
+    "typecheck": "astro check",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@williamzujkowski/oklch-terminal-themes": "workspace:*",
@@ -18,6 +20,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.4",
     "@types/node": "^22.19.17",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.4"
   }
 }

--- a/site/test/formatters.test.ts
+++ b/site/test/formatters.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatCssVars,
+  formatTailwindTheme,
+  formatJson,
+  formatPermalink,
+  type SlimThemeLike,
+} from '../src/lib/formatters';
+
+const theme: SlimThemeLike = {
+  name: 'Dracula',
+  slug: 'dracula',
+  isDark: true,
+  colors: {
+    background: 'oklch(0.288 0.022 277.5)',
+    foreground: 'oklch(0.978 0.008 106.5)',
+    brightRed: 'oklch(0.705 0.209 25.3)',
+  },
+};
+
+describe('formatCssVars', () => {
+  it('emits a :root block with kebab-case variables', () => {
+    const out = formatCssVars(theme);
+    expect(out).toMatch(/^\/\* Dracula — oklch-terminal-themes \*\//);
+    expect(out).toContain(':root {');
+    expect(out).toContain('--terminal-background: oklch(0.288 0.022 277.5);');
+    expect(out).toContain('--terminal-foreground: oklch(0.978 0.008 106.5);');
+    expect(out).toMatch(/}\n$/);
+  });
+
+  it('converts camelCase color keys to kebab-case', () => {
+    const out = formatCssVars(theme);
+    expect(out).toContain('--terminal-bright-red: oklch(0.705 0.209 25.3);');
+    expect(out).not.toContain('brightRed');
+  });
+});
+
+describe('formatTailwindTheme', () => {
+  it('emits an @theme block with --color-terminal-<key> properties', () => {
+    const out = formatTailwindTheme(theme);
+    expect(out).toMatch(/^\/\* Dracula — Tailwind v4 \*\//);
+    expect(out).toContain('@theme {');
+    expect(out).toContain('--color-terminal-background: oklch(0.288 0.022 277.5);');
+    expect(out).toContain('--color-terminal-bright-red: oklch(0.705 0.209 25.3);');
+  });
+});
+
+describe('formatJson', () => {
+  it('is a parseable JSON dump of the theme', () => {
+    const out = formatJson(theme);
+    expect(out.endsWith('\n')).toBe(true);
+    const parsed = JSON.parse(out) as unknown;
+    expect(parsed).toEqual(theme);
+  });
+
+  it('pretty-prints with two-space indent', () => {
+    const out = formatJson(theme);
+    expect(out).toContain('\n  "name": "Dracula",');
+  });
+});
+
+describe('formatPermalink', () => {
+  it('returns an absolute URL with ?theme=<slug>', () => {
+    const base = new URL('https://williamzujkowski.github.io/oklch-terminal-themes/');
+    const url = formatPermalink('dracula', base);
+    expect(url).toBe('https://williamzujkowski.github.io/oklch-terminal-themes/?theme=dracula');
+  });
+
+  it('preserves other params on the base URL', () => {
+    const base = new URL('https://example.com/picker?compare=nord');
+    const url = formatPermalink('dracula', base);
+    expect(url).toContain('compare=nord');
+    expect(url).toContain('theme=dracula');
+  });
+
+  it('replaces an existing theme param rather than appending', () => {
+    const base = new URL('https://example.com/?theme=old');
+    const url = formatPermalink('new', base);
+    expect(new URL(url).searchParams.getAll('theme')).toEqual(['new']);
+  });
+});

--- a/site/test/theme-filter.test.ts
+++ b/site/test/theme-filter.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  matches,
+  parseFilterFromUrl,
+  writeFilterToUrl,
+  ALL_TAGS,
+  type FilterableTheme,
+  type FilterState,
+} from '../src/lib/theme-filter';
+
+const dracula: FilterableTheme = {
+  slug: 'dracula',
+  name: 'Dracula',
+  isDark: true,
+  tags: ['dark', 'vibrant', 'popular'],
+};
+
+const gruvboxLight: FilterableTheme = {
+  slug: 'gruvbox-light',
+  name: 'Gruvbox Light',
+  isDark: false,
+  tags: ['light', 'muted'],
+};
+
+function state(q = '', tags: readonly string[] = []): FilterState {
+  return { query: q, tags: new Set(tags) };
+}
+
+describe('theme-filter: matches', () => {
+  it('matches everything with empty state', () => {
+    const s = state();
+    expect(matches(dracula, s)).toBe(true);
+    expect(matches(gruvboxLight, s)).toBe(true);
+  });
+
+  it('query matches name substring case-insensitively', () => {
+    expect(matches(dracula, state('DRAC'))).toBe(true);
+    expect(matches(dracula, state('gruv'))).toBe(false);
+  });
+
+  it('query matches slug as well as name', () => {
+    expect(matches(gruvboxLight, state('gruvbox-light'))).toBe(true);
+  });
+
+  it('single tag filter — passes only when theme has that tag', () => {
+    expect(matches(dracula, state('', ['popular']))).toBe(true);
+    expect(matches(gruvboxLight, state('', ['popular']))).toBe(false);
+  });
+
+  it('multiple tag filters are AND-combined', () => {
+    expect(matches(dracula, state('', ['dark', 'vibrant']))).toBe(true);
+    expect(matches(dracula, state('', ['dark', 'muted']))).toBe(false);
+  });
+
+  it('query and tags both apply (AND)', () => {
+    expect(matches(dracula, state('dracula', ['popular']))).toBe(true);
+    expect(matches(dracula, state('dracula', ['muted']))).toBe(false);
+    expect(matches(gruvboxLight, state('dracula', ['muted']))).toBe(false);
+  });
+
+  it('all documented tags are valid', () => {
+    expect(ALL_TAGS).toContain('dark');
+    expect(ALL_TAGS).toContain('light');
+    expect(ALL_TAGS).toContain('popular');
+    expect(ALL_TAGS).toHaveLength(7);
+  });
+});
+
+describe('theme-filter: parseFilterFromUrl', () => {
+  it('returns empty state for bare URL', () => {
+    const s = parseFilterFromUrl('');
+    expect(s.query).toBe('');
+    expect(s.tags.size).toBe(0);
+  });
+
+  it('reads ?q=', () => {
+    const s = parseFilterFromUrl('?q=dracula');
+    expect(s.query).toBe('dracula');
+    expect(s.tags.size).toBe(0);
+  });
+
+  it('reads ?tags= as comma-separated list', () => {
+    const s = parseFilterFromUrl('?tags=dark,popular');
+    expect(s.query).toBe('');
+    expect(s.tags.has('dark')).toBe(true);
+    expect(s.tags.has('popular')).toBe(true);
+    expect(s.tags.size).toBe(2);
+  });
+
+  it('reads q + tags together', () => {
+    const s = parseFilterFromUrl('?q=nord&tags=light,muted');
+    expect(s.query).toBe('nord');
+    expect(s.tags.size).toBe(2);
+  });
+
+  it('empty tags= yields empty Set (not a singleton empty-string tag)', () => {
+    const s = parseFilterFromUrl('?tags=');
+    expect(s.tags.size).toBe(0);
+  });
+});
+
+describe('theme-filter: writeFilterToUrl', () => {
+  const base = new URL('https://example.com/picker');
+
+  it('empty state removes both params', () => {
+    const result = writeFilterToUrl(state(), base);
+    expect(result.searchParams.has('q')).toBe(false);
+    expect(result.searchParams.has('tags')).toBe(false);
+  });
+
+  it('query sets ?q=', () => {
+    const result = writeFilterToUrl(state('nord'), base);
+    expect(result.searchParams.get('q')).toBe('nord');
+  });
+
+  it('tags joined by comma', () => {
+    const result = writeFilterToUrl(state('', ['dark', 'popular']), base);
+    expect(result.searchParams.get('tags')).toBe('dark,popular');
+  });
+
+  it('preserves other query params', () => {
+    const withExtra = new URL('https://example.com/picker?theme=dracula');
+    const result = writeFilterToUrl(state('nord', ['dark']), withExtra);
+    expect(result.searchParams.get('theme')).toBe('dracula');
+    expect(result.searchParams.get('q')).toBe('nord');
+    expect(result.searchParams.get('tags')).toBe('dark');
+  });
+
+  it('is a round-trip with parseFilterFromUrl', () => {
+    const original = state('catppuccin', ['dark', 'popular']);
+    const url = writeFilterToUrl(original, base);
+    const parsed = parseFilterFromUrl(url.search);
+    expect(parsed.query).toBe(original.query);
+    expect([...parsed.tags].sort()).toEqual([...original.tags].sort());
+  });
+});

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  test: {
+    include: ['test/**/*.test.ts'],
+    reporters: ['default'],
+  },
+});


### PR DESCRIPTION
## Summary

The two pure-TypeScript library files in `site/src/lib/` shipped with zero coverage. This adds vitest at the site-package level (25 tests across 2 files), wired into CI so filter predicates and format output are guarded against regressions.

## Coverage

**`theme-filter.test.ts`** (17 tests):
- `matches()`: empty state passes all, case-insensitive query substring, single tag filter, multi-tag AND, query + tags AND, `ALL_TAGS` sanity.
- `parseFilterFromUrl()`: bare URL, `?q=`, `?tags=` comma-list, combined, empty `tags=` yields empty Set (not singleton empty-string tag).
- `writeFilterToUrl()`: empty state removes both params, sets `?q=`, joins tags by comma, preserves other query params, round-trip with `parseFilterFromUrl`.

**`formatters.test.ts`** (8 tests):
- `formatCssVars()`: `:root` block, kebab-case keys, camelCase conversion.
- `formatTailwindTheme()`: `@theme` block with `--color-terminal-<key>`.
- `formatJson()`: parseable, 2-space pretty-print, round-trip.
- `formatPermalink()`: absolute URL, preserves other params, replaces (not appends) existing `?theme`.

## Wiring

- `site/package.json` — `test` + `test:watch` scripts, `vitest` devDep (reuses workspace version).
- `site/vitest.config.ts` — same `@/*` alias as astro config.
- `.github/workflows/ci.yml` — site job runs tests before build.

## Test plan

- [x] `pnpm --filter ...site test` — 25 / 25 green locally
- [x] `pnpm lint` + `pnpm typecheck` + `pnpm test` (root) — green
- [x] `pnpm format:check` — clean
- [ ] PR CI green, including the new site test step