### PR TITLE
feat(site): open-graph + twitter meta + canonical

### DIFF
--- a/site/public/og-image.svg
+++ b/site/public/og-image.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="oklch(0.2 0.02 265)" />
+      <stop offset="1" stop-color="oklch(0.14 0.015 270)" />
+    </linearGradient>
+    <style>
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .sans { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)" />
+
+  <!-- Swatch strip — a representative slice of OKLCH primaries across hue. -->
+  <g transform="translate(80, 120)">
+    <rect x="0"   y="0" width="128" height="72" rx="10" fill="oklch(0.70 0.21 25)"  />
+    <rect x="140" y="0" width="128" height="72" rx="10" fill="oklch(0.80 0.18 80)"  />
+    <rect x="280" y="0" width="128" height="72" rx="10" fill="oklch(0.82 0.20 145)" />
+    <rect x="420" y="0" width="128" height="72" rx="10" fill="oklch(0.82 0.14 200)" />
+    <rect x="560" y="0" width="128" height="72" rx="10" fill="oklch(0.70 0.18 265)" />
+    <rect x="700" y="0" width="128" height="72" rx="10" fill="oklch(0.70 0.21 320)" />
+    <rect x="840" y="0" width="128" height="72" rx="10" fill="oklch(0.75 0.18 350)" />
+    <rect x="980" y="0" width="60"  height="72" rx="10" fill="oklch(0.95 0.005 260)" />
+  </g>
+
+  <!-- Title. -->
+  <text x="80" y="300" class="sans" font-size="88" font-weight="650" fill="oklch(0.96 0.005 260)" letter-spacing="-1">
+    OKLCH Terminal Themes
+  </text>
+
+  <!-- Subtitle. -->
+  <text x="80" y="380" class="sans" font-size="38" font-weight="400" fill="oklch(0.85 0.008 260)">
+    485 schemes · live preview · copy as CSS, Tailwind, or JSON
+  </text>
+
+  <!-- Mono footer. -->
+  <text x="80" y="540" class="mono" font-size="28" fill="oklch(0.7 0.1 265)">
+    <tspan fill="oklch(0.82 0.20 145)">$</tspan>
+    pnpm add <tspan fill="oklch(0.85 0.18 80)">@williamzujkowski/oklch-terminal-themes</tspan>
+  </text>
+
+  <!-- Corner tag. -->
+  <g transform="translate(1000, 540)">
+    <rect width="140" height="44" rx="22" fill="oklch(0.28 0.03 265)" stroke="oklch(0.45 0.12 265)" stroke-width="1.5" />
+    <text x="70" y="29" text-anchor="middle" class="mono" font-size="20" fill="oklch(0.92 0.06 265)">
+      oklch()
+    </text>
+  </g>
+</svg>

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -6,8 +6,15 @@ export interface Props {
   description?: string;
 }
 
-const { title, description = 'Canonical OKLCH conversions of 485+ terminal color schemes.' } =
-  Astro.props;
+const {
+  title,
+  description = 'Browse, preview, and copy 485 terminal color schemes converted to OKLCH — CSS variables, Tailwind @theme, or raw JSON.',
+} = Astro.props;
+
+// `Astro.site` + `Astro.url.pathname` give us absolute URLs for canonical + OG tags.
+const canonical = new URL(Astro.url.pathname, Astro.site ?? Astro.url).toString();
+const ogImage = new URL(`${import.meta.env.BASE_URL}/og-image.svg`, Astro.site ?? Astro.url).toString();
+const siteName = 'oklch-terminal-themes';
 ---
 
 <!doctype html>
@@ -17,7 +24,24 @@ const { title, description = 'Canonical OKLCH conversions of 485+ terminal color
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <meta name="color-scheme" content="light dark" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href={canonical} />
     <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.svg`} />
+
+    <!-- Open Graph (Facebook, LinkedIn, Slack, Discord, iMessage). -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content={siteName} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonical} />
+    <meta property="og:image" content={ogImage} />
+
+    <!-- Twitter / X. -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImage} />
+
     <title>{title}</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary

Makes shared links (Slack, Discord, iMessage, Twitter/X, Facebook, LinkedIn) render with title + description + preview image instead of a bare URL.

## Changes

**`BaseLayout.astro`** — complete meta-tag block:

- Open Graph: `og:type`, `og:site_name`, `og:title`, `og:description`, `og:url`, `og:image`.
- Twitter: `summary_large_image` card with `twitter:title`, `twitter:description`, `twitter:image`.
- `<link rel="canonical">` and `<meta name="robots" content="index, follow">`.
- All absolute URLs derived from `Astro.site` + `Astro.url.pathname` so they're correct on the GH Pages base (`/oklch-terminal-themes/`).
- Default description refreshed to emphasise the picker value ("browse, preview, and copy") rather than the raw dataset shape.

**`site/public/og-image.svg`** — 1200×630 OG card:

- OKLCH swatch strip across hue
- Title + subtitle
- Install-command footer
- Matches site dark chrome

SVG renders in most modern consumers (Slack / Discord / modern Safari). Twitter and older Facebook crawlers that require raster images will fall back to the text-only card; acceptable trade-off vs. shipping a rasteriser.

## Test plan

- [x] Astro typecheck: 0 / 0 / 0
- [x] Astro build: clean; all meta tags present in emitted `index.html` (verified via grep)
- [x] Root lint + format:check: green
- [ ] PR CI green
- [ ] Post-deploy: OG validator ([opengraph.xyz](https://www.opengraph.xyz/)) + share preview in Slack confirm title + description + image render