### PR TITLE
feat(ci): publish via npm trusted publishing (oidc) — no token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,24 @@
 name: Release (npm)
 
+# Publishes to npm via **Trusted Publishing** (OIDC) — no \`NPM_TOKEN\`.
+#
+# One-time setup on https://www.npmjs.com/ before the first publish:
+#   1. Sign in to your npm account.
+#   2. Go to Access Tokens → Trusted Publishers → Add Trusted Publisher.
+#      (Or visit https://www.npmjs.com/trusted-publishers/new directly.)
+#   3. Configure:
+#        Publisher:         GitHub Actions
+#        Organization/User: williamzujkowski
+#        Repository:        oklch-terminal-themes
+#        Workflow filename: release.yml
+#        Environment:       (leave blank)
+#        Package name:      @williamzujkowski/oklch-terminal-themes
+#   4. Save. The package doesn't have to exist yet — npm will trust this
+#      workflow to claim the name on the first publish.
+#
+# After that, every tag push of `v*.*.*` triggers this workflow, which
+# authenticates via the GitHub OIDC token and publishes with provenance.
+
 on:
   push:
     tags:
@@ -14,10 +33,9 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # OIDC required for npm provenance (public repo + package).
     permissions:
       contents: read
-      id-token: write
+      id-token: write # required for both provenance attestation and OIDC auth
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -39,7 +57,10 @@ jobs:
           pnpm validate
           pnpm build:ts
 
-      - name: Publish with provenance
-        run: pnpm publish --access public --no-git-checks --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Trusted-publishing support landed in npm 11.5.1+. Node 22 ships with
+      # an older npm by default; upgrade just before publish.
+      - name: Upgrade npm for Trusted Publishing support
+        run: npm install --global npm@latest
+
+      - name: Publish with provenance (OIDC)
+        run: npm publish --access public --provenance

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,70 @@
+# Releasing
+
+Version bumps are cut as a git tag. The `Release (npm)` workflow runs on tag push, builds the dataset + TypeScript, and publishes to npm via **Trusted Publishing** (OIDC). No `NPM_TOKEN` secret is required.
+
+## One-time npm setup
+
+Before the first publish, configure npm to trust this repo's release workflow:
+
+1. Sign in at <https://www.npmjs.com/>.
+2. Open **Access Tokens → Trusted Publishers → Add Trusted Publisher** (or visit <https://www.npmjs.com/trusted-publishers/new>).
+3. Fill in:
+
+   | Field             | Value                                     |
+   | ----------------- | ----------------------------------------- |
+   | Publisher         | `GitHub Actions`                          |
+   | Organization/User | `williamzujkowski`                        |
+   | Repository        | `oklch-terminal-themes`                   |
+   | Workflow filename | `release.yml`                             |
+   | Environment       | _(leave blank)_                           |
+   | Package name      | `@williamzujkowski/oklch-terminal-themes` |
+
+4. Save. The package doesn't need to exist yet — npm will trust the workflow to claim the name on its first publish.
+
+That's it. You'll never need to generate or rotate an npm automation token.
+
+## Cutting a release
+
+```bash
+# 1. Pull latest main
+git checkout main && git pull
+
+# 2. Bump the version in package.json. Pick the kind of bump intentionally:
+#    - patch for fixes and internal cleanup
+#    - minor for new features + new data columns (485 themes is expected to drift)
+#    - major for breaking public API changes (exports, schema, color keys)
+pnpm version patch   # or minor / major — updates package.json + creates the tag
+
+# 3. Push the branch + the tag
+git push origin main
+git push origin "v$(jq -r .version package.json)"
+```
+
+The `Release (npm)` workflow fires on the tag push. Watch it via
+`gh run watch --repo williamzujkowski/oklch-terminal-themes` or
+<https://github.com/williamzujkowski/oklch-terminal-themes/actions/workflows/release.yml>.
+
+## Provenance
+
+Every publish carries an [npm provenance](https://docs.npmjs.com/generating-provenance-statements) attestation tying the tarball to the exact commit SHA on GitHub. Consumers can verify it with:
+
+```bash
+npm audit signatures
+```
+
+## Pre-release checklist
+
+The workflow itself runs `lint + typecheck + test + build:data + validate + build:ts` before publish, so a clean `main` is usually sufficient. For the first release specifically:
+
+- [ ] `package.json` `version` reflects the intended release.
+- [ ] `CHANGELOG.md` `[Unreleased]` section has been renamed to the new version and dated.
+- [ ] `npm pack --dry-run` locally shows the expected files (`dist/`, `data/`, `README.md`, `LICENSE`, `NOTICE`).
+- [ ] Trusted Publisher is configured on npm per the one-time setup above.
+
+## Troubleshooting
+
+**`npm ERR! 401 Unauthorized`** — Trusted Publisher isn't configured (or the workflow filename / repo slug doesn't match). Re-check the setup; npm is case-sensitive about the workflow filename.
+
+**`npm ERR! 403 Forbidden`** — the package is already claimed by another account, or the package name differs from the Trusted Publisher's package field.
+
+**`npm ERR! insufficient scope`** — npm CLI on the runner is older than 11.5.1. The workflow upgrades npm before publish for this reason; verify the `Upgrade npm for Trusted Publishing support` step ran.

--- a/lychee.toml
+++ b/lychee.toml
@@ -28,6 +28,9 @@ exclude = [
   "^https://github\\.com/williamzujkowski/oklch-terminal-themes/(compare|releases/tag)/",
   # GitHub Pages URL 404s until the first successful deploy of .github/workflows/pages.yml.
   "^https://williamzujkowski\\.github\\.io/oklch-terminal-themes/?$",
+  # npmjs.com returns 403 to bot-like user agents; lychee can't verify. Their
+  # availability is not a useful link-check signal.
+  "^https://(www|docs)\\.npmjs\\.com/",
 ]
 
 accept = [200, 204, 301, 302, 307, 308]


### PR DESCRIPTION
## Summary

Set up the release pipeline to publish via npm **Trusted Publishing** (OIDC). After a one-time setup on npmjs.com, pushing a `v*.*.*` tag triggers the workflow, which authenticates via the GitHub OIDC token and publishes with provenance — no `NPM_TOKEN` secret required.

## Changes

**`.github/workflows/release.yml`**:
- Drops `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN` entirely.
- Keeps `id-token: write` — used both for provenance attestation *and* for OIDC auth to npm.
- Swaps `pnpm publish` for `npm publish`. pnpm 9.x doesn't route OIDC credentials to the registry; npm 11.5.1+ does. Workflow upgrades npm just before publish.
- Adds header comments pointing at the one-time setup.

**`docs/RELEASING.md`** (new):
- Step-by-step Trusted Publisher setup on npmjs.com (exact values to enter).
- Release procedure (`pnpm version` + push tag).
- Provenance verification (`npm audit signatures`).
- Troubleshooting for 401 / 403 / insufficient-scope.

## One-time npm setup (blocking the first publish)

On npmjs.com → **Access Tokens → Trusted Publishers → Add Trusted Publisher**:

| Field | Value |
| --- | --- |
| Publisher | GitHub Actions |
| Organization/User | `williamzujkowski` |
| Repository | `oklch-terminal-themes` |
| Workflow filename | `release.yml` |
| Environment | _(blank)_ |
| Package name | `@williamzujkowski/oklch-terminal-themes` |

The package doesn't have to exist yet — Trusted Publishing can claim an unpublished name.

After that, `git tag v0.1.0 && git push origin v0.1.0` publishes.

## Test plan

- [x] `pnpm lint:md` — green
- [x] `pnpm format:check` — green
- [ ] PR CI green
- [ ] Post-merge: configure Trusted Publisher on npmjs.com
- [ ] Post-setup: tag `v0.1.0` and watch the release workflow