### PR TITLE
feat(ci): github release automation with conventional-commit labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,32 @@
+# Configures GitHub's auto-generated release notes — categorises merged PRs
+# since the last tag by the labels our auto-label workflow applies from each
+# PR's Conventional Commit title prefix.
+#
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  categories:
+    - title: '⚠️ Breaking Changes'
+      labels: [breaking]
+    - title: '✨ New Features'
+      labels: [feat, enhancement]
+    - title: '🐛 Bug Fixes'
+      labels: [fix, bug]
+    - title: '⚡ Performance'
+      labels: [perf]
+    - title: '♻️ Refactoring'
+      labels: [refactor]
+    - title: '📚 Documentation'
+      labels: [docs, documentation]
+    - title: '🧪 Tests & CI'
+      labels: [test, ci]
+    - title: '🔒 Security'
+      labels: [security]
+    - title: '📦 Dependencies'
+      labels: [dependencies]
+    - title: '🔧 Maintenance'
+      labels: [chore]
+    # Catch-all for PRs without a categorised label. The auto-label workflow
+    # should cover Conventional-Commit-prefixed PRs; this only fires when a
+    # human-authored PR lands without a matching prefix.
+    - title: '📝 Other Changes'
+      labels: ['*']

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,49 @@
+name: PR auto-label
+
+# Parses the PR title's Conventional-Commit prefix (`feat:`, `fix(scope):`,
+# etc.) and applies the matching label. Also applies `breaking` when the
+# title uses the `!` indicator or the body contains a `BREAKING CHANGE:`
+# footer. Feeds GitHub's auto-generated release notes via `.github/release.yml`.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions: read-all
+
+jobs:
+  label:
+    name: Apply conventional-commit label
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr.title ?? '';
+            const body = pr.body ?? '';
+
+            // Conventional Commit: type(scope)?!?: description
+            const match = title.match(/^(feat|fix|refactor|perf|test|chore|docs)(\([^)]+\))?(!)?:/);
+            const labels = new Set();
+            if (match) {
+              labels.add(match[1]);
+              if (match[3] === '!') labels.add('breaking');
+            }
+            if (/^BREAKING CHANGE:/m.test(body)) labels.add('breaking');
+
+            if (labels.size === 0) {
+              core.info('PR title has no recognised Conventional Commit prefix; leaving labels alone.');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: [...labels],
+            });
+            core.info(`Applied labels: ${[...labels].join(', ')}`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: read
+      contents: write # needed to create the GitHub Release at the bottom
       id-token: write # required for both provenance attestation and OIDC auth
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -64,3 +64,16 @@ jobs:
 
       - name: Publish with provenance (OIDC)
         run: npm publish --access public --provenance
+
+      - name: Create GitHub Release with auto-generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          # --generate-notes reads .github/release.yml to categorise PRs since
+          # the previous tag. --verify-tag ensures the tag that triggered this
+          # workflow is the one being released.
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --generate-notes \
+            --verify-tag

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,27 @@
 # Releasing
 
-Version bumps are cut as a git tag. The `Release (npm)` workflow runs on tag push, builds the dataset + TypeScript, and publishes to npm via **Trusted Publishing** (OIDC). No `NPM_TOKEN` secret is required.
+Version bumps are cut as a git tag. The `Release (npm)` workflow runs on tag push, builds the dataset + TypeScript, publishes to npm via **Trusted Publishing** (OIDC), and creates a GitHub Release with auto-generated categorised notes. No `NPM_TOKEN` secret is required.
+
+## Conventions
+
+The repo follows [Semantic Versioning 2.0](https://semver.org/) and [Conventional Commits 1.0](https://www.conventionalcommits.org/en/v1.0.0/). Commit / PR title prefixes drive both the version bump and the release-notes categorisation:
+
+| Prefix                                       | Semver bump                  | Release-notes section          |
+| -------------------------------------------- | ---------------------------- | ------------------------------ |
+| `feat:`                                      | minor                        | ✨ New Features                |
+| `fix:`                                       | patch                        | 🐛 Bug Fixes                   |
+| `perf:`                                      | patch                        | ⚡ Performance                 |
+| `refactor:`                                  | patch (no public-API change) | ♻️ Refactoring                 |
+| `docs:`                                      | patch                        | 📚 Documentation               |
+| `test:`                                      | patch                        | 🧪 Tests & CI                  |
+| `chore:` / `ci:` / `build:`                  | patch or no release          | 🔧 Maintenance / 🧪 Tests & CI |
+| _any_ with `!:` or `BREAKING CHANGE:` footer | **major**                    | ⚠️ Breaking Changes            |
+
+A Dependabot-raised PR lands under 📦 Dependencies. Anything else falls under 📝 Other Changes.
+
+The `.github/workflows/pr-auto-label.yml` workflow reads the PR title and applies the matching label automatically when the PR is opened, edited, or re-synchronised — the GitHub Release notes are then grouped by those labels via `.github/release.yml`.
+
+Commit messages themselves are validated by commitlint via a husky `commit-msg` hook and by the `Commit Messages` CI job on PRs.
 
 ## One-time npm setup
 
@@ -43,6 +64,11 @@ git push origin "v$(jq -r .version package.json)"
 The `Release (npm)` workflow fires on the tag push. Watch it via
 `gh run watch --repo williamzujkowski/oklch-terminal-themes` or
 <https://github.com/williamzujkowski/oklch-terminal-themes/actions/workflows/release.yml>.
+
+When it finishes, both things are in place:
+
+1. **npm** — `npm view @williamzujkowski/oklch-terminal-themes` shows the new version with provenance attestation.
+2. **GitHub Release** — `gh release view vX.Y.Z` shows release notes grouped by Conventional Commit category (see the table at the top of this file). The `[Unreleased]` block in `CHANGELOG.md` should be renamed to the new version + dated; future entries go under a new `[Unreleased]` block. The auto-generated GitHub release notes are a terse per-release diff; `CHANGELOG.md` is the curated cumulative narrative.
 
 ## Provenance
 


### PR DESCRIPTION
## Summary

Closes the last release-flow gap. Every tag now produces:

1. **npm publish** (OIDC via Trusted Publisher, landed in #44).
2. **GitHub Release** with auto-generated categorised notes (this PR).

Driven end-to-end by Conventional Commit prefixes → PR labels → release-notes sections.

## Changes

**`.github/release.yml`** — categorisation for GitHub's `--generate-notes`:

| Section | Labels |
| --- | --- |
| ⚠️ Breaking Changes | `breaking` |
| ✨ New Features | `feat`, `enhancement` |
| 🐛 Bug Fixes | `fix`, `bug` |
| ⚡ Performance | `perf` |
| ♻️ Refactoring | `refactor` |
| 📚 Documentation | `docs`, `documentation` |
| 🧪 Tests & CI | `test`, `ci` |
| 🔒 Security | `security` |
| 📦 Dependencies | `dependencies` |
| 🔧 Maintenance | `chore` |
| 📝 Other Changes | catch-all |

**`.github/workflows/pr-auto-label.yml`** — `actions/github-script` parses the PR title's Conventional Commit prefix on opened/edited/synchronize/reopened and applies matching label(s). `!` in the prefix or `BREAKING CHANGE:` in the body adds `breaking`.

**`.github/workflows/release.yml`** — adds a `gh release create --generate-notes --verify-tag` step after npm publish. `contents` permission bumped from read → write.

**`docs/RELEASING.md`** — new Conventions section maps commit prefixes ↔ semver bumps ↔ release sections; release flow now ends documenting both npm + GH Release outputs.

## Test plan

- [x] Lint / format / markdownlint — green
- [ ] PR CI green
- [ ] This PR's own title (`feat(ci): …`) triggers the labeler → PR gets `feat` label → lands under 'New Features' in the v0.1.0 release notes