### PR TITLE
fix(site): force [hidden] to win over display: grid in theme selector

### DIFF
--- a/site/src/components/ThemeSelector.astro
+++ b/site/src/components/ThemeSelector.astro
@@ -187,6 +187,11 @@ import { ALL_TAGS } from '@/lib/theme-filter';
     display: grid;
     gap: 0.5rem;
   }
+  /* Astro's `display: grid` below wins over the user-agent `[hidden]` rule
+     unless we opt back in explicitly. */
+  [hidden] {
+    display: none !important;
+  }
   .row {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto auto auto auto;


### PR DESCRIPTION
## Summary

Post-deploy chrome verification showed the theme-listbox panel and the compare row both rendering on page load, even though both had the `hidden` attribute set in HTML. Root cause: my `.listbox { display: grid }` and `.compare-row { display: grid }` rules were beating the UA `[hidden] { display: none }` rule due to specificity.

## Fix

Scoped `!important [hidden]` override inside `.theme-selector` so the `hidden` attribute controls visibility on every child regardless of the `display` property.

## Test plan

- [x] Site build clean
- [ ] PR CI green
- [ ] Live verification: listbox + compare row both hidden on load; open on interaction; persist URL state