### PR TITLE
fix(site): apply [hidden] override globally

### DIFF
--- a/site/src/components/ThemeSelector.astro
+++ b/site/src/components/ThemeSelector.astro
@@ -187,6 +187,11 @@ import { ALL_TAGS } from '@/lib/theme-filter';
     display: grid;
     gap: 0.5rem;
   }
+  /* Astro's `display: grid` below wins over the user-agent `[hidden]` rule
+     unless we opt back in explicitly. */
+  [hidden] {
+    display: none !important;
+  }
   .row {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto auto auto auto;

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -85,6 +85,13 @@ const siteName = 'oklch-terminal-themes';
       ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
   }
 
+  /* Site-wide: the `hidden` attribute always hides, even on elements we style
+     with display: grid / flex. Without this, custom `display` rules beat the
+     UA `[hidden] { display: none }` by specificity. */
+  [hidden] {
+    display: none !important;
+  }
+
   /* Light (default + explicit override). */
   :root,
   :root[data-site-theme='light'] {


### PR DESCRIPTION
The earlier scoped fix only covered .theme-selector's descendants, so the Showcase component's pane B still rendered when compare mode was off. Promoting the override to the site-wide `is:global` block covers every element.