### PR TITLE
feat(site): remove compare mode; single-theme picker

### DIFF
--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -4,22 +4,11 @@ import ShowcaseTerminal from './ShowcaseTerminal.astro';
 import ShowcaseIde from './ShowcaseIde.astro';
 import ShowcaseReading from './ShowcaseReading.astro';
 import ShowcaseDashboard from './ShowcaseDashboard.astro';
-
-export interface Props {
-  /**
-   * `a` = primary theme slot (reads `?theme=<slug>`).
-   * `b` = compare slot (reads `?compare=<slug>`, only rendered in compare mode).
-   */
-  slot?: 'a' | 'b';
-}
-
-const { slot = 'a' } = Astro.props;
-const paramName = slot === 'a' ? 'theme' : 'compare';
 ---
 
-<div class="showcase" data-showcase-slot={slot} data-url-param={paramName}>
+<div class="showcase">
   <div class="showcase-head">
-    <span class="eyebrow">{slot === 'a' ? 'Preview' : 'Compare'}</span>
+    <span class="eyebrow">Preview</span>
     <h1 class="theme-name" data-theme-name>—</h1>
     <p class="theme-meta" data-theme-meta>—</p>
   </div>

--- a/site/src/components/ShowcaseController.astro
+++ b/site/src/components/ShowcaseController.astro
@@ -1,9 +1,9 @@
 ---
-// Centralised script for the redesign. Wires the ThemeSelector combobox,
-// prev/next/random/compare controls, the listbox search + tag filters, the
+// Centralised script for the picker. Wires the ThemeSelector combobox,
+// prev/next/random controls, the listbox search + tag filters, the
 // showcase colour-variable application, and the export menu.
 //
-// All state is URL-driven: `?theme=<slug>`, `?compare=<slug>`, `?q=`, `?tags=`.
+// All state is URL-driven: `?theme=<slug>`, `?q=`, `?tags=`.
 ---
 
 <script>
@@ -38,37 +38,21 @@
   const BY_SLUG: Record<string, SlimTheme> = {};
   for (const t of THEMES) BY_SLUG[t.slug] = t;
 
-  const DEFAULT_PRIMARY = BY_SLUG['dracula'] ? 'dracula' : (THEMES[0]?.slug ?? '');
-  const DEFAULT_COMPARE =
-    BY_SLUG['github'] ? 'github' : BY_SLUG['nord'] ? 'nord' : (THEMES[1]?.slug ?? '');
+  const DEFAULT_THEME = BY_SLUG['dracula'] ? 'dracula' : (THEMES[0]?.slug ?? '');
 
-  const SLOTS = ['a', 'b'] as const;
-  type SlotId = (typeof SLOTS)[number];
-  const URL_PARAM: Record<SlotId, 'theme' | 'compare'> = { a: 'theme', b: 'compare' };
-
-  function currentSlug(slot: SlotId): string | null {
+  function currentSlug(): string {
     const url = new URLSearchParams(window.location.search);
-    const val = url.get(URL_PARAM[slot]);
+    const val = url.get('theme');
     if (val !== null && val in BY_SLUG) return val;
-    return slot === 'a' ? DEFAULT_PRIMARY : null;
+    return DEFAULT_THEME;
   }
 
-  function applySlot(slot: SlotId): void {
-    const showcase = document.querySelector<HTMLElement>(
-      `.showcase[data-showcase-slot="${slot}"]`,
-    );
+  function applyTheme(): void {
+    const showcase = document.querySelector<HTMLElement>('.showcase');
     if (!showcase) return;
-    const slug = currentSlug(slot);
-    if (slug === null) {
-      showcase.hidden = true;
-      return;
-    }
+    const slug = currentSlug();
     const theme = BY_SLUG[slug];
-    if (!theme) {
-      showcase.hidden = true;
-      return;
-    }
-    showcase.hidden = false;
+    if (!theme) return;
     const nameEl = showcase.querySelector<HTMLElement>('[data-theme-name]');
     const metaEl = showcase.querySelector<HTMLElement>('[data-theme-meta]');
     if (nameEl) nameEl.textContent = theme.name;
@@ -87,7 +71,7 @@
       }
     }
 
-    const combo = document.querySelector<HTMLElement>(`.combo-trigger[data-slot="${slot}"]`);
+    const combo = document.querySelector<HTMLElement>('.combo-trigger');
     if (combo) {
       const label = combo.querySelector<HTMLElement>('[data-combo-label]');
       const meta = combo.querySelector<HTMLElement>('[data-combo-meta]');
@@ -96,40 +80,12 @@
     }
   }
 
-  function applyAll(): void {
-    for (const slot of SLOTS) applySlot(slot);
-  }
-
-  function compareActive(): boolean {
-    return document.body.dataset.compare === 'true';
-  }
-
-  function setCompare(on: boolean): void {
-    const root = document.querySelector<HTMLElement>('.site-shell');
-    if (!root) return;
-    document.body.dataset.compare = on ? 'true' : 'false';
-    root.classList.toggle('is-comparing', on);
-    const compareRow = document.querySelector<HTMLElement>('.compare-row');
-    if (compareRow) compareRow.hidden = !on;
-    const toggle = document.querySelector<HTMLElement>('.compare-toggle');
-    if (toggle) toggle.setAttribute('aria-pressed', on ? 'true' : 'false');
-
-    const next = new URL(window.location.href);
-    if (on) {
-      if (!next.searchParams.get('compare')) next.searchParams.set('compare', DEFAULT_COMPARE);
-    } else {
-      next.searchParams.delete('compare');
-    }
-    history.replaceState(null, '', next.toString());
-    applyAll();
-  }
-
-  function setSlug(slot: SlotId, slug: string): void {
+  function setSlug(slug: string): void {
     if (!(slug in BY_SLUG)) return;
     const next = new URL(window.location.href);
-    next.searchParams.set(URL_PARAM[slot], slug);
+    next.searchParams.set('theme', slug);
     history.replaceState(null, '', next.toString());
-    applyAll();
+    applyTheme();
   }
 
   // ===== Listbox (filters + list) =====
@@ -145,7 +101,7 @@
   const listItems = Array.from(document.querySelectorAll<HTMLElement>('.listbox-item'));
   const emptyEl = document.querySelector<HTMLElement>('.listbox-empty');
 
-  let openForSlot: SlotId | null = null;
+  let listboxOpen = false;
   let filterState: FilterState = parseFilterFromUrl(window.location.search);
 
   function applyFilters(): void {
@@ -173,15 +129,14 @@
     history.replaceState(null, '', url.toString());
   }
 
-  function openListbox(slot: SlotId): void {
+  function openListbox(): void {
     if (!listbox) return;
-    openForSlot = slot;
+    listboxOpen = true;
     listbox.hidden = false;
-    for (const t of document.querySelectorAll<HTMLElement>('.combo-trigger')) {
-      t.setAttribute('aria-expanded', t.dataset.slot === slot ? 'true' : 'false');
-    }
+    const combo = document.querySelector<HTMLElement>('.combo-trigger');
+    combo?.setAttribute('aria-expanded', 'true');
     // Highlight current selection
-    const slug = currentSlug(slot);
+    const slug = currentSlug();
     for (const li of listItems) {
       li.setAttribute('aria-selected', li.dataset.slug === slug ? 'true' : 'false');
     }
@@ -196,23 +151,16 @@
   function closeListbox(): void {
     if (!listbox) return;
     listbox.hidden = true;
-    openForSlot = null;
-    for (const t of document.querySelectorAll<HTMLElement>('.combo-trigger')) {
-      t.setAttribute('aria-expanded', 'false');
-    }
+    listboxOpen = false;
+    const combo = document.querySelector<HTMLElement>('.combo-trigger');
+    combo?.setAttribute('aria-expanded', 'false');
   }
 
-  // Wire combobox triggers
-  for (const trigger of document.querySelectorAll<HTMLElement>('.combo-trigger')) {
-    trigger.addEventListener('click', () => {
-      const slot = (trigger.dataset.slot ?? 'a') as SlotId;
-      if (openForSlot === slot) {
-        closeListbox();
-      } else {
-        openListbox(slot);
-      }
-    });
-  }
+  // Wire combobox trigger
+  document.querySelector<HTMLElement>('.combo-trigger')?.addEventListener('click', () => {
+    if (listboxOpen) closeListbox();
+    else openListbox();
+  });
 
   // Close listbox when clicking outside
   document.addEventListener('click', (ev) => {
@@ -226,9 +174,8 @@
   // Listbox item click
   for (const li of listItems) {
     li.addEventListener('click', () => {
-      if (openForSlot === null) return;
       const slug = li.dataset.slug ?? '';
-      setSlug(openForSlot, slug);
+      setSlug(slug);
       closeListbox();
     });
   }
@@ -267,19 +214,18 @@
     return listItems.filter((li) => !li.hidden).map((li) => li.dataset.slug ?? '');
   }
 
-  function step(slot: SlotId, delta: number): void {
+  function step(delta: number): void {
     const slugs = visibleSlugs();
     if (slugs.length === 0) return;
-    const current = currentSlug(slot);
-    const idx = current ? slugs.indexOf(current) : -1;
+    const current = currentSlug();
+    const idx = slugs.indexOf(current);
     const next = slugs[(idx + delta + slugs.length) % slugs.length];
-    if (next !== undefined) setSlug(slot, next);
+    if (next !== undefined) setSlug(next);
   }
 
   for (const btn of document.querySelectorAll<HTMLElement>('[data-nav]')) {
     btn.addEventListener('click', () => {
-      const slot = (btn.dataset.slot ?? 'a') as SlotId;
-      step(slot, btn.dataset.nav === 'next' ? 1 : -1);
+      step(btn.dataset.nav === 'next' ? 1 : -1);
     });
   }
 
@@ -289,13 +235,7 @@
       const slugs = visibleSlugs();
       if (slugs.length === 0) return;
       const pick = slugs[Math.floor(Math.random() * slugs.length)];
-      if (pick) setSlug('a', pick);
-    });
-
-  document
-    .querySelector<HTMLElement>('[data-action="compare-toggle"]')
-    ?.addEventListener('click', () => {
-      setCompare(!compareActive());
+      if (pick) setSlug(pick);
     });
 
   // ===== Export menu =====
@@ -322,8 +262,7 @@
 
   for (const btn of document.querySelectorAll<HTMLButtonElement>('[data-export]')) {
     btn.addEventListener('click', async () => {
-      const slug = currentSlug('a');
-      if (slug === null) return;
+      const slug = currentSlug();
       const theme = BY_SLUG[slug];
       if (!theme) return;
       const action = btn.dataset.export;
@@ -347,8 +286,7 @@
   // ===== Palette chip copy =====
   for (const chip of document.querySelectorAll<HTMLButtonElement>('.palette-chip')) {
     chip.addEventListener('click', async () => {
-      const slug = currentSlug('a');
-      if (slug === null) return;
+      const slug = currentSlug();
       const theme = BY_SLUG[slug];
       if (!theme) return;
       const key = chip.dataset.key ?? '';
@@ -389,20 +327,15 @@
     switch (ev.key) {
       case '/':
         ev.preventDefault();
-        openListbox('a');
+        openListbox();
         break;
       case 'ArrowLeft':
         ev.preventDefault();
-        step('a', -1);
+        step(-1);
         break;
       case 'ArrowRight':
         ev.preventDefault();
-        step('a', 1);
-        break;
-      case 'c':
-      case 'C':
-        ev.preventDefault();
-        setCompare(!compareActive());
+        step(1);
         break;
       case 'r':
       case 'R':
@@ -415,21 +348,13 @@
         if (listbox && !listbox.hidden) {
           ev.preventDefault();
           closeListbox();
-        } else if (compareActive()) {
-          ev.preventDefault();
-          setCompare(false);
         }
         break;
     }
   });
 
   // ===== Init =====
-  // If URL already has ?compare=<slug>, start in compare mode.
-  if (new URLSearchParams(window.location.search).get('compare')) {
-    setCompare(true);
-  } else {
-    applyAll();
-  }
+  applyTheme();
 
   window.addEventListener('popstate', () => {
     filterState = parseFilterFromUrl(window.location.search);
@@ -439,25 +364,11 @@
       chip.setAttribute('aria-pressed', filterState.tags.has(tag) ? 'true' : 'false');
     }
     applyFilters();
-    if (new URLSearchParams(window.location.search).get('compare')) {
-      setCompare(true);
-    } else {
-      setCompare(false);
-    }
+    applyTheme();
   });
 </script>
 
 <style is:global>
-  /* Compare-mode layout: side-by-side showcases in the main column. */
-  .site-shell.is-comparing .showcase-panes {
-    grid-template-columns: 1fr 1fr;
-  }
-  @media (max-width: 64rem) {
-    .site-shell.is-comparing .showcase-panes {
-      grid-template-columns: 1fr;
-    }
-  }
-
   /* Export feedback chip next to the summary. */
   .export-menu summary[data-feedback]::after {
     content: attr(data-feedback);

--- a/site/src/components/ShowcaseDashboard.astro
+++ b/site/src/components/ShowcaseDashboard.astro
@@ -89,19 +89,19 @@
             <span class="pct">100%</span>
           </li>
           <li>
-            <span>Ship compare mode</span>
-            <div class="bar"><div class="bar-fill" style="width:88%"></div></div>
-            <span class="pct">88%</span>
-          </li>
-          <li>
             <span>Reach Lighthouse ≥ 90</span>
-            <div class="bar"><div class="bar-fill" style="width:52%"></div></div>
-            <span class="pct">52%</span>
+            <div class="bar"><div class="bar-fill" style="width:72%"></div></div>
+            <span class="pct">72%</span>
           </li>
           <li>
             <span>Publish to npm</span>
             <div class="bar"><div class="bar-fill" style="width:100%"></div></div>
             <span class="pct">100%</span>
+          </li>
+          <li>
+            <span>Mobile responsive</span>
+            <div class="bar"><div class="bar-fill" style="width:90%"></div></div>
+            <span class="pct">90%</span>
           </li>
         </ul>
       </section>

--- a/site/src/components/ThemeSelector.astro
+++ b/site/src/components/ThemeSelector.astro
@@ -2,8 +2,8 @@
 import themes from '@williamzujkowski/oklch-terminal-themes/themes.json';
 import { ALL_TAGS } from '@/lib/theme-filter';
 
-// Selector owns primary + compare slots. Clicking a theme in the list picks it
-// for whichever slot is currently "armed" (primary by default).
+// Single-combobox selector. Clicking a theme in the listbox updates
+// ?theme=<slug> and repaints the showcase.
 ---
 
 <section class="theme-selector" role="group" aria-label="Theme picker">
@@ -12,15 +12,14 @@ import { ALL_TAGS } from '@/lib/theme-filter';
       <span aria-hidden="true">‹</span>
     </button>
 
-    <div class="combobox" data-slot="a">
-      <label class="visually-hidden" for="theme-combo-a">Active theme</label>
+    <div class="combobox">
+      <label class="visually-hidden" for="theme-combo">Active theme</label>
       <button
         type="button"
         class="combo-trigger"
-        id="theme-combo-a"
+        id="theme-combo"
         aria-haspopup="listbox"
         aria-expanded="false"
-        data-slot="a"
       >
         <span class="combo-eyebrow">Theme</span>
         <span class="combo-label" data-combo-label>—</span>
@@ -36,16 +35,6 @@ import { ALL_TAGS } from '@/lib/theme-filter';
     <button type="button" class="icon-btn" data-action="random" aria-label="Random theme"
       title="Surprise me">
       <span aria-hidden="true">✦</span>
-    </button>
-
-    <button
-      type="button"
-      class="icon-btn compare-toggle"
-      data-action="compare-toggle"
-      aria-pressed="false"
-      title="Toggle side-by-side compare (c)"
-    >
-      <span class="label">Compare</span>
     </button>
 
     <details class="export-menu">
@@ -70,33 +59,7 @@ import { ALL_TAGS } from '@/lib/theme-filter';
     </details>
   </div>
 
-  <!-- Compare slot, revealed when compare mode is active. -->
-  <div class="row compare-row" hidden>
-    <button type="button" class="nav" data-nav="prev" data-slot="b" aria-label="Previous compare theme">
-      <span aria-hidden="true">‹</span>
-    </button>
-    <div class="combobox" data-slot="b">
-      <label class="visually-hidden" for="theme-combo-b">Compare theme</label>
-      <button
-        type="button"
-        class="combo-trigger"
-        id="theme-combo-b"
-        aria-haspopup="listbox"
-        aria-expanded="false"
-        data-slot="b"
-      >
-        <span class="combo-eyebrow">Compare</span>
-        <span class="combo-label" data-combo-label>—</span>
-        <span class="combo-meta" data-combo-meta>—</span>
-        <span class="combo-caret" aria-hidden="true">▾</span>
-      </button>
-    </div>
-    <button type="button" class="nav" data-nav="next" data-slot="b" aria-label="Next compare theme">
-      <span aria-hidden="true">›</span>
-    </button>
-  </div>
-
-  <!-- Shared listbox panel used by whichever combo is open. -->
+  <!-- Listbox panel opened by the combobox. -->
   <div
     id="theme-listbox"
     class="listbox"
@@ -194,12 +157,9 @@ import { ALL_TAGS } from '@/lib/theme-filter';
   }
   .row {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto auto auto auto;
+    grid-template-columns: auto minmax(0, 1fr) auto auto auto;
     gap: 0.4rem;
     align-items: stretch;
-  }
-  .compare-row {
-    grid-template-columns: auto minmax(0, 1fr) auto;
   }
   /* Narrow viewports: combobox gets its own row, actions wrap underneath. */
   @media (max-width: 40rem) {
@@ -275,12 +235,6 @@ import { ALL_TAGS } from '@/lib/theme-filter';
       display: inline;
     }
   }
-  .compare-toggle[aria-pressed='true'] {
-    background: color-mix(in oklch, var(--accent) 18%, transparent);
-    color: var(--accent);
-    border-color: var(--accent);
-  }
-
   .combobox {
     position: relative;
   }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -21,7 +21,7 @@ const slimJson = JSON.stringify(slim);
       <h1>OKLCH Terminal Themes</h1>
       <p class="tagline">
         Browse {themes.length} terminal color schemes in a live showcase — terminal,
-        editor, reading, dashboard — swap themes with ←/→, <kbd>c</kbd> to compare,
+        editor, reading, dashboard — swap themes with ←/→,
         <kbd>/</kbd> to search, <kbd>r</kbd> for a random pick.
       </p>
       <dl class="stats">
@@ -34,10 +34,7 @@ const slimJson = JSON.stringify(slim);
 
     <ThemeSelector />
 
-    <div class="showcase-panes">
-      <Showcase slot="a" />
-      <Showcase slot="b" />
-    </div>
+    <Showcase />
 
     <ShowcaseController />
 
@@ -96,12 +93,5 @@ const slimJson = JSON.stringify(slim);
     font-weight: 600;
     margin: 0;
     font-variant-numeric: tabular-nums;
-  }
-
-  .showcase-panes {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    gap: 1.1rem;
-    align-items: start;
   }
 </style>

--- a/site/test/formatters.test.ts
+++ b/site/test/formatters.test.ts
@@ -67,9 +67,9 @@ describe('formatPermalink', () => {
   });
 
   it('preserves other params on the base URL', () => {
-    const base = new URL('https://example.com/picker?compare=nord');
+    const base = new URL('https://example.com/picker?q=dark');
     const url = formatPermalink('dracula', base);
-    expect(url).toContain('compare=nord');
+    expect(url).toContain('q=dark');
     expect(url).toContain('theme=dracula');
   });
 


### PR DESCRIPTION
## Summary
- Removes the side-by-side A/B compare pane. With 485 themes, discovery (search + tag-filter + random) matters more than comparison, and compare-mode doubled page height, broke at mobile widths, and cost ~160 LOC of dual-slot state management.
- **Kept unchanged**: search, tag filters, palette chip copy, prev / next / random buttons, permalink format (`?theme=<slug>`), all four export formats (CSS vars / Tailwind v4 / Raw JSON / Permalink), keyboard shortcuts `←`/`→`/`/`/`r`.
- **Gone**: Compare toggle button, \`?compare=<slug>\` URL param, \`c\` keyboard shortcut, compare-row (second combobox), slot-b showcase, compare-mode grid CSS, dashboard mock row referencing 'Ship compare mode'.
- Validated via \`nexus-agents consensus_vote\` (higher-order strategy, 5 / 6 approve) before implementation — contrarian concerns about desktop A/B use were weighed against the mobile-first trajectory of this repo.

Net diff: **+63 / −219**. Controller logic drops from 403 to 245 lines.

## Test plan
- [x] \`pnpm build\` + \`pnpm typecheck\` + \`pnpm lint\` green
- [x] Updated \`formatters.test.ts\` to drop stale \`compare=nord\` fixture, uses \`?q=dark\` instead
- [x] All 25 site tests + 24 root tests pass
- [x] Local preview verified: default theme renders, combobox opens listbox with 485 items, item click updates URL to \`?theme=<slug>\` and repaints, no compare button / compare row / slot-b exist, \`c\` key is a no-op
- [ ] Await CI green (Lighthouse, axe, link-check)

Note: stacks with open PR #52 (mobile responsive) — will need a quick CSS merge in \`ThemeSelector.astro\` whichever one lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)