### PR TITLE
feat(classify): compute WCAG contrast data on every theme

### DIFF
--- a/data/by-name/0x96f.json
+++ b/data/by-name/0x96f.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/0x96f.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#262427",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.991 0.003 106.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.98736223531605,
+    "minAnsi": 5.405457549496037,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/12-bit-rainbow.json
+++ b/data/by-name/12-bit-rainbow.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/12-bit Rainbow.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#040404",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 20.465226245727198,
+    "minAnsi": 2.173156742940344,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/3024-day.json
+++ b/data/by-name/3024-day.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/3024 Day.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f7f7f7",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.976 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.816057552122258,
+    "minAnsi": 1.7892684123648972,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/3024-night.json
+++ b/data/by-name/3024-night.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/3024 Night.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#090300",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.976 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.090376250999649,
+    "minAnsi": 2.0454139168455816,
+    "minAnsiSlot": "brightGreen"
   }
 }

--- a/data/by-name/aardvark-blue.json
+++ b/data/by-name/aardvark-blue.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aardvark Blue.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#102040",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.976 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.868782411080737,
+    "minAnsi": 2.4870906408519557,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/abernathy.json
+++ b/data/by-name/abernathy.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Abernathy.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#111416",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.919643988665126,
+    "minAnsi": 3.1667849280656473,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/adventure-time.json
+++ b/data/by-name/adventure-time.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adventure Time.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1f1d45",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.973 0.008 293.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.113966282696687,
+    "minAnsi": 2.1328725131315767,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/adventure.json
+++ b/data/by-name/adventure.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adventure.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#040404",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.881 0.025 65.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 20.465226245727198,
+    "minAnsi": 4.549050814459397,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/adwaita-dark.json
+++ b/data/by-name/adwaita-dark.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adwaita Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d1d20",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.971 0.002 67.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.8155377168847,
+    "minAnsi": 2.752972028782864,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/adwaita.json
+++ b/data/by-name/adwaita.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adwaita.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.971 0.002 67.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 1.7544651015331638,
+    "minAnsiSlot": "brightCyan"
   }
 }

--- a/data/by-name/afterglow.json
+++ b/data/by-name/afterglow.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Afterglow.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#212121",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.97 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.439697060587305,
+    "minAnsi": 2.7518794428131885,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/aizen-dark.json
+++ b/data/by-name/aizen-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aizen Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1a1a1a",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.066055932105117,
+    "minAnsi": 7.19388524139549,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/aizen-light.json
+++ b/data/by-name/aizen-light.json
@@ -3,12 +3,14 @@
   "slug": "aizen-light",
   "isDark": false,
   "tags": [
-    "light"
+    "light",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aizen Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f0f2f6",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.428 0.042 279.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.363358729842013,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/alabaster.json
+++ b/data/by-name/alabaster.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Alabaster.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f7f7f7",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.976 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 19.602217167508474,
+    "minAnsi": 1.778257050595166,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/alien-blood.json
+++ b/data/by-name/alien-blood.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa-large"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Alien Blood.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0f1610",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.885 0.186 148.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.131824451082685,
+    "minAnsi": 1.9931186853570928,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/andromeda.json
+++ b/data/by-name/andromeda.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Andromeda.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#262a33",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.407365218447465,
+    "minAnsi": 2.791497587776118,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/apple-classic.json
+++ b/data/by-name/apple-classic.json
@@ -3,12 +3,13 @@
   "slug": "apple-classic",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Apple Classic.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2c2b2b",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.048527078431232,
+    "minAnsi": 1.914333565863103,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/apple-system-colors-light.json
+++ b/data/by-name/apple-system-colors-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Apple System Colors Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#feffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 20.962166116928003,
+    "minAnsi": 1.8188603147109128,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/apple-system-colors.json
+++ b/data/by-name/apple-system-colors.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Apple System Colors.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1e1e1e",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.67115667431794,
+    "minAnsi": 3.090764391581366,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/arcoiris.json
+++ b/data/by-name/arcoiris.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Arcoiris.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#201f1e",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.952 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.113383572161831,
+    "minAnsi": 3.346995540140267,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/ardoise.json
+++ b/data/by-name/ardoise.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ardoise.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1e1e1e",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.997 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.857474337764968,
+    "minAnsi": 2.257962048740802,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/argonaut.json
+++ b/data/by-name/argonaut.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Argonaut.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0e1019",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 18.27980978944089,
+    "minAnsi": 2.713830325000255,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/arthur.json
+++ b/data/by-name/arthur.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Arthur.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1c1c1c",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.855 0.03 67.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.078643157977426,
+    "minAnsi": 3.4530549565921453,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/atelier-sulphurpool.json
+++ b/data/by-name/atelier-sulphurpool.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atelier Sulphurpool.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#202746",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.977 0.011 274.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.414841177867144,
+    "minAnsi": 2.0967078405880457,
+    "minAnsiSlot": "brightGreen"
   }
 }

--- a/data/by-name/atom-one-dark.json
+++ b/data/by-name/atom-one-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atom One Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#21252b",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.762 0.02 263)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.22197939059332,
+    "minAnsi": 4.817082099235591,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/atom-one-light.json
+++ b/data/by-name/atom-one-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atom One Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f9f9f9",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.239833955316717,
+    "minAnsi": 1.8602032925263683,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/atom.json
+++ b/data/by-name/atom.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atom.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#161719",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.907 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.635607286220665,
+    "minAnsi": 6.904856074987967,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/aura.json
+++ b/data/by-name/aura.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aura.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#15141b",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.944 0.003 308.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.537628430566988,
+    "minAnsi": 5.766817550072907,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/aurora.json
+++ b/data/by-name/aurora.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "vibrant"
+    "vibrant",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aurora.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#23262e",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.649 0.242 317.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.891393012270951,
+    "minAnsi": 1.824799856967808,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/ayu-light.json
+++ b/data/by-name/ayu-light.json
@@ -4,12 +4,13 @@
   "isDark": false,
   "tags": [
     "light",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ayu Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f8f9fa",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.861 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.934812759512011,
+    "minAnsi": 1.8233432417765811,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/ayu-mirage.json
+++ b/data/by-name/ayu-mirage.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ayu Mirage.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1f2430",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.454497337874741,
+    "minAnsi": 5.9456122299542065,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/ayu.json
+++ b/data/by-name/ayu.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ayu.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0b0e14",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.274416767856575,
+    "minAnsi": 6.33868001629521,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/banana-blueberry.json
+++ b/data/by-name/banana-blueberry.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Banana Blueberry.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#191323",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.285012520072431,
+    "minAnsi": 4.173883068640812,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/batman.json
+++ b/data/by-name/batman.json
@@ -5,12 +5,13 @@
   "tags": [
     "dark",
     "muted",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa-large"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Batman.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1b1d1e",
@@ -192,5 +193,10 @@
       },
       "oklchCss": "oklch(0.889 0.007 115.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 3.367360421928134,
+    "minAnsi": 2.705453770745099,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/belafonte-day.json
+++ b/data/by-name/belafonte-day.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Belafonte Day.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#d5ccba",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.848 0.026 84.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.065447991368135,
+    "minAnsi": 1.7715117803328628,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/belafonte-night.json
+++ b/data/by-name/belafonte-night.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Belafonte Night.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#20111b",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.848 0.026 84.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.5086070861374195,
+    "minAnsi": 2.8251493881125196,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/birds-of-paradise.json
+++ b/data/by-name/birds-of-paradise.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Birds Of Paradise.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2a1f1d",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.978 0.047 99.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.42053308730299,
+    "minAnsi": 2.7380088390241584,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/black-metal-bathory.json
+++ b/data/by-name/black-metal-bathory.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Bathory).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.811 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.665528080210105,
+    "minAnsi": 5.302022326099849,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/black-metal-burzum.json
+++ b/data/by-name/black-metal-burzum.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Burzum).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.811 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.665528080210105,
+    "minAnsi": 5.302022326099849,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/black-metal-dark-funeral.json
+++ b/data/by-name/black-metal-dark-funeral.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Dark Funeral).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.811 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.665528080210105,
+    "minAnsi": 5.170004476038628,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/black-metal-gorgoroth.json
+++ b/data/by-name/black-metal-gorgoroth.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Gorgoroth).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.811 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.665528080210105,
+    "minAnsi": 5.302022326099849,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/black-metal-immortal.json
+++ b/data/by-name/black-metal-immortal.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Immortal).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.811 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.665528080210105,
+    "minAnsi": 3.553189319516299,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/black-metal-khold.json
+++ b/data/by-name/black-metal-khold.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Khold).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.811 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.665528080210105,
+    "minAnsi": 3.41073197097461,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/black-metal-marduk.json
+++ b/data/by-name/black-metal-marduk.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Marduk).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.811 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.665528080210105,
+    "minAnsi": 3.818266607523982,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/black-metal-mayhem.json
+++ b/data/by-name/black-metal-mayhem.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Mayhem).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.811 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.665528080210105,
+    "minAnsi": 5.302022326099849,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/black-metal-nile.json
+++ b/data/by-name/black-metal-nile.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Nile).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.811 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.665528080210105,
+    "minAnsi": 4.554293428899023,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/black-metal-venom.json
+++ b/data/by-name/black-metal-venom.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Venom).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.811 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.665528080210105,
+    "minAnsi": 2.085125879935977,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/black-metal.json
+++ b/data/by-name/black-metal.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.811 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.665528080210105,
+    "minAnsi": 3.7354550726829094,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/blazer.json
+++ b/data/by-name/blazer.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blazer.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0d1926",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.9772666218614,
+    "minAnsi": 4.478698684813335,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/blue-berry-pie.json
+++ b/data/by-name/blue-berry-pie.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blue Berry Pie.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1c0c28",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.49 0.084 215)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.546087376536567,
+    "minAnsi": 2.06095558162547,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/blue-dolphin.json
+++ b/data/by-name/blue-dolphin.json
@@ -3,12 +3,13 @@
   "slug": "blue-dolphin",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blue Dolphin.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#006984",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.223572571709242,
+    "minAnsi": 2.624043838476951,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/blue-matrix.json
+++ b/data/by-name/blue-matrix.json
@@ -3,12 +3,14 @@
   "slug": "blue-matrix",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blue Matrix.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#101116",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.834399264935834,
+    "minAnsi": 4.843488536888253,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/bluloco-dark.json
+++ b/data/by-name/bluloco-dark.json
@@ -3,12 +3,15 @@
   "slug": "bluloco-dark",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Bluloco Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282c34",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.6429594705314825,
+    "minAnsi": 3.3816564098969817,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/bluloco-light.json
+++ b/data/by-name/bluloco-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Bluloco Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f9f9f9",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.867 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.816784394191304,
+    "minAnsi": 2.303514790146454,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/borland.json
+++ b/data/by-name/borland.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Borland.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0000a4",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.802832815575501,
+    "minAnsi": 4.925520462555745,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/box.json
+++ b/data/by-name/box.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "vibrant",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Box.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#141d2b",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.948642919560694,
+    "minAnsi": 2.8911886438272014,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/branch.json
+++ b/data/by-name/branch.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/branch.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#32221a",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.816 0.036 81.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.593893421562631,
+    "minAnsi": 3.3804888513483955,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/breadog.json
+++ b/data/by-name/breadog.json
@@ -4,12 +4,15 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Breadog.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f1ebe6",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.915 0.014 60.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.516984728118752,
+    "minAnsi": 3.551081210057594,
+    "minAnsiSlot": "brightGreen"
   }
 }

--- a/data/by-name/breeze.json
+++ b/data/by-name/breeze.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Breeze.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#31363b",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.991 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.691418971163678,
+    "minAnsi": 2.0799367639426634,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/bright-lights.json
+++ b/data/by-name/bright-lights.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Bright Lights.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#191919",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.833 0.022 268.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.258212000763624,
+    "minAnsi": 4.949922051401596,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/broadcast.json
+++ b/data/by-name/broadcast.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Broadcast.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2b2b2b",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.901201394892102,
+    "minAnsi": 3.366601690433081,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/brogrammer.json
+++ b/data/by-name/brogrammer.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Brogrammer.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#131313",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.38055610561519,
+    "minAnsi": 2.8452502311416352,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/builtin-dark.json
+++ b/data/by-name/builtin-dark.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.938659901217408,
+    "minAnsi": 1.9087088049756329,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/builtin-light.json
+++ b/data/by-name/builtin-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 1.8941005847454646,
+    "minAnsiSlot": "brightGreen"
   }
 }

--- a/data/by-name/builtin-pastel-dark.json
+++ b/data/by-name/builtin-pastel-dark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Pastel Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.938659901217408,
+    "minAnsi": 7.565930477694234,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/builtin-tango-dark.json
+++ b/data/by-name/builtin-tango-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Tango Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.949 0.003 106.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 3.189857951985112,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/builtin-tango-light.json
+++ b/data/by-name/builtin-tango-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Tango Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.949 0.003 106.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 1.7952876128727326,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/c64.json
+++ b/data/by-name/c64.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-fail"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/C64.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#40318d",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.976 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 2.2607656244342924,
+    "minAnsi": 1.7528273106950094,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/calamity.json
+++ b/data/by-name/calamity.json
@@ -3,12 +3,15 @@
   "slug": "calamity",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Calamity.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2f2833",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.278505646168245,
+    "minAnsi": 3.2235122088779002,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/carbonfox.json
+++ b/data/by-name/carbonfox.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Carbonfox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#161616",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.919 0.001 286.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.434104834959708,
+    "minAnsi": 5.44018049973752,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/catppuccin-frappe.json
+++ b/data/by-name/catppuccin-frappe.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Frappe.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#303446",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.808 0.051 272.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.058361993601588,
+    "minAnsi": 4.087013150070628,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/catppuccin-latte.json
+++ b/data/by-name/catppuccin-latte.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Latte.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#eff1f5",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.808 0.017 271.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.0619995573104415,
+    "minAnsi": 1.9141888968694352,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/catppuccin-macchiato.json
+++ b/data/by-name/catppuccin-macchiato.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Macchiato.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#24273a",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.812 0.046 274.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.91891243005997,
+    "minAnsi": 5.194473756643897,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/catppuccin-mocha.json
+++ b/data/by-name/catppuccin-mocha.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Mocha.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1e1e2e",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(0.817 0.04 272.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.341133436863977,
+    "minAnsi": 6.177654146691573,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/cga.json
+++ b/data/by-name/cga.json
@@ -3,12 +3,14 @@
   "slug": "cga",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/CGA.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.039555596643915,
+    "minAnsi": 1.7584621294329432,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/chalk.json
+++ b/data/by-name/chalk.json
@@ -3,12 +3,14 @@
   "slug": "chalk",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Chalk.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2b2d2e",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.878 0.007 208.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.597623877390692,
+    "minAnsi": 2.385502309081929,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/chalkboard.json
+++ b/data/by-name/chalkboard.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Chalkboard.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#29262f",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.717055368088978,
+    "minAnsi": 3.4857732997160817,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/challenger-deep.json
+++ b/data/by-name/challenger-deep.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Challenger Deep.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1e1c31",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.899 0.026 208.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.217613990801206,
+    "minAnsi": 4.56276031526616,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/chester.json
+++ b/data/by-name/chester.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Chester.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2c3643",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.239111925768343,
+    "minAnsi": 2.927915443263548,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/ciapre.json
+++ b/data/by-name/ciapre.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ciapre.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#191c27",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.967 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.784768448344223,
+    "minAnsi": 1.7944955850844855,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/citruszest.json
+++ b/data/by-name/citruszest.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Citruszest.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#121212",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.982 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.187465865194712,
+    "minAnsi": 5.046160960201738,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/clrs.json
+++ b/data/by-name/clrs.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/CLRS.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.949 0.003 106.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.133529408889883,
+    "minAnsi": 1.8120859440085175,
+    "minAnsiSlot": "brightCyan"
   }
 }

--- a/data/by-name/cobalt-neon.json
+++ b/data/by-name/cobalt-neon.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "vibrant",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Neon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#142838",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.882 0.176 142.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.200746748171563,
+    "minAnsi": 1.764991976970595,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/cobalt-next-dark.json
+++ b/data/by-name/cobalt-next-dark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Next Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0b1c24",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.876057625515893,
+    "minAnsi": 5.122564749771748,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/cobalt-next-minimal.json
+++ b/data/by-name/cobalt-next-minimal.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Next Minimal.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0b1c24",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.876057625515893,
+    "minAnsi": 5.798179209508437,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/cobalt-next.json
+++ b/data/by-name/cobalt-next.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Next.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#162c35",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.738742024166898,
+    "minAnsi": 4.665202123018976,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/cobalt2.json
+++ b/data/by-name/cobalt2.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt2.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#132738",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.272707504267059,
+    "minAnsi": 2.642557726110494,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/coffee-theme.json
+++ b/data/by-name/coffee-theme.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Coffee Theme.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f5deb3",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.98194056409643,
+    "minAnsi": 1.7576534298401374,
+    "minAnsiSlot": "brightCyan"
   }
 }

--- a/data/by-name/crayon-pony-fish.json
+++ b/data/by-name/crayon-pony-fish.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-fail"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Crayon Pony Fish.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#150707",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.695 0.036 356.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 2.762639595886461,
+    "minAnsi": 1.992869950464761,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/cursor-dark.json
+++ b/data/by-name/cursor-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cursor Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#141414",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.919 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.428629164208074,
+    "minAnsi": 5.764803105478651,
+    "minAnsiSlot": "green"
   }
 }

--- a/data/by-name/cursor-light.json
+++ b/data/by-name/cursor-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cursor Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f3f3f3",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.814106751785841,
+    "minAnsi": 2.6670308375679537,
+    "minAnsiSlot": "brightGreen"
   }
 }

--- a/data/by-name/cutie-pro.json
+++ b/data/by-name/cutie-pro.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cutie Pro.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#181818",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.579609455685839,
+    "minAnsi": 6.273312690550735,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/cyberdyne.json
+++ b/data/by-name/cyberdyne.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cyberdyne.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#151144",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.148126605437431,
+    "minAnsi": 3.565804895020556,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/cyberpunk-scarlet-protocol.json
+++ b/data/by-name/cyberpunk-scarlet-protocol.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa-large",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cyberpunk Scarlet Protocol.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#101116",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.091109353200948,
+    "minAnsi": 3.62733294554639,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/cyberpunk.json
+++ b/data/by-name/cyberpunk.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cyberpunk.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#332a57",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.357265239330985,
+    "minAnsi": 4.9607825757273964,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/dalton-dark.json
+++ b/data/by-name/dalton-dark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dalton Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1b1b1b",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.882 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.40226118924566,
+    "minAnsi": 3.333491278285508,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/dark-modern.json
+++ b/data/by-name/dark-modern.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dark Modern.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1f1f1f",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.263829808673044,
+    "minAnsi": 3.1522225087832743,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/dark-pastel.json
+++ b/data/by-name/dark-pastel.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dark Pastel.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 4.1296587927193125,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/dark-plus.json
+++ b/data/by-name/dark-plus.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dark+.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1e1e1e",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.38100762286638,
+    "minAnsi": 3.2385726181133854,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/darkermatrix.json
+++ b/data/by-name/darkermatrix.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-fail"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Darkermatrix.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#070c0e",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.3 0.072 156.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 1.8891474483742787,
+    "minAnsi": 1.4835861328218996,
+    "minAnsiSlot": "brightWhite"
   }
 }

--- a/data/by-name/darkmatrix.json
+++ b/data/by-name/darkmatrix.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-fail"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Darkmatrix.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#070c0e",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.445 0.112 154.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 2.4148124528679924,
+    "minAnsi": 1.9971603474964532,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/darkside.json
+++ b/data/by-name/darkside.json
@@ -3,12 +3,15 @@
   "slug": "darkside",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Darkside.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222324",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.789 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.11184133931825,
+    "minAnsi": 3.702759687367773,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/dawnfox.json
+++ b/data/by-name/dawnfox.json
@@ -4,12 +4,13 @@
   "isDark": false,
   "tags": [
     "light",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dawnfox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#faf4ed",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.939 0.012 259.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.657280748896968,
+    "minAnsi": 1.8622861946636253,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/dayfox.json
+++ b/data/by-name/dayfox.json
@@ -4,12 +4,15 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dayfox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f6f2ee",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.948 0.012 59.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.145625973707121,
+    "minAnsi": 3.423765237278193,
+    "minAnsiSlot": "brightCyan"
   }
 }

--- a/data/by-name/deep.json
+++ b/data/by-name/deep.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Deep.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#090909",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.525578239702938,
+    "minAnsi": 3.6900032458893013,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/desert.json
+++ b/data/by-name/desert.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Desert.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#333333",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.63465434445799,
+    "minAnsi": 3.3887553194646247,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/detuned.json
+++ b/data/by-name/detuned.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Detuned.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.422496589297461,
+    "minAnsi": 4.384187804236253,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/dimidium.json
+++ b/data/by-name/dimidium.json
@@ -3,12 +3,15 @@
   "slug": "dimidium",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dimidium.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#141414",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.912 0.006 211)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.243459202609898,
+    "minAnsi": 3.9850072682445767,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/dimmed-monokai.json
+++ b/data/by-name/dimmed-monokai.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dimmed Monokai.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1f1f1f",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.982 0.089 109.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.60660988107443,
+    "minAnsi": 2.7222691485480346,
+    "minAnsiSlot": "brightGreen"
   }
 }

--- a/data/by-name/django-reborn-again.json
+++ b/data/by-name/django-reborn-again.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Django Reborn Again.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#051f14",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.75252191789214,
+    "minAnsi": 1.8708818052136582,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/django-smooth.json
+++ b/data/by-name/django-smooth.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Django Smooth.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#245032",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.716509923733199,
+    "minAnsi": 3.039571335883196,
+    "minAnsiSlot": "green"
   }
 }

--- a/data/by-name/django.json
+++ b/data/by-name/django.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Django.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0b2f20",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.715626088537237,
+    "minAnsi": 1.9200420702527614,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/dogxi-misty.json
+++ b/data/by-name/dogxi-misty.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dogxi Misty.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282a36",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.958 0.001 106.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.432422229651946,
+    "minAnsi": 4.69287905910325,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/doom-one.json
+++ b/data/by-name/doom-one.json
@@ -3,12 +3,15 @@
   "slug": "doom-one",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Doom One.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282c34",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.805 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.82001691967415,
+    "minAnsi": 4.754293214763805,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/doom-peacock.json
+++ b/data/by-name/doom-peacock.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Doom Peacock.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2b2a27",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.904 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.040463008158579,
+    "minAnsi": 2.7739983953430367,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/dot-gov.json
+++ b/data/by-name/dot-gov.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dot Gov.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#262c35",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.790012195641419,
+    "minAnsi": 1.9063800181761583,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/dracula-plus.json
+++ b/data/by-name/dracula-plus.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dracula+.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#212121",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.978 0.008 106.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.105706312919677,
+    "minAnsi": 5.1240051447700266,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/dracula.json
+++ b/data/by-name/dracula.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dracula.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282a36",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.359134716531573,
+    "minAnsi": 4.531550766258277,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/duckbones.json
+++ b/data/by-name/duckbones.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Duckbones.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0e101a",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.764 0.05 111.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.924986427886736,
+    "minAnsi": 3.8058637916577545,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/duotone-dark.json
+++ b/data/by-name/duotone-dark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Duotone Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1f1d27",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.934 0.035 294.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.5638203903938415,
+    "minAnsi": 3.645325501787195,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/duskfox.json
+++ b/data/by-name/duskfox.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Duskfox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#232136",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.915 0.031 289.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.86365608062847,
+    "minAnsi": 5.262685221829585,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/earthsong.json
+++ b/data/by-name/earthsong.json
@@ -3,12 +3,15 @@
   "slug": "earthsong",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Earthsong.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#292520",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.972 0.015 110.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.475427990413575,
+    "minAnsi": 3.125435442939281,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/electron-highlighter.json
+++ b/data/by-name/electron-highlighter.json
@@ -3,12 +3,15 @@
   "slug": "electron-highlighter",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Electron Highlighter.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#23283d",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.849 0.03 262.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.100651776346242,
+    "minAnsi": 4.3902870108206224,
+    "minAnsiSlot": "white"
   }
 }

--- a/data/by-name/elegant.json
+++ b/data/by-name/elegant.json
@@ -3,12 +3,15 @@
   "slug": "elegant",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Elegant.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#292b31",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.307474260490578,
+    "minAnsi": 3.6313709940352723,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/elemental.json
+++ b/data/by-name/elemental.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa-large"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Elemental.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#22211d",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.967 0.019 52)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 3.80099836701166,
+    "minAnsi": 2.040322350568522,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/elementary.json
+++ b/data/by-name/elementary.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Elementary.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#181818",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.526 0.279 301.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.442153532069472,
+    "minAnsi": 2.041646504087658,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/embark.json
+++ b/data/by-name/embark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Embark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1e1c31",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.765 0.039 263.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.10503538749257,
+    "minAnsi": 3.642765360796553,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/embers-dark.json
+++ b/data/by-name/embers-dark.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Embers Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#16130f",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.879 0.009 67.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.685352943486375,
+    "minAnsi": 1.8100227598035976,
+    "minAnsiSlot": "brightGreen"
   }
 }

--- a/data/by-name/encom.json
+++ b/data/by-name/encom.json
@@ -3,12 +3,13 @@
   "slug": "encom",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/ENCOM.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.816038646398305,
+    "minAnsi": 2.444,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/espresso-libre.json
+++ b/data/by-name/espresso-libre.json
@@ -3,12 +3,13 @@
   "slug": "espresso-libre",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Espresso Libre.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2a211c",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(0.949 0.003 106.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.822331199348381,
+    "minAnsi": 2.6767588284314123,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/espresso.json
+++ b/data/by-name/espresso.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Espresso.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#323232",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.82113382786086,
+    "minAnsi": 2.907925115204386,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/everblush.json
+++ b/data/by-name/everblush.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Everblush.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#141b1e",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.812 0.007 185.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.463678735509065,
+    "minAnsi": 5.87584391665661,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/everforest-dark-hard.json
+++ b/data/by-name/everforest-dark-hard.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Everforest Dark Hard.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1e2326",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.988 0.016 91.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.389409238303774,
+    "minAnsi": 4.700885040833118,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/everforest-light-med.json
+++ b/data/by-name/everforest-light-med.json
@@ -5,12 +5,13 @@
   "tags": [
     "light",
     "low-contrast",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Everforest Light Med.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#efebd4",
@@ -192,5 +193,10 @@
       },
       "oklchCss": "oklch(0.988 0.016 91.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.655789215480987,
+    "minAnsi": 1.7645371424739247,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/fahrenheit.json
+++ b/data/by-name/fahrenheit.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fahrenheit.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 20.447246276133974,
+    "minAnsi": 1.9721182882538013,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/fairyfloss.json
+++ b/data/by-name/fairyfloss.json
@@ -3,12 +3,13 @@
   "slug": "fairyfloss",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fairyfloss.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#5a5475",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(0.977 0.011 106.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.656147192335941,
+    "minAnsi": 1.8745525850950375,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/farmhouse-dark.json
+++ b/data/by-name/farmhouse-dark.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Farmhouse Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d2027",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.954 0.007 354.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.89900514830556,
+    "minAnsi": 2.176443979144189,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/farmhouse-light.json
+++ b/data/by-name/farmhouse-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Farmhouse Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#e8e4e1",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.954 0.007 354.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.89900514830556,
+    "minAnsi": 1.757259726600676,
+    "minAnsiSlot": "brightGreen"
   }
 }

--- a/data/by-name/fideloper.json
+++ b/data/by-name/fideloper.json
@@ -3,12 +3,14 @@
   "slug": "fideloper",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fideloper.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#292f33",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.968 0.029 89.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.761096476981518,
+    "minAnsi": 2.3656552689423345,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/firefly-traditional.json
+++ b/data/by-name/firefly-traditional.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Firefly Traditional.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.94 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 19.261973035868383,
+    "minAnsi": 3.8611990287320728,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/firefox-dev.json
+++ b/data/by-name/firefox-dev.json
@@ -3,12 +3,13 @@
   "slug": "firefox-dev",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Firefox Dev.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0e1011",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(0.913 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.7427252530694535,
+    "minAnsi": 2.5351482722551846,
+    "minAnsiSlot": "brightCyan"
   }
 }

--- a/data/by-name/firewatch.json
+++ b/data/by-name/firewatch.json
@@ -3,12 +3,14 @@
   "slug": "firewatch",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Firewatch.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1e2027",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.931 0.035 287.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.354799503682964,
+    "minAnsi": 3.8883243379757633,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/fish-tank.json
+++ b/data/by-name/fish-tank.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fish Tank.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#232537",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.988 0.027 127.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.269820457575744,
+    "minAnsi": 2.515732324823122,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/flat.json
+++ b/data/by-name/flat.json
@@ -3,12 +3,14 @@
   "slug": "flat",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flat.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#002240",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.94 0.006 211)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.101124628561992,
+    "minAnsi": 1.8835598420354975,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/flatland.json
+++ b/data/by-name/flatland.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flatland.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d1f21",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.350259892661535,
+    "minAnsi": 2.983224496524538,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/flexoki-dark.json
+++ b/data/by-name/flexoki-dark.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flexoki Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#100f0f",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.846 0.014 102.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.979773058854278,
+    "minAnsi": 2.8533476149486487,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/flexoki-light.json
+++ b/data/by-name/flexoki-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flexoki Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fffcf0",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.846 0.014 102.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 18.623142284944873,
+    "minAnsi": 1.9997046436301846,
+    "minAnsiSlot": "brightBlack"
   }
 }

--- a/data/by-name/floraverse.json
+++ b/data/by-name/floraverse.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Floraverse.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0e0d15",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.971 0.036 89.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.72480043817595,
+    "minAnsi": 1.9532504412357568,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/forest-blue.json
+++ b/data/by-name/forest-blue.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Forest Blue.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#051519",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.887 0.019 70.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.245458131110349,
+    "minAnsi": 2.421347169146018,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/framer.json
+++ b/data/by-name/framer.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa-large",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Framer.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#111111",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.216767253166575,
+    "minAnsi": 6.0089274371800805,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/front-end-delight.json
+++ b/data/by-name/front-end-delight.json
@@ -3,12 +3,14 @@
   "slug": "front-end-delight",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Front End Delight.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1b1c1d",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.573 0.047 65.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.605132393579298,
+    "minAnsi": 2.3161944434553474,
+    "minAnsiSlot": "green"
   }
 }

--- a/data/by-name/fun-forrest.json
+++ b/data/by-name/fun-forrest.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fun Forrest.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#251200",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.938 0.092 93.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.231694781477739,
+    "minAnsi": 2.557323542402356,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/galaxy.json
+++ b/data/by-name/galaxy.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Galaxy.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d2837",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.883842395618611,
+    "minAnsi": 2.661171519469546,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/galizur.json
+++ b/data/by-name/galizur.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Galizur.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#071317",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.838 0.03 248.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.92405646818393,
+    "minAnsi": 2.52341646176751,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/ghostty-default-style-dark.json
+++ b/data/by-name/ghostty-default-style-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ghostty Default Style Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282c34",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.937 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.999227678845402,
+    "minAnsi": 3.362407270681048,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/github-dark-colorblind.json
+++ b/data/by-name/github-dark-colorblind.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark Colorblind.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0d1117",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.261031969575138,
+    "minAnsi": 7.491836480293032,
+    "minAnsiSlot": "green"
   }
 }

--- a/data/by-name/github-dark-default.json
+++ b/data/by-name/github-dark-default.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark Default.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0d1117",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.016082890827004,
+    "minAnsi": 7.4497929930639835,
+    "minAnsiSlot": "green"
   }
 }

--- a/data/by-name/github-dark-dimmed.json
+++ b/data/by-name/github-dark-dimmed.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark Dimmed.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#22272e",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.88 0.021 248.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.601990586445604,
+    "minAnsi": 5.2593014228844295,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/github-dark-high-contrast.json
+++ b/data/by-name/github-dark-high-contrast.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark High Contrast.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0a0c10",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.57358905641591,
+    "minAnsi": 9.20247817686318,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/github-dark.json
+++ b/data/by-name/github-dark.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#101216",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.095203207234266,
+    "minAnsi": 3.5371506775963657,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/github-light-colorblind.json
+++ b/data/by-name/github-light-colorblind.json
@@ -5,12 +5,15 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Light Colorblind.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.666 0.018 250.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.652157369459891,
+    "minAnsi": 3.235284115220877,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/github-light-default.json
+++ b/data/by-name/github-light-default.json
@@ -5,12 +5,15 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Light Default.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.666 0.018 250.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.797619425332647,
+    "minAnsi": 3.235284115220877,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/github-light-high-contrast.json
+++ b/data/by-name/github-light-high-contrast.json
@@ -5,12 +5,15 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Light High Contrast.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.655 0.02 250.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 18.911466369919406,
+    "minAnsi": 3.6066342162960927,
+    "minAnsiSlot": "brightCyan"
   }
 }

--- a/data/by-name/github.json
+++ b/data/by-name/github.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f4f4f4",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.724390698748637,
+    "minAnsi": 1.7500957400041959,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/gitlab-dark-grey.json
+++ b/data/by-name/gitlab-dark-grey.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitLab Dark Grey.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222222",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.909984431773273,
+    "minAnsi": 4.556266451930614,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/gitlab-dark.json
+++ b/data/by-name/gitlab-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitLab Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#28262b",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.974840721943796,
+    "minAnsi": 4.288462047023658,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/gitlab-light.json
+++ b/data/by-name/gitlab-light.json
@@ -4,12 +4,15 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitLab Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fafaff",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.309 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.684668567771666,
+    "minAnsi": 4.875209096305248,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/glacier.json
+++ b/data/by-name/glacier.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Glacier.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0c1115",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 18.976350018147606,
+    "minAnsi": 2.4372245185839745,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/grape.json
+++ b/data/by-name/grape.json
@@ -3,12 +3,14 @@
   "slug": "grape",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Grape.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#171423",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.698 0.16 292.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.847286081822569,
+    "minAnsi": 3.0025008281247483,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/grass.json
+++ b/data/by-name/grass.json
@@ -4,12 +4,13 @@
   "isDark": false,
   "tags": [
     "light",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Grass.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#13773d",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.890282728037497,
+    "minAnsi": 1.8163650295143616,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/grey-green.json
+++ b/data/by-name/grey-green.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "vibrant",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Grey Green.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#002a1a",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.95 0.01 17.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.600600680657527,
+    "minAnsi": 3.9553687462970113,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/gruber-darker.json
+++ b/data/by-name/gruber-darker.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruber Darker.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#181818",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.97 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.965255158215777,
+    "minAnsi": 4.522507826699491,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/gruvbox-dark-hard.json
+++ b/data/by-name/gruvbox-dark-hard.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Dark Hard.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d2021",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.894 0.057 89.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.95176123994368,
+    "minAnsi": 2.996207163429576,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/gruvbox-dark.json
+++ b/data/by-name/gruvbox-dark.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282828",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.894 0.057 89.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.74706817440964,
+    "minAnsi": 2.6942006289764127,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/gruvbox-light-hard.json
+++ b/data/by-name/gruvbox-light-hard.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Light Hard.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f9f5d7",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.344 0.007 48.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.529783804658695,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/gruvbox-light.json
+++ b/data/by-name/gruvbox-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fbf1c7",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.344 0.007 48.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.21974550734294,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/gruvbox-material-dark.json
+++ b/data/by-name/gruvbox-material-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Material Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282828",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.839 0.056 81.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.156664666774935,
+    "minAnsi": 4.700629435816308,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/gruvbox-material-light.json
+++ b/data/by-name/gruvbox-material-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "muted",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Material Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fbf1c7",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.363 0.041 54.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.385612446038595,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/gruvbox-material.json
+++ b/data/by-name/gruvbox-material.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Material.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d2021",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.070986340601117,
+    "minAnsi": 4.05697671141115,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/guezwhoz.json
+++ b/data/by-name/guezwhoz.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Guezwhoz.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d1d1d",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.946 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.942746828644987,
+    "minAnsi": 4.756351522702039,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/hacktober.json
+++ b/data/by-name/hacktober.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hacktober.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#141414",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.125078595062687,
+    "minAnsi": 2.6392882012686116,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/hardcore.json
+++ b/data/by-name/hardcore.json
@@ -3,12 +3,15 @@
   "slug": "hardcore",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hardcore.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#121212",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.978 0.008 106.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.163977871523068,
+    "minAnsi": 3.65293820151869,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/harper.json
+++ b/data/by-name/harper.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Harper.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#010101",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.986 0.023 98.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.410955179933248,
+    "minAnsi": 6.222091885349799,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/havn-daggry.json
+++ b/data/by-name/havn-daggry.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Havn Daggry.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f8f9fb",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.892 0.023 272)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.148195918236711,
+    "minAnsi": 1.9637061003022214,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/havn-skumring.json
+++ b/data/by-name/havn-skumring.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Havn Skumring.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#111522",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.975 0.029 87.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.161914123850126,
+    "minAnsi": 4.083171817254882,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/hax0r-blue.json
+++ b/data/by-name/hax0r-blue.json
@@ -3,12 +3,15 @@
   "slug": "hax0r-blue",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/HaX0R Blue.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#010515",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.997 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.938850149710262,
+    "minAnsi": 8.50346924609034,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/hax0r-gr33n.json
+++ b/data/by-name/hax0r-gr33n.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "vibrant"
+    "vibrant",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/HaX0R Gr33N.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#020f01",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.997 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.841199156356613,
+    "minAnsi": 9.390074925552794,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/hax0r-r3d.json
+++ b/data/by-name/hax0r-r3d.json
@@ -5,12 +5,13 @@
   "tags": [
     "dark",
     "vibrant",
-    "low-contrast"
+    "low-contrast",
+    "wcag-fail"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/HaX0R R3D.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#200101",
@@ -192,5 +193,10 @@
       },
       "oklchCss": "oklch(0.997 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 2.756135861744877,
+    "minAnsi": 2.7287710521046282,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/heeler.json
+++ b/data/by-name/heeler.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Heeler.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#211f46",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.302796925075487,
+    "minAnsi": 3.9819301718588416,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/highway.json
+++ b/data/by-name/highway.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Highway.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222225",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.552626888705587,
+    "minAnsi": 1.9736076403036666,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/hipster-green.json
+++ b/data/by-name/hipster-green.json
@@ -3,12 +3,14 @@
   "slug": "hipster-green",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hipster Green.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#100b05",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.016200138054561,
+    "minAnsi": 2.2796548460723143,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/hivacruz.json
+++ b/data/by-name/hivacruz.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hivacruz.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#132638",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.977 0.011 274.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.348066049215886,
+    "minAnsi": 2.7358525149149737,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/homebrew.json
+++ b/data/by-name/homebrew.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "vibrant",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Homebrew.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.303999999999998,
+    "minAnsi": 1.8270002567023051,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/hopscotch-256.json
+++ b/data/by-name/hopscotch-256.json
@@ -3,12 +3,14 @@
   "slug": "hopscotch-256",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hopscotch.256.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#322931",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.922862329946787,
+    "minAnsi": 3.3763238959414608,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/hopscotch.json
+++ b/data/by-name/hopscotch.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hopscotch.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#322931",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.922862329946787,
+    "minAnsi": 1.9198229617709017,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/horizon-bright.json
+++ b/data/by-name/horizon-bright.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Horizon Bright.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fdf0ed",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.971 0.015 33.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.169317016587108,
+    "minAnsi": 1.7804293458175173,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/horizon.json
+++ b/data/by-name/horizon.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Horizon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1c1e26",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.609755119696096,
+    "minAnsi": 4.803410184690108,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/hot-dog-stand-mustard.json
+++ b/data/by-name/hot-dog-stand-mustard.json
@@ -4,12 +4,15 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hot Dog Stand (Mustard).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffff54",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.827 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 19.684018666596657,
+    "minAnsi": 3.9397305912370046,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/hot-dog-stand.json
+++ b/data/by-name/hot-dog-stand.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa-large",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hot Dog Stand.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ea3323",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.827 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.203122533935382,
+    "minAnsi": 3.9397305912370046,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/hurtado.json
+++ b/data/by-name/hurtado.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hurtado.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.891 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.167515597833736,
+    "minAnsi": 3.456016012905084,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/hybrid.json
+++ b/data/by-name/hybrid.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hybrid.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#161719",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.492 0.016 248.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.324062360375843,
+    "minAnsi": 2.1947354930287886,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/ibm-5153-cga-black.json
+++ b/data/by-name/ibm-5153-cga-black.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IBM 5153 CGA (Black).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.040228030240003,
+    "minAnsi": 1.7971044637833282,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/ibm-5153-cga.json
+++ b/data/by-name/ibm-5153-cga.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IBM 5153 CGA.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#141414",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.70632091649946,
+    "minAnsi": 1.8547009332170838,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/ic-green-ppl.json
+++ b/data/by-name/ic-green-ppl.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IC Green PPL.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2c2c2c",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.94 0.033 139.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.827225506508844,
+    "minAnsi": 3.7210464701369617,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/ic-orange-ppl.json
+++ b/data/by-name/ic-orange-ppl.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IC Orange PPL.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#262626",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.987 0.007 286.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.177019711731324,
+    "minAnsi": 2.776456575756782,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/iceberg-dark.json
+++ b/data/by-name/iceberg-dark.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Iceberg Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#161821",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(0.871 0.014 277)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.603558844665839,
+    "minAnsi": 6.059976604928213,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/iceberg-light.json
+++ b/data/by-name/iceberg-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Iceberg Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#e8e9ec",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.291 0.039 275.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.655044494507733,
+    "minAnsi": 1.0981360061729746,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/idea.json
+++ b/data/by-name/idea.json
@@ -3,12 +3,14 @@
   "slug": "idea",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Idea.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#202020",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.209 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.260353274094703,
+    "minAnsi": 1.089792329672652,
+    "minAnsiSlot": "brightWhite"
   }
 }

--- a/data/by-name/idle-toes.json
+++ b/data/by-name/idle-toes.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Idle Toes.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#323232",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.82113382786086,
+    "minAnsi": 3.0948288927602916,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/ir-black.json
+++ b/data/by-name/ir-black.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IR Black.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 18.592447937756635,
+    "minAnsi": 7.378729175710199,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/irix-console.json
+++ b/data/by-name/irix-console.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IRIX Console.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0c0c0c",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.961 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.47362420993011,
+    "minAnsi": 2.508064209720709,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/irix-terminal.json
+++ b/data/by-name/irix-terminal.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "vibrant",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IRIX Terminal.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000043",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.97 0.193 109.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.352083942454144,
+    "minAnsi": 2.276830533343979,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/iterm2-dark-background.json
+++ b/data/by-name/iterm2-dark-background.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Dark Background.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.422496589297461,
+    "minAnsi": 2.091912595931719,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/iterm2-default.json
+++ b/data/by-name/iterm2-default.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Default.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 2.1297478518898183,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/iterm2-light-background.json
+++ b/data/by-name/iterm2-light-background.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Light Background.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 1.7541341704031068,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/iterm2-pastel-dark-background.json
+++ b/data/by-name/iterm2-pastel-dark-background.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Pastel Dark Background.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.422496589297461,
+    "minAnsi": 8.746080804146642,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/iterm2-smoooooth.json
+++ b/data/by-name/iterm2-smoooooth.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Smoooooth.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#15191f",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.860973833303843,
+    "minAnsi": 2.2992902909975608,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/iterm2-solarized-dark.json
+++ b/data/by-name/iterm2-solarized-dark.json
@@ -5,12 +5,13 @@
   "tags": [
     "dark",
     "low-contrast",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Solarized Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#002b36",
@@ -192,5 +193,10 @@
       },
       "oklchCss": "oklch(0.974 0.026 90.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.747877839876171,
+    "minAnsi": 2.789627547583178,
+    "minAnsiSlot": "brightGreen"
   }
 }

--- a/data/by-name/iterm2-solarized-light.json
+++ b/data/by-name/iterm2-solarized-light.json
@@ -6,12 +6,13 @@
     "light",
     "muted",
     "low-contrast",
+    "wcag-aa-large",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Solarized Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fdf6e3",
@@ -193,5 +194,10 @@
       },
       "oklchCss": "oklch(0.974 0.026 90.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.129605890896795,
+    "minAnsi": 2.4789959188576267,
+    "minAnsiSlot": "brightCyan"
   }
 }

--- a/data/by-name/iterm2-tango-dark.json
+++ b/data/by-name/iterm2-tango-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Tango Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.958 0.001 106.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 4.105495243097395,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/iterm2-tango-light.json
+++ b/data/by-name/iterm2-tango-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Tango Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.958 0.001 106.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 1.7589311345907752,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/jackie-brown.json
+++ b/data/by-name/jackie-brown.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Jackie Brown.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2c1d16",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.761676622349576,
+    "minAnsi": 1.8880956497869026,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/japanesque.json
+++ b/data/by-name/japanesque.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Japanesque.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1e1e1e",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.769 0.01 125.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.359981327860599,
+    "minAnsi": 2.1319328673578264,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/jellybeans.json
+++ b/data/by-name/jellybeans.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Jellybeans.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#121212",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.924656375487373,
+    "minAnsi": 5.247114925613579,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/jetbrains-darcula.json
+++ b/data/by-name/jetbrains-darcula.json
@@ -3,12 +3,14 @@
   "slug": "jetbrains-darcula",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/JetBrains Darcula.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#202020",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.949 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.260353274094703,
+    "minAnsi": 2.5263016552037088,
+    "minAnsiSlot": "green"
   }
 }

--- a/data/by-name/jubi.json
+++ b/data/by-name/jubi.json
@@ -3,12 +3,14 @@
   "slug": "jubi",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Jubi.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#262b33",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.914 0.024 240.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.278499933441514,
+    "minAnsi": 2.836661760683309,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/kanagawa-dragon.json
+++ b/data/by-name/kanagawa-dragon.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawa Dragon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#181616",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(0.832 0.007 145.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.757897010440683,
+    "minAnsi": 5.20986364962469,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/kanagawa-lotus.json
+++ b/data/by-name/kanagawa-lotus.json
@@ -5,12 +5,13 @@
   "tags": [
     "light",
     "muted",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawa Lotus.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f2ecbc",
@@ -192,5 +193,10 @@
       },
       "oklchCss": "oklch(0.402 0.068 282.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.18561286722523,
+    "minAnsi": 2.6961088191135745,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/kanagawa-wave.json
+++ b/data/by-name/kanagawa-wave.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawa Wave.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1f1f28",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(0.876 0.039 99.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.26343080332848,
+    "minAnsi": 3.218025386691309,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/kanagawabones.json
+++ b/data/by-name/kanagawabones.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawabones.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1f1f28",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(0.716 0.033 99)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.373953362086501,
+    "minAnsi": 4.674151702669178,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/kanso-ink.json
+++ b/data/by-name/kanso-ink.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Ink.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#14171d",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.832 0.005 165)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.729013943415868,
+    "minAnsi": 5.1882351630502175,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/kanso-mist.json
+++ b/data/by-name/kanso-mist.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Mist.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#22262d",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.832 0.005 165)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.075942806509774,
+    "minAnsi": 4.3888586458090595,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/kanso-pearl.json
+++ b/data/by-name/kanso-pearl.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Pearl.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f2f1ef",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.402 0.068 282.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.450395855946788,
+    "minAnsi": 2.86622271752278,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/kanso-zen.json
+++ b/data/by-name/kanso-zen.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Zen.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#090e13",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.832 0.005 165)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.582424142032995,
+    "minAnsi": 5.600919201333923,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/kibble.json
+++ b/data/by-name/kibble.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kibble.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0e100a",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.866133591756054,
+    "minAnsi": 2.7522766186617584,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/kitty-default.json
+++ b/data/by-name/kitty-default.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kitty Default.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.461102578439387,
+    "minAnsi": 3.5861553235963606,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/kitty-low-contrast.json
+++ b/data/by-name/kitty-low-contrast.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kitty Low Contrast.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#333333",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.63465434445799,
+    "minAnsi": 2.157611092341805,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/kolorit.json
+++ b/data/by-name/kolorit.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kolorit.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d1a1e",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.946 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.670431939489694,
+    "minAnsi": 5.8016740392948085,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/konsolas.json
+++ b/data/by-name/konsolas.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Konsolas.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#060606",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.437324452164141,
+    "minAnsi": 1.790002483544427,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/kurokula.json
+++ b/data/by-name/kurokula.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kurokula.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#141515",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.086706945791647,
+    "minAnsi": 4.025378356397241,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/lab-fox.json
+++ b/data/by-name/lab-fox.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Lab Fox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2e2e2e",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.579770974464187,
+    "minAnsi": 1.8209701792863637,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/laser.json
+++ b/data/by-name/laser.json
@@ -3,12 +3,14 @@
   "slug": "laser",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Laser.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#030d18",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.467379042591636,
+    "minAnsi": 5.266182758914931,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/later-this-evening.json
+++ b/data/by-name/later-this-evening.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Later This Evening.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222222",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.813 0.001 197.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.311567916009271,
+    "minAnsi": 1.7892578426663424,
+    "minAnsiSlot": "white"
   }
 }

--- a/data/by-name/lavandula.json
+++ b/data/by-name/lavandula.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa-large"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Lavandula.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#050014",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.699 0.152 279.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.186173978306482,
+    "minAnsi": 1.9806839109135272,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/light-owl.json
+++ b/data/by-name/light-owl.json
@@ -3,12 +3,14 @@
   "slug": "light-owl",
   "isDark": false,
   "tags": [
-    "light"
+    "light",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Light Owl.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fbfbfb",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.955 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.880546554670078,
+    "minAnsi": 1.9698200780183888,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/liquid-carbon-transparent.json
+++ b/data/by-name/liquid-carbon-transparent.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Liquid Carbon Transparent.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.833 0.017 196.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.318514984564993,
+    "minAnsi": 5.717461028726613,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/liquid-carbon.json
+++ b/data/by-name/liquid-carbon.json
@@ -3,12 +3,15 @@
   "slug": "liquid-carbon",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Liquid Carbon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#303030",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.833 0.017 196.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.113477468370681,
+    "minAnsi": 3.5933185810680217,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/lovelace.json
+++ b/data/by-name/lovelace.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Lovelace.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d1f28",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.802 0.004 286.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.143077935691124,
+    "minAnsi": 3.5731138219092697,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/man-page.json
+++ b/data/by-name/man-page.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Man Page.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fef49c",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 18.63449957390289,
+    "minAnsi": 1.746832493323516,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/mariana.json
+++ b/data/by-name/mariana.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mariana.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#343d46",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.17315831400962,
+    "minAnsi": 3.362507076953814,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/material-dark.json
+++ b/data/by-name/material-dark.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#232322",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.885 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.487679129242336,
+    "minAnsi": 1.7666483386118776,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/material-darker.json
+++ b/data/by-name/material-darker.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Darker.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#212121",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.629422591616345,
+    "minAnsi": 5.155211008020823,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/material-design-colors.json
+++ b/data/by-name/material-design-colors.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Design Colors.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d262a",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.843006590335344,
+    "minAnsi": 4.103729106434181,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/material-ocean.json
+++ b/data/by-name/material-ocean.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Ocean.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0f111a",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.153036408356529,
+    "minAnsi": 6.027638935261423,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/material.json
+++ b/data/by-name/material.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#eaeaea",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.885 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.07567402495151,
+    "minAnsi": 1.8513565192760821,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/mathias.json
+++ b/data/by-name/mathias.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mathias.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.938659901217408,
+    "minAnsi": 4.1296587927193125,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/matrix.json
+++ b/data/by-name/matrix.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-fail"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Matrix.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0f191c",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.601 0.076 141.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 2.7341061213046127,
+    "minAnsi": 2.1230093292775423,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/matte-black.json
+++ b/data/by-name/matte-black.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Matte Black.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#121212",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.079026358071443,
+    "minAnsi": 2.0040940574500588,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/medallion.json
+++ b/data/by-name/medallion.json
@@ -3,12 +3,15 @@
   "slug": "medallion",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Medallion.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d1908",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.896 0.091 78.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.76600262805789,
+    "minAnsi": 3.3313326482129932,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/melange-dark.json
+++ b/data/by-name/melange-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Melange Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#292522",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.916 0.018 64.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.807387917777396,
+    "minAnsi": 4.772352822083565,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/melange-light.json
+++ b/data/by-name/melange-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Melange Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f1f1f1",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.398 0.028 49.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.296780692978805,
+    "minAnsi": 1.143608204672927,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/mellifluous.json
+++ b/data/by-name/mellifluous.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mellifluous.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1a1a1a",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.449926988251232,
+    "minAnsi": 3.113042083214476,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/mellow.json
+++ b/data/by-name/mellow.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mellow.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#161617",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.843 0.028 288.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.793901902326235,
+    "minAnsi": 7.137414070144248,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/miasma.json
+++ b/data/by-name/miasma.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Miasma.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222222",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.821 0.087 93.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.816782470109812,
+    "minAnsi": 2.296006786476582,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/midnight-in-mojave.json
+++ b/data/by-name/midnight-in-mojave.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Midnight In Mojave.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1e1e1e",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.67115667431794,
+    "minAnsi": 4.570605294259279,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/mirage.json
+++ b/data/by-name/mirage.json
@@ -3,12 +3,14 @@
   "slug": "mirage",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mirage.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1b2738",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.995198775446447,
+    "minAnsi": 7.030176879732231,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/misterioso.json
+++ b/data/by-name/misterioso.json
@@ -3,12 +3,14 @@
   "slug": "misterioso",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Misterioso.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2d3743",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.22772465949827,
+    "minAnsi": 2.0136112777163815,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/modus-operandi-tinted.json
+++ b/data/by-name/modus-operandi-tinted.json
@@ -4,12 +4,15 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Operandi Tinted.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fbf7f0",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.464 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 19.66440576437239,
+    "minAnsi": 6.555095879220985,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/modus-operandi.json
+++ b/data/by-name/modus-operandi.json
@@ -4,12 +4,15 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Operandi.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.464 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 7.000313923192387,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/modus-vivendi-tinted.json
+++ b/data/by-name/modus-vivendi-tinted.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Vivendi Tinted.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0d0e1c",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 19.14841760827243,
+    "minAnsi": 6.413021480459339,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/modus-vivendi.json
+++ b/data/by-name/modus-vivendi.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Vivendi.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 7.033137350809865,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/molokai.json
+++ b/data/by-name/molokai.json
@@ -3,12 +3,15 @@
   "slug": "molokai",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Molokai.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#121212",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.758151339882987,
+    "minAnsi": 3.0992432360783924,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/mona-lisa.json
+++ b/data/by-name/mona-lisa.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mona Lisa.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#120b0d",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.926 0.1 91.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.694253636827321,
+    "minAnsi": 2.4101140129278913,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/monokai-classic.json
+++ b/data/by-name/monokai-classic.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Classic.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#272822",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.995 0.018 113.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.686788462138944,
+    "minAnsi": 3.9268476458761508,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/monokai-pro-light-sun.json
+++ b/data/by-name/monokai-pro-light-sun.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Light Sun.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f8efe7",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.271 0.024 320.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.332623545205923,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/monokai-pro-light.json
+++ b/data/by-name/monokai-pro-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#faf4f2",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.268 0.013 320.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.975573957112271,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/monokai-pro-machine.json
+++ b/data/by-name/monokai-pro-machine.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Machine.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#273136",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.99 0.014 180.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.974613609909985,
+    "minAnsi": 4.902730566835759,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/monokai-pro-octagon.json
+++ b/data/by-name/monokai-pro-octagon.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Octagon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282a3a",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.955 0.009 188.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.458299554012848,
+    "minAnsi": 4.987836152714678,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/monokai-pro-ristretto.json
+++ b/data/by-name/monokai-pro-ristretto.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Ristretto.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2c2525",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.97 0.015 7.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.678374839673454,
+    "minAnsi": 5.35197457474938,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/monokai-pro-spectrum.json
+++ b/data/by-name/monokai-pro-spectrum.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Spectrum.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222222",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.967 0.02 305.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.380315292688463,
+    "minAnsi": 5.306193260414424,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/monokai-pro.json
+++ b/data/by-name/monokai-pro.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2d2a2e",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.991 0.003 106.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.792654363958263,
+    "minAnsi": 4.936796222167998,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/monokai-remastered.json
+++ b/data/by-name/monokai-remastered.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Remastered.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0c0c0c",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.971 0.009 106.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.858423328500182,
+    "minAnsi": 4.668582442464516,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/monokai-soda.json
+++ b/data/by-name/monokai-soda.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Soda.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1a1a1a",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.971 0.009 106.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.946069785556245,
+    "minAnsi": 4.153720118535801,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/monokai-vivid.json
+++ b/data/by-name/monokai-vivid.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Vivid.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#121212",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.793529016500525,
+    "minAnsi": 2.901063352451498,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/monospace-dark.json
+++ b/data/by-name/monospace-dark.json
@@ -3,12 +3,15 @@
   "slug": "monospace-dark",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monospace Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#10151d",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.988 0.004 271.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.234515770436655,
+    "minAnsi": 6.156660025847598,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/monospace-light.json
+++ b/data/by-name/monospace-light.json
@@ -3,12 +3,15 @@
   "slug": "monospace-light",
   "isDark": false,
   "tags": [
-    "light"
+    "light",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monospace Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f4f7fd",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.439 0.034 258.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.266353531891272,
+    "minAnsi": 4.505357332424551,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/moonfly.json
+++ b/data/by-name/moonfly.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Moonfly.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#080808",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.919 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.659933999239652,
+    "minAnsi": 6.340238803392663,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/n0tch2k.json
+++ b/data/by-name/n0tch2k.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/N0Tch2K.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222222",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.842 0.025 61.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.084168958953755,
+    "minAnsi": 2.7708877609388116,
+    "minAnsiSlot": "green"
   }
 }

--- a/data/by-name/neobones-dark.json
+++ b/data/by-name/neobones-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neobones Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0f191f",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.705 0.014 167)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.720184438248431,
+    "minAnsi": 5.2426063355364,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/neobones-light.json
+++ b/data/by-name/neobones-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neobones Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#e5ede6",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.434 0.065 135.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.00210015017332,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/neon.json
+++ b/data/by-name/neon.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#14161a",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.412025090407829,
+    "minAnsi": 1.8277614021550688,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/neopolitan.json
+++ b/data/by-name/neopolitan.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neopolitan.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#271f19",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.979 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.19996616356344,
+    "minAnsi": 1.8439469394618435,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/neutron.json
+++ b/data/by-name/neutron.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neutron.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1c1e22",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.946 0.007 268.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.633660688662903,
+    "minAnsi": 2.981583346060887,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/night-lion-v1.json
+++ b/data/by-name/night-lion-v1.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Lion V1.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.938659901217408,
+    "minAnsi": 3.112959094998821,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/night-lion-v2.json
+++ b/data/by-name/night-lion-v2.json
@@ -3,12 +3,14 @@
   "slug": "night-lion-v2",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Lion V2.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#171717",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.338407013867828,
+    "minAnsi": 2.657553969968964,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/night-owl.json
+++ b/data/by-name/night-owl.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Owl.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#011627",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.53940404990579,
+    "minAnsi": 5.258898207615183,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/night-owlish-light.json
+++ b/data/by-name/night-owlish-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Owlish Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.703 0.028 268.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.224415580610703,
+    "minAnsi": 1.763208306837443,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/nightfox.json
+++ b/data/by-name/nightfox.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nightfox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#192330",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.919 0.001 286.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.0612149558544,
+    "minAnsi": 3.641362087864303,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/niji.json
+++ b/data/by-name/niji.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Niji.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#141515",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 18.295244886897216,
+    "minAnsi": 3.8619377765509926,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/no-clown-fiesta-light.json
+++ b/data/by-name/no-clown-fiesta-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/No Clown Fiesta Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#e1e1e1",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.337 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.964447543611657,
+    "minAnsi": 1.1114261503387803,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/no-clown-fiesta.json
+++ b/data/by-name/no-clown-fiesta.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/No Clown Fiesta.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#101010",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.754 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.551821344102843,
+    "minAnsi": 4.623111343449321,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/nocturnal-winter.json
+++ b/data/by-name/nocturnal-winter.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nocturnal Winter.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0d0d17",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.366059343122442,
+    "minAnsi": 4.817923666381618,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/nord-light.json
+++ b/data/by-name/nord-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "muted",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nord Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#e5e9f0",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.951 0.007 260.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.522127784995569,
+    "minAnsi": 1.8996402873179057,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/nord-wave.json
+++ b/data/by-name/nord-wave.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nord Wave.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#212121",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(0.951 0.007 260.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.919405742162793,
+    "minAnsi": 3.9360445553453185,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/nord.json
+++ b/data/by-name/nord.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nord.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2e3440",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.951 0.007 260.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.245243340706116,
+    "minAnsi": 3.0529785210102194,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/nordfox.json
+++ b/data/by-name/nordfox.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nordfox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2e3440",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.942 0.012 259.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.925159685601855,
+    "minAnsi": 3.0529785210102194,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/novel.json
+++ b/data/by-name/novel.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Novel.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#dfdbc3",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.38876302397345,
+    "minAnsi": 2.602952294010411,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/novmbr.json
+++ b/data/by-name/novmbr.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/novmbr.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#241d1a",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.792 0.024 61.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.596459173796818,
+    "minAnsi": 3.4332338892382444,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/nvim-dark.json
+++ b/data/by-name/nvim-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nvim Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#14161b",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.958 0.01 267.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.992604952689101,
+    "minAnsi": 11.62803481704881,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/nvim-light.json
+++ b/data/by-name/nvim-light.json
@@ -5,12 +5,15 @@
   "tags": [
     "light",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nvim Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#e0e2ea",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.958 0.01 267.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.992604952689101,
+    "minAnsi": 4.38830879526678,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/obsidian.json
+++ b/data/by-name/obsidian.json
@@ -3,12 +3,14 @@
   "slug": "obsidian",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Obsidian.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#283033",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.463511117836331,
+    "minAnsi": 1.9096858460763608,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/ocean.json
+++ b/data/by-name/ocean.json
@@ -3,12 +3,14 @@
   "slug": "ocean",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ocean.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#224fbc",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.210109398318694,
+    "minAnsi": 1.7728586167803841,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/oceanic-material.json
+++ b/data/by-name/oceanic-material.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Oceanic Material.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1c262b",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.208078041725516,
+    "minAnsi": 1.8762051225776182,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/oceanic-next.json
+++ b/data/by-name/oceanic-next.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Oceanic Next.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#162c35",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.38226331693684,
+    "minAnsi": 4.426151819457613,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/ollie.json
+++ b/data/by-name/ollie.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ollie.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222125",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.548 0.092 269.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.954611624675583,
+    "minAnsi": 2.3398842060925027,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/one-dark-two.json
+++ b/data/by-name/one-dark-two.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Dark Two.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#21252b",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(0.925 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.334143005151907,
+    "minAnsi": 5.305273709224045,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/one-double-dark.json
+++ b/data/by-name/one-double-dark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Double Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282c34",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.981 0.005 258.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.465097902118544,
+    "minAnsi": 4.511665445871898,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/one-double-light.json
+++ b/data/by-name/one-double-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Double Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fafafa",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.849451259037943,
+    "minAnsi": 2.2053403905397357,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/one-half-dark.json
+++ b/data/by-name/one-half-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Half Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282c34",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.903 0.008 260.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.478412941103713,
+    "minAnsi": 4.380661260730335,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/one-half-light.json
+++ b/data/by-name/one-half-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Half Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fafafa",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.863393658010082,
+    "minAnsi": 1.8993201372831612,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/onenord-light.json
+++ b/data/by-name/onenord-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Onenord Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f7f8fa",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.951 0.007 260.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.753443309657749,
+    "minAnsi": 1.960773395813948,
+    "minAnsiSlot": "brightCyan"
   }
 }

--- a/data/by-name/onenord.json
+++ b/data/by-name/onenord.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Onenord.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2e3440",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(0.951 0.007 260.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.25659652805605,
+    "minAnsi": 3.908267949467851,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/operator-mono-dark.json
+++ b/data/by-name/operator-mono-dark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Operator Mono Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#191919",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.992 0.009 106.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.505178272829403,
+    "minAnsi": 3.4289982280025533,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/overnight-slumber.json
+++ b/data/by-name/overnight-slumber.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Overnight Slumber.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0e1729",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.77413845803145,
+    "minAnsi": 7.449058975558719,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/owl.json
+++ b/data/by-name/owl.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/owl.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2f2b2c",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.386836704362713,
+    "minAnsi": 2.0261237240353873,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/oxocarbon.json
+++ b/data/by-name/oxocarbon.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Oxocarbon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#161616",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.967 0.006 264.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.434104834959708,
+    "minAnsi": 5.582387546659929,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/pale-night-hc.json
+++ b/data/by-name/pale-night-hc.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pale Night Hc.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#3e4251",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.683 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.218254940110127,
+    "minAnsi": 3.4895700916505707,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/pandora.json
+++ b/data/by-name/pandora.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pandora.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#141e43",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.386273222738254,
+    "minAnsi": 2.70101622647231,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/paraiso-dark.json
+++ b/data/by-name/paraiso-dark.json
@@ -3,12 +3,13 @@
   "slug": "paraiso-dark",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Paraiso Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2f1e2e",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(0.929 0.019 113.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.884989370345183,
+    "minAnsi": 2.946392098596513,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/paul-millr.json
+++ b/data/by-name/paul-millr.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Paul Millr.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 18.758462357639324,
+    "minAnsi": 4.258308763379725,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/pencil-dark.json
+++ b/data/by-name/pencil-dark.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pencil Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#212121",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.958 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.256150521367877,
+    "minAnsi": 2.134569969193749,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/pencil-light.json
+++ b/data/by-name/pencil-light.json
@@ -3,12 +3,14 @@
   "slug": "pencil-light",
   "isDark": false,
   "tags": [
-    "light"
+    "light",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pencil Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f1f1f1",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.958 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.89758745422114,
+    "minAnsi": 1.8000751461131685,
+    "minAnsiSlot": "brightGreen"
   }
 }

--- a/data/by-name/peppermint.json
+++ b/data/by-name/peppermint.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Peppermint.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.904 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.551608808593013,
+    "minAnsi": 5.477832594172877,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/phala-green-dark.json
+++ b/data/by-name/phala-green-dark.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "vibrant",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Phala Green Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.937 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.192967582604293,
+    "minAnsi": 2.0041481377565944,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/piatto-light.json
+++ b/data/by-name/piatto-light.json
@@ -4,12 +4,15 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Piatto Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.961 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.207985564813495,
+    "minAnsi": 3.3777555423987504,
+    "minAnsiSlot": "brightGreen"
   }
 }

--- a/data/by-name/pierre-dark.json
+++ b/data/by-name/pierre-dark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pierre Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#070707",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.988 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 19.466519025872614,
+    "minAnsi": 4.8256228680752455,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/pierre-light.json
+++ b/data/by-name/pierre-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pierre Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.892 0.003 286.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 20.144005124323062,
+    "minAnsi": 2.143605535002515,
+    "minAnsiSlot": "brightCyan"
   }
 }

--- a/data/by-name/pnevma.json
+++ b/data/by-name/pnevma.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pnevma.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1c1c1c",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.952 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.04905582259089,
+    "minAnsi": 3.773370334704558,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/poimandres-darker.json
+++ b/data/by-name/poimandres-darker.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres Darker.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#16161e",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.05391830376466,
+    "minAnsi": 5.231935091581677,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/poimandres-storm.json
+++ b/data/by-name/poimandres-storm.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres Storm.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#252b37",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.356688691112879,
+    "minAnsi": 4.129391604797894,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/poimandres-white.json
+++ b/data/by-name/poimandres-white.json
@@ -4,12 +4,13 @@
   "isDark": false,
   "tags": [
     "light",
-    "low-contrast"
+    "low-contrast",
+    "wcag-fail"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres White.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fefeff",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 2.6755931412786236,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/poimandres.json
+++ b/data/by-name/poimandres.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1a1e28",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.461852439701996,
+    "minAnsi": 4.847321037417616,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/popping-and-locking.json
+++ b/data/by-name/popping-and-locking.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Popping And Locking.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#181921",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.894 0.057 89.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.758172497859183,
+    "minAnsi": 3.19836776044365,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/powershell.json
+++ b/data/by-name/powershell.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Powershell.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#052454",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.812 0.003 308.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.020509235779741,
+    "minAnsi": 1.8069630733148705,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/primary.json
+++ b/data/by-name/primary.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Primary.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 1.846133950253248,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/pro-light.json
+++ b/data/by-name/pro-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pro Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.961 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.581691183046004,
+    "minAnsi": 1.8107564747142557,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/pro.json
+++ b/data/by-name/pro.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pro.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 18.758462357639324,
+    "minAnsi": 2.1233846988883243,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/purple-rain.json
+++ b/data/by-name/purple-rain.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Purple Rain.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#21084a",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.009044216336548,
+    "minAnsi": 3.419143255584005,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/purplepeter.json
+++ b/data/by-name/purplepeter.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Purplepeter.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2a1a4a",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.772 0.053 298.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.919124689259478,
+    "minAnsi": 6.013488481454252,
+    "minAnsiSlot": "brightPurple"
   }
 }

--- a/data/by-name/rapture.json
+++ b/data/by-name/rapture.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rapture.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#111e2a",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.239434034482036,
+    "minAnsi": 5.539149438155462,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/raycast-dark.json
+++ b/data/by-name/raycast-dark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Raycast Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1a1a1a",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.40432753274219,
+    "minAnsi": 3.7403436061563577,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/raycast-light.json
+++ b/data/by-name/raycast-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Raycast Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 2.0527520433423008,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/rebecca.json
+++ b/data/by-name/rebecca.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rebecca.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#292a44",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.965 0.01 299.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.248141083660046,
+    "minAnsi": 4.535856617188583,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/red-alert.json
+++ b/data/by-name/red-alert.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Red Alert.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#762423",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.259262636372943,
+    "minAnsi": 2.13003691601782,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/red-planet.json
+++ b/data/by-name/red-planet.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Red Planet.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222222",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.822 0.028 37.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.9322520180450375,
+    "minAnsi": 2.009464569074746,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/red-sands.json
+++ b/data/by-name/red-sands.json
@@ -3,12 +3,13 @@
   "slug": "red-sands",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Red Sands.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#7a251e",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.064777615087849,
+    "minAnsi": 1.8146520910097659,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/relaxed.json
+++ b/data/by-name/relaxed.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Relaxed.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#353a44",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.976 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.085253934930217,
+    "minAnsi": 2.4968042890653295,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/retro-legends.json
+++ b/data/by-name/retro-legends.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "vibrant",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Retro Legends.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0d0d0d",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.987 0.022 145.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.237276805572264,
+    "minAnsi": 4.072864638260987,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/retro.json
+++ b/data/by-name/retro.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "vibrant"
+    "vibrant",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Retro.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.685 0.228 142.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.131978314215707,
+    "minAnsi": 6.131978314215707,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/rippedcasts.json
+++ b/data/by-name/rippedcasts.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rippedcasts.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2b2b2b",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.159028077509387,
+    "minAnsi": 2.399531884329739,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/rose-pine-dawn.json
+++ b/data/by-name/rose-pine-dawn.json
@@ -5,12 +5,13 @@
   "tags": [
     "light",
     "muted",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rose Pine Dawn.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#faf4ed",
@@ -192,5 +193,10 @@
       },
       "oklchCss": "oklch(0.46 0.063 289.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.657280748896968,
+    "minAnsi": 1.0975949529306095,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/rose-pine-moon.json
+++ b/data/by-name/rose-pine-moon.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rose Pine Moon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#232136",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(0.909 0.03 290)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.86365608062847,
+    "minAnsi": 4.2917619544933325,
+    "minAnsiSlot": "green"
   }
 }

--- a/data/by-name/rose-pine.json
+++ b/data/by-name/rose-pine.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rose Pine.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#191724",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(0.909 0.03 290)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.388874563413934,
+    "minAnsi": 3.3844729603705237,
+    "minAnsiSlot": "green"
   }
 }

--- a/data/by-name/rouge-2.json
+++ b/data/by-name/rouge-2.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rouge 2.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#17182b",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.932 0.003 286.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.951602240413291,
+    "minAnsi": 2.2199150694626915,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/royal.json
+++ b/data/by-name/royal.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-fail"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Royal.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#100815",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.674 0.074 301.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 2.344317840825611,
+    "minAnsi": 2.3451310575567703,
+    "minAnsiSlot": "white"
   }
 }

--- a/data/by-name/ryuuko.json
+++ b/data/by-name/ryuuko.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ryuuko.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2c3941",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.943 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.050443066375967,
+    "minAnsi": 2.1494132766980996,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/sakura.json
+++ b/data/by-name/sakura.json
@@ -3,12 +3,14 @@
   "slug": "sakura",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sakura.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#18131e",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.82 0.103 297.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.900875593125184,
+    "minAnsi": 3.4860996084218416,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/scarlet-protocol.json
+++ b/data/by-name/scarlet-protocol.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa-large",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Scarlet Protocol.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1c153d",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 3.722686705931152,
+    "minAnsi": 3.3006754326442884,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/sea-shells.json
+++ b/data/by-name/sea-shells.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sea Shells.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#09141b",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.934 0.041 62.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.063584268094104,
+    "minAnsi": 1.8838589698587347,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/seafoam-pastel.json
+++ b/data/by-name/seafoam-pastel.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seafoam Pastel.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#243435",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.907 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.002648131351295,
+    "minAnsi": 2.239137355390117,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/seedflip-abyss.json
+++ b/data/by-name/seedflip-abyss.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Abyss.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#050510",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.536212085927929,
+    "minAnsi": 5.3902549732184895,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/seedflip-amethyst.json
+++ b/data/by-name/seedflip-amethyst.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Amethyst.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f8f7f6",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.193 0.069 300.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.41793666081968,
+    "minAnsi": 1.4148225725009902,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/seedflip-canopy.json
+++ b/data/by-name/seedflip-canopy.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Canopy.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0f1714",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.557596566165074,
+    "minAnsi": 4.808989972669291,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/seedflip-carbon.json
+++ b/data/by-name/seedflip-carbon.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Carbon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fafafa",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 20.119467064985724,
+    "minAnsi": 1.4201145053585909,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/seedflip-coral.json
+++ b/data/by-name/seedflip-coral.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Coral.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.231 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.857588663262874,
+    "minAnsi": 1.4115336199566344,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/seedflip-ember.json
+++ b/data/by-name/seedflip-ember.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Ember.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0a0a0a",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.91088278219183,
+    "minAnsi": 5.2446309800109665,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/seedflip-glacier.json
+++ b/data/by-name/seedflip-glacier.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Glacier.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f8fafc",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.208 0.04 265.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.062933971317335,
+    "minAnsi": 1.4499487730975231,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/seedflip-inkwell.json
+++ b/data/by-name/seedflip-inkwell.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Inkwell.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0a0a0a",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.64436712791649,
+    "minAnsi": 5.335962454984181,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/seedflip-ivory.json
+++ b/data/by-name/seedflip-ivory.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Ivory.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.26 0.06 251.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.537529558868556,
+    "minAnsi": 1.4115336199566344,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/seedflip-nightfall.json
+++ b/data/by-name/seedflip-nightfall.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Nightfall.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0a0a0f",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.565974491498903,
+    "minAnsi": 5.232225084839507,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/seedflip-phosphor.json
+++ b/data/by-name/seedflip-phosphor.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Phosphor.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0c0c0c",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.64757704069159,
+    "minAnsi": 5.181976866215178,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/seedflip-pulse.json
+++ b/data/by-name/seedflip-pulse.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Pulse.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#121212",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 18.733663902900595,
+    "minAnsi": 4.904182567407399,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/seedflip-ultraviolet.json
+++ b/data/by-name/seedflip-ultraviolet.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Ultraviolet.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0b0014",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.0221059320603,
+    "minAnsi": 5.430870724668883,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/seedflip-voltage.json
+++ b/data/by-name/seedflip-voltage.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Voltage.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0a0a0a",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.37272426550883,
+    "minAnsi": 5.2446309800109665,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/seedflip-wavelength.json
+++ b/data/by-name/seedflip-wavelength.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Wavelength.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0d1117",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.016082890827004,
+    "minAnsi": 5.004239886748117,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/selenized-black.json
+++ b/data/by-name/selenized-black.json
@@ -3,12 +3,15 @@
   "slug": "selenized-black",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Selenized Black.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#181818",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.901 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.049775236144459,
+    "minAnsi": 4.793224199856737,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/selenized-dark.json
+++ b/data/by-name/selenized-dark.json
@@ -3,12 +3,14 @@
   "slug": "selenized-dark",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Selenized Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#103c48",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.872 0.015 202)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.070714842078603,
+    "minAnsi": 3.714015544132306,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/selenized-light.json
+++ b/data/by-name/selenized-light.json
@@ -3,12 +3,13 @@
   "slug": "selenized-light",
   "isDark": false,
   "tags": [
-    "light"
+    "light",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Selenized Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fbf3db",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(0.407 0.026 219.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.368789066610502,
+    "minAnsi": 1.1533436464304379,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/seoulbones-dark.json
+++ b/data/by-name/seoulbones-dark.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seoulbones Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#4b4b4b",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.732 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.4228523951217955,
+    "minAnsi": 3.454928793150346,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/seoulbones-light.json
+++ b/data/by-name/seoulbones-light.json
@@ -4,12 +4,13 @@
   "isDark": false,
   "tags": [
     "light",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seoulbones Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#e2e2e2",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.569 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.75486124007544,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/seti.json
+++ b/data/by-name/seti.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seti.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#111213",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.807341305446808,
+    "minAnsi": 3.253769633312443,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/shades-of-purple.json
+++ b/data/by-name/shades-of-purple.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Shades Of Purple.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1e1d40",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.092165121757127,
+    "minAnsi": 2.948324833991461,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/shaman.json
+++ b/data/by-name/shaman.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-fail"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Shaman.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#001015",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.894 0.145 174.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 2.4412048193974893,
+    "minAnsi": 2.4412048193974893,
+    "minAnsiSlot": "white"
   }
 }

--- a/data/by-name/slate.json
+++ b/data/by-name/slate.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Slate.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222222",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.907 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.341918037634301,
+    "minAnsi": 2.02361972704601,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/sleepy-hollow.json
+++ b/data/by-name/sleepy-hollow.json
@@ -3,12 +3,14 @@
   "slug": "sleepy-hollow",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sleepy Hollow.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#121214",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.831 0.042 90.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.997767716208966,
+    "minAnsi": 3.3168617734467447,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/smyck.json
+++ b/data/by-name/smyck.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Smyck.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1b1b1b",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.976 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.077909234705352,
+    "minAnsi": 3.14840256472224,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/snazzy-soft.json
+++ b/data/by-name/snazzy-soft.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Snazzy Soft.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282a36",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.958 0.001 106.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.432422229651946,
+    "minAnsi": 4.69287905910325,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/snazzy.json
+++ b/data/by-name/snazzy.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Snazzy.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1e1f29",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.946 0.001 106.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.772605398339516,
+    "minAnsi": 4.699429687603196,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/soft-server.json
+++ b/data/by-name/soft-server.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Soft Server.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#242626",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.896 0.015 186.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.879429518296938,
+    "minAnsi": 3.2630057380542925,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/solarized-darcula.json
+++ b/data/by-name/solarized-darcula.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Darcula.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#3d3f41",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.878 0.007 208.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.334558680660561,
+    "minAnsi": 2.231211230420756,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/solarized-dark-higher-contrast.json
+++ b/data/by-name/solarized-dark-higher-contrast.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Dark Higher Contrast.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#001e27",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.967 0.033 91.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.986231218796952,
+    "minAnsi": 3.1249182198659002,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/solarized-dark-patched.json
+++ b/data/by-name/solarized-dark-patched.json
@@ -5,12 +5,13 @@
   "tags": [
     "dark",
     "low-contrast",
+    "wcag-aa-large",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Dark Patched.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#001e27",
@@ -192,5 +193,10 @@
       },
       "oklchCss": "oklch(0.967 0.033 91.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.292316518586955,
+    "minAnsi": 2.4203347306846625,
+    "minAnsiSlot": "brightGreen"
   }
 }

--- a/data/by-name/solarized-osaka-night.json
+++ b/data/by-name/solarized-osaka-night.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Osaka Night.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1a1b26",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.846 0.061 274.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.586955488631288,
+    "minAnsi": 6.459598504862066,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/sonokai.json
+++ b/data/by-name/sonokai.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sonokai.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2c2e34",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.913 0.001 286.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.482533479806625,
+    "minAnsi": 4.520821168756997,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/spacedust.json
+++ b/data/by-name/spacedust.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacedust.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0a1e24",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.996 0.018 110)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.541950548199733,
+    "minAnsi": 2.1740694075162947,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/spacegray-bright.json
+++ b/data/by-name/spacegray-bright.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray Bright.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2a2e3a",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.976 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.2072193118411,
+    "minAnsi": 2.942947011543349,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/spacegray-eighties-dull.json
+++ b/data/by-name/spacegray-eighties-dull.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray Eighties Dull.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222222",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.309085578355408,
+    "minAnsi": 3.0356889444505972,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/spacegray-eighties.json
+++ b/data/by-name/spacegray-eighties.json
@@ -3,12 +3,15 @@
   "slug": "spacegray-eighties",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray Eighties.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222222",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.181159560092757,
+    "minAnsi": 4.194744394376575,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/spacegray.json
+++ b/data/by-name/spacegray.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#20242d",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.81333937048496,
+    "minAnsi": 2.951986272858967,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/spiderman.json
+++ b/data/by-name/spiderman.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "vibrant",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spiderman.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1b1d1e",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.998 0.008 106.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.184335675121535,
+    "minAnsi": 2.100683552485315,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/spring.json
+++ b/data/by-name/spring.json
@@ -3,12 +3,14 @@
   "slug": "spring",
   "isDark": false,
   "tags": [
-    "light"
+    "light",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spring.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.462734156064165,
+    "minAnsi": 1.8096338111861874,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/square.json
+++ b/data/by-name/square.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Square.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1a1a1a",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.913 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.660552557276896,
+    "minAnsi": 2.6436825037748144,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/squirrelsong-dark.json
+++ b/data/by-name/squirrelsong-dark.json
@@ -3,12 +3,13 @@
   "slug": "squirrelsong-dark",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Squirrelsong Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#372920",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(0.889 0.047 62)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.2777803385124376,
+    "minAnsi": 2.5998690630068184,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/srcery.json
+++ b/data/by-name/srcery.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Srcery.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1c1b19",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.938 0.053 82.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.317294396222751,
+    "minAnsi": 3.7256622149750083,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/starlight.json
+++ b/data/by-name/starlight.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Starlight.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#242424",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.522910417680388,
+    "minAnsi": 4.00029384939123,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/sublette.json
+++ b/data/by-name/sublette.json
@@ -3,12 +3,15 @@
   "slug": "sublette",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sublette.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#202535",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.996 0.022 106.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.660461971394787,
+    "minAnsi": 4.501947279840205,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/subliminal.json
+++ b/data/by-name/subliminal.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Subliminal.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282c35",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.87 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.433021582474693,
+    "minAnsi": 3.8836571842058842,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/sugarplum.json
+++ b/data/by-name/sugarplum.json
@@ -3,12 +3,14 @@
   "slug": "sugarplum",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sugarplum.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#111147",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.691 0.195 303)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.685816665804914,
+    "minAnsi": 5.0298091929605615,
+    "minAnsiSlot": "white"
   }
 }

--- a/data/by-name/sundried.json
+++ b/data/by-name/sundried.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sundried.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1a1818",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.676827770199447,
+    "minAnsi": 2.2853991383298307,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/sunset-drive.json
+++ b/data/by-name/sunset-drive.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sunset Drive.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#0f0f1a",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.981 0.009 286.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.442942518787937,
+    "minAnsi": 4.922417664339642,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/symfonic.json
+++ b/data/by-name/symfonic.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Symfonic.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 4.3325819930115825,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/synthwave-alpha.json
+++ b/data/by-name/synthwave-alpha.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Synthwave Alpha.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#241b30",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.957 0.02 106.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.582969904906374,
+    "minAnsi": 2.027201120274542,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/synthwave-everything.json
+++ b/data/by-name/synthwave-everything.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Synthwave Everything.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2a2139",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.997 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.324266084774642,
+    "minAnsi": 3.5924708673024863,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/synthwave.json
+++ b/data/by-name/synthwave.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Synthwave.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.730931171766903,
+    "minAnsi": 5.445853667182818,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/tango-adapted.json
+++ b/data/by-name/tango-adapted.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tango Adapted.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.973 0.003 106.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 1.7728242657985633,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/tango-half-adapted.json
+++ b/data/by-name/tango-half-adapted.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tango Half Adapted.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.967 0.003 106.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 1.7459296405192763,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/tearout.json
+++ b/data/by-name/tearout.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tearout.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#34392d",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.687 0.082 80.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.295737558769867,
+    "minAnsi": 3.56188855262931,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/teerb.json
+++ b/data/by-name/teerb.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Teerb.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#262626",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.952 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.81167442210102,
+    "minAnsi": 5.486634636507461,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/terafox.json
+++ b/data/by-name/terafox.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Terafox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#152528",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.949 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 13.051867566503034,
+    "minAnsi": 3.465125748737453,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/terminal-basic-dark.json
+++ b/data/by-name/terminal-basic-dark.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Terminal Basic Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d1e1d",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.946 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.72383121302713,
+    "minAnsi": 2.8602520349675142,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/terminal-basic.json
+++ b/data/by-name/terminal-basic.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Terminal Basic.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 1.7775640487086088,
+    "minAnsiSlot": "brightCyan"
   }
 }

--- a/data/by-name/thayer-bright.json
+++ b/data/by-name/thayer-bright.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Thayer Bright.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1b1d1e",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.978 0.008 106.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.932465003618038,
+    "minAnsi": 2.7560749420902746,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/the-hulk.json
+++ b/data/by-name/the-hulk.json
@@ -3,12 +3,14 @@
   "slug": "the-hulk",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/The Hulk.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1b1d1e",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.923 0.007 115.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.252014407932334,
+    "minAnsi": 1.9171854932336487,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/tinacious-design-dark.json
+++ b/data/by-name/tinacious-design-dark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tinacious Design Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d1d26",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.884 0.04 284)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.62116497814062,
+    "minAnsi": 4.835816637339798,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/tinacious-design-light.json
+++ b/data/by-name/tinacious-design-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tinacious Design Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f8f8ff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.884 0.04 284)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.814194778398958,
+    "minAnsi": 1.8078987379182248,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/tokyonight-day.json
+++ b/data/by-name/tokyonight-day.json
@@ -5,12 +5,13 @@
   "tags": [
     "light",
     "low-contrast",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Day.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#e1e2e7",
@@ -192,5 +193,10 @@
       },
       "oklchCss": "oklch(0.512 0.156 264.1)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.524626461068713,
+    "minAnsi": 1.0683271955280342,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/tokyonight-moon.json
+++ b/data/by-name/tokyonight-moon.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Moon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#222436",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.869 0.049 271.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.258978159440368,
+    "minAnsi": 4.611378263479609,
+    "minAnsiSlot": "white"
   }
 }

--- a/data/by-name/tokyonight-night.json
+++ b/data/by-name/tokyonight-night.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Night.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1a1b26",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.846 0.061 274.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.586955488631288,
+    "minAnsi": 6.459598504862066,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/tokyonight-storm.json
+++ b/data/by-name/tokyonight-storm.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Storm.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#24283b",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.846 0.061 274.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.022797368046596,
+    "minAnsi": 5.505232212499105,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/tokyonight.json
+++ b/data/by-name/tokyonight.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1a1b26",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.846 0.061 274.8)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.586955488631288,
+    "minAnsi": 6.459598504862066,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/tomorrow-night-blue.json
+++ b/data/by-name/tomorrow-night-blue.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Blue.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#002451",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.315423933501545,
+    "minAnsi": 7.73855958107012,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/tomorrow-night-bright.json
+++ b/data/by-name/tomorrow-night-bright.json
@@ -6,12 +6,15 @@
     "dark",
     "muted",
     "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Bright.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -193,5 +196,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.455715087925668,
+    "minAnsi": 5.043889156185626,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/tomorrow-night-burns.json
+++ b/data/by-name/tomorrow-night-burns.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Burns.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#151515",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.97 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.189429486456223,
+    "minAnsi": 2.087171779793005,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/tomorrow-night-eighties.json
+++ b/data/by-name/tomorrow-night-eighties.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Eighties.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#2d2d2d",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.57577203782333,
+    "minAnsi": 4.586348251671749,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/tomorrow-night.json
+++ b/data/by-name/tomorrow-night.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1d1f21",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.802581130534,
+    "minAnsi": 4.455907574271388,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/tomorrow.json
+++ b/data/by-name/tomorrow.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.462734156064165,
+    "minAnsi": 1.8630433291508341,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/toy-chest.json
+++ b/data/by-name/toy-chest.json
@@ -3,12 +3,13 @@
   "slug": "toy-chest",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Toy Chest.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#24364b",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(0.873 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.12514029490876,
+    "minAnsi": 1.843454967804912,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/traffic.json
+++ b/data/by-name/traffic.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/traffic.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#272c30",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.86 0.024 61.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.492577249349715,
+    "minAnsi": 2.113054016108762,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/treehouse.json
+++ b/data/by-name/treehouse.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa-large"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Treehouse.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#191919",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.858 0.175 88.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 3.3711625379246564,
+    "minAnsi": 2.437084401192714,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/twilight.json
+++ b/data/by-name/twilight.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Twilight.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#141414",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.989 0.055 107.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 17.989775991412532,
+    "minAnsi": 1.9703046715158683,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/ubuntu.json
+++ b/data/by-name/ubuntu.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ubuntu.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#300a24",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.949 0.003 106.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.132233235942888,
+    "minAnsi": 2.6703044473030277,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/ultra-dark.json
+++ b/data/by-name/ultra-dark.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ultra Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 7.3383170961873185,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/ultra-violent.json
+++ b/data/by-name/ultra-violent.json
@@ -3,12 +3,15 @@
   "slug": "ultra-violent",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ultra Violent.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#242728",
@@ -190,5 +193,10 @@
       },
       "oklchCss": "oklch(0.981 0.005 106.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.357224924929971,
+    "minAnsi": 4.051063468277669,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/under-the-sea.json
+++ b/data/by-name/under-the-sea.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Under The Sea.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#011116",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.894 0.145 174.7)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 19.212197278249175,
+    "minAnsi": 2.4230908129799236,
+    "minAnsiSlot": "white"
   }
 }

--- a/data/by-name/unikitty.json
+++ b/data/by-name/unikitty.json
@@ -3,12 +3,14 @@
   "slug": "unikitty",
   "isDark": false,
   "tags": [
-    "light"
+    "light",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Unikitty.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ff8cd9",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(0.977 0.019 328.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.377538846094247,
+    "minAnsi": 1.7705259390552852,
+    "minAnsiSlot": "brightYellow"
   }
 }

--- a/data/by-name/urban.json
+++ b/data/by-name/urban.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/urban.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#312e39",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.747 0.035 49.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.843439340558473,
+    "minAnsi": 1.819986830276663,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/urple.json
+++ b/data/by-name/urple.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa-large"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Urple.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1b1b23",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.775 0.131 297.2)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.306866255422723,
+    "minAnsi": 2.279660237886026,
+    "minAnsiSlot": "purple"
   }
 }

--- a/data/by-name/vague.json
+++ b/data/by-name/vague.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vague.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#141415",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.879 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.581186263208878,
+    "minAnsi": 5.298736117887128,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/vaughn.json
+++ b/data/by-name/vaughn.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vaughn.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#25234f",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.58140024072453,
+    "minAnsi": 2.0616588151758917,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/vercel.json
+++ b/data/by-name/vercel.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vercel.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#101010",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.997 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 18.230259212984933,
+    "minAnsi": 4.082538788719744,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/vesper.json
+++ b/data/by-name/vesper.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vesper.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#101010",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 19.028110547666497,
+    "minAnsi": 7.276577801701197,
+    "minAnsiSlot": "white"
   }
 }

--- a/data/by-name/vibrant-ink.json
+++ b/data/by-name/vibrant-ink.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vibrant Ink.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.922 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 2.444,
+    "minAnsiSlot": "brightBlue"
   }
 }

--- a/data/by-name/vimbones.json
+++ b/data/by-name/vimbones.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vimbones.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f0f0ca",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.475 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.526673507558153,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/violet-dark.json
+++ b/data/by-name/violet-dark.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "low-contrast"
+    "low-contrast",
+    "wcag-aa-large"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Violet Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1c1d1f",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.826 0.013 91.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 4.189220737359681,
+    "minAnsi": 2.9727791091037665,
+    "minAnsiSlot": "brightRed"
   }
 }

--- a/data/by-name/violet-light.json
+++ b/data/by-name/violet-light.json
@@ -3,12 +3,13 @@
   "slug": "violet-light",
   "isDark": false,
   "tags": [
-    "light"
+    "light",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Violet Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#fcf4dc",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(0.826 0.013 91.5)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 5.335951445041022,
+    "minAnsi": 2.858219229105977,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/violite.json
+++ b/data/by-name/violite.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Violite.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#241c36",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.984 0.003 247.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 14.606541287543338,
+    "minAnsi": 5.124584655833913,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/warm-neon.json
+++ b/data/by-name/warm-neon.json
@@ -3,12 +3,13 @@
   "slug": "warm-neon",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Warm Neon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#404040",
@@ -190,5 +191,10 @@
       },
       "oklchCss": "oklch(0.842 0.025 61.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.678634147244857,
+    "minAnsi": 1.85039566330447,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/wez.json
+++ b/data/by-name/wez.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wez.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#000000",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.015715656764469,
+    "minAnsi": 3.557585470026421,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/whimsy.json
+++ b/data/by-name/whimsy.json
@@ -3,12 +3,14 @@
   "slug": "whimsy",
   "isDark": true,
   "tags": [
-    "dark"
+    "dark",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Whimsy.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#29283b",
@@ -190,5 +192,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.911844163669688,
+    "minAnsi": 4.683836383729729,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/wild-cherry.json
+++ b/data/by-name/wild-cherry.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wild Cherry.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1f1726",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.717 0.119 13.9)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.800135652275895,
+    "minAnsi": 3.082915872408531,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/wilmersdorf.json
+++ b/data/by-name/wilmersdorf.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wilmersdorf.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#282b33",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.867 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.28688211956369,
+    "minAnsi": 4.2254933570537805,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/wombat.json
+++ b/data/by-name/wombat.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wombat.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#171717",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 12.835889125683005,
+    "minAnsi": 6.069440212997957,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/wryan.json
+++ b/data/by-name/wryan.json
@@ -4,12 +4,13 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wryan.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#101010",
@@ -191,5 +192,10 @@
       },
       "oklchCss": "oklch(0.808 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 6.6437742847642784,
+    "minAnsi": 2.4654380362095925,
+    "minAnsiSlot": "blue"
   }
 }

--- a/data/by-name/xcode-dark-hc.json
+++ b/data/by-name/xcode-dark-hc.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Dark hc.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1f1f24",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 16.409700712545998,
+    "minAnsi": 7.164334445585376,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/xcode-dark.json
+++ b/data/by-name/xcode-dark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#292a30",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.904 0.001 286.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.74075405420282,
+    "minAnsi": 4.926427134221313,
+    "minAnsiSlot": "cyan"
   }
 }

--- a/data/by-name/xcode-light-hc.json
+++ b/data/by-name/xcode-light-hc.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Light hc.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 21,
+    "minAnsi": 1.4808153836317437,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/xcode-light.json
+++ b/data/by-name/xcode-light.json
@@ -4,12 +4,14 @@
   "isDark": false,
   "tags": [
     "light",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#ffffff",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.269 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 15.133529408889883,
+    "minAnsi": 1.4808153836317437,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/xcode-wwdc.json
+++ b/data/by-name/xcode-wwdc.json
@@ -4,12 +4,14 @@
   "isDark": true,
   "tags": [
     "dark",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode WWDC.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#292c36",
@@ -191,5 +193,10 @@
       },
       "oklchCss": "oklch(0.931 0.004 271.4)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 11.367411063502368,
+    "minAnsi": 2.4802130228261756,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/zenbones-dark.json
+++ b/data/by-name/zenbones-dark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenbones Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#1c1917",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.646 0.011 238.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.166992692840367,
+    "minAnsi": 5.148083003418225,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/zenbones-light.json
+++ b/data/by-name/zenbones-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenbones Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f0edec",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.473 0.025 237.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.605791939903588,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/zenbones.json
+++ b/data/by-name/zenbones.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenbones.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#f0edec",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.473 0.025 237.3)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.605791939903588,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/by-name/zenburn.json
+++ b/data/by-name/zenburn.json
@@ -5,12 +5,14 @@
   "tags": [
     "dark",
     "muted",
+    "wcag-aaa",
+    "wcag-aa",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenburn.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#3f3f3f",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(1 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 7.598464114749242,
+    "minAnsi": 1.803190077291759,
+    "minAnsiSlot": "red"
   }
 }

--- a/data/by-name/zenburned.json
+++ b/data/by-name/zenburned.json
@@ -5,12 +5,15 @@
   "tags": [
     "dark",
     "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible",
     "popular"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenburned.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#404040",
@@ -192,5 +195,10 @@
       },
       "oklchCss": "oklch(0.75 0.056 81.6)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 8.247013993858703,
+    "minAnsi": 3.0521629235417307,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/zenwritten-dark.json
+++ b/data/by-name/zenwritten-dark.json
@@ -4,12 +4,15 @@
   "isDark": true,
   "tags": [
     "dark",
-    "muted"
+    "muted",
+    "wcag-aaa",
+    "wcag-aa",
+    "ansi-legible"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenwritten Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#191919",
@@ -191,5 +194,10 @@
       },
       "oklchCss": "oklch(0.647 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 9.158101920932046,
+    "minAnsi": 5.175562388137477,
+    "minAnsiSlot": "yellow"
   }
 }

--- a/data/by-name/zenwritten-light.json
+++ b/data/by-name/zenwritten-light.json
@@ -5,12 +5,14 @@
   "tags": [
     "light",
     "muted",
-    "high-contrast"
+    "high-contrast",
+    "wcag-aaa",
+    "wcag-aa"
   ],
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenwritten Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-20T11:34:00.030Z",
+  "updatedAt": "2026-04-21T01:55:56.860Z",
   "colors": {
     "background": {
       "hex": "#eeeeee",
@@ -192,5 +194,10 @@
       },
       "oklchCss": "oklch(0.475 0 0)"
     }
+  },
+  "contrast": {
+    "fgOnBg": 10.572181156861216,
+    "minAnsi": 1,
+    "minAnsiSlot": "black"
   }
 }

--- a/data/index.json
+++ b/data/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-20T11:34:00.030Z",
+  "generatedAt": "2026-04-21T01:55:56.860Z",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
   "count": 485,
   "themes": [
@@ -9,7 +9,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -18,7 +21,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -27,7 +32,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -36,7 +43,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -45,7 +54,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -54,7 +65,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -64,7 +78,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -73,7 +90,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -82,7 +101,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -91,7 +112,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -101,7 +124,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -111,7 +136,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -119,7 +147,9 @@
       "slug": "aizen-light",
       "isDark": false,
       "tags": [
-        "light"
+        "light",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -128,7 +158,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -137,7 +169,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa-large"
       ]
     },
     {
@@ -146,7 +179,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -154,7 +189,8 @@
       "slug": "apple-classic",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa"
       ]
     },
     {
@@ -163,7 +199,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -172,7 +211,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -181,7 +222,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -190,7 +234,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -199,7 +245,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -209,7 +257,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -218,7 +269,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -227,7 +279,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -237,6 +292,9 @@
       "tags": [
         "dark",
         "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -247,6 +305,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -256,7 +316,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -265,7 +328,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "vibrant"
+        "vibrant",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -275,6 +340,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -284,6 +352,7 @@
       "isDark": false,
       "tags": [
         "light",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -293,6 +362,9 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -302,7 +374,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -312,7 +387,8 @@
       "tags": [
         "dark",
         "muted",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa-large"
       ]
     },
     {
@@ -321,7 +397,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -330,7 +408,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -339,7 +418,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -349,7 +430,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -359,7 +443,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -369,7 +456,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -379,7 +469,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -389,7 +482,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -399,7 +495,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -409,7 +508,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -419,7 +521,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -429,7 +534,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -439,7 +547,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -449,7 +560,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -459,7 +572,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -468,7 +584,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -476,7 +594,8 @@
       "slug": "blue-dolphin",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa"
       ]
     },
     {
@@ -484,7 +603,9 @@
       "slug": "blue-matrix",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -492,7 +613,10 @@
       "slug": "bluloco-dark",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -501,7 +625,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -510,7 +636,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -520,7 +649,9 @@
       "tags": [
         "dark",
         "vibrant",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -529,7 +660,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -538,7 +672,10 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -547,7 +684,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -556,7 +695,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -566,7 +708,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -575,7 +720,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -584,7 +731,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -593,7 +742,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -602,7 +753,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -612,6 +766,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -622,6 +779,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -631,7 +790,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-fail"
       ]
     },
     {
@@ -639,7 +799,10 @@
       "slug": "calamity",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -648,7 +811,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -657,6 +823,9 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -666,6 +835,8 @@
       "isDark": false,
       "tags": [
         "light",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -675,6 +846,9 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -686,6 +860,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -694,7 +871,9 @@
       "slug": "cga",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -702,7 +881,9 @@
       "slug": "chalk",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -712,7 +893,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -721,7 +905,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -730,7 +917,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -739,7 +928,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -748,7 +938,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -757,7 +950,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -767,7 +962,9 @@
       "tags": [
         "dark",
         "vibrant",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -777,7 +974,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -786,7 +986,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -796,7 +999,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -805,7 +1011,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -814,7 +1022,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -823,7 +1033,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-fail"
       ]
     },
     {
@@ -833,7 +1044,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -843,7 +1057,9 @@
       "tags": [
         "light",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -853,7 +1069,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -862,7 +1081,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -871,7 +1093,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -880,7 +1105,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa-large",
+        "ansi-legible"
       ]
     },
     {
@@ -889,7 +1116,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -898,7 +1128,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -907,7 +1140,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -916,7 +1152,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -925,7 +1164,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-fail"
       ]
     },
     {
@@ -934,7 +1174,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-fail"
       ]
     },
     {
@@ -942,7 +1183,10 @@
       "slug": "darkside",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -951,7 +1195,8 @@
       "isDark": false,
       "tags": [
         "light",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -960,7 +1205,10 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -969,7 +1217,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -978,7 +1229,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -987,7 +1241,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -995,7 +1252,10 @@
       "slug": "dimidium",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1004,6 +1264,8 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -1014,7 +1276,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1023,7 +1287,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1032,7 +1298,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1041,7 +1310,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1049,7 +1321,10 @@
       "slug": "doom-one",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1058,7 +1333,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1067,7 +1344,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1077,6 +1356,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1087,6 +1369,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1096,7 +1381,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1105,6 +1393,9 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1115,7 +1406,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1123,7 +1417,10 @@
       "slug": "earthsong",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1131,7 +1428,10 @@
       "slug": "electron-highlighter",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1139,7 +1439,10 @@
       "slug": "elegant",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1148,7 +1451,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa-large"
       ]
     },
     {
@@ -1157,7 +1461,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1166,7 +1472,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1175,7 +1484,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -1183,7 +1493,8 @@
       "slug": "encom",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa"
       ]
     },
     {
@@ -1193,7 +1504,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1201,7 +1514,8 @@
       "slug": "espresso-libre",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa"
       ]
     },
     {
@@ -1211,7 +1525,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1220,6 +1537,9 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1230,6 +1550,7 @@
       "tags": [
         "light",
         "low-contrast",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -1240,7 +1561,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1248,7 +1571,8 @@
       "slug": "fairyfloss",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa"
       ]
     },
     {
@@ -1257,7 +1581,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1266,7 +1592,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1274,7 +1602,9 @@
       "slug": "fideloper",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1283,7 +1613,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1291,7 +1624,8 @@
       "slug": "firefox-dev",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa"
       ]
     },
     {
@@ -1299,7 +1633,9 @@
       "slug": "firewatch",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1308,7 +1644,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1316,7 +1654,9 @@
       "slug": "flat",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1325,7 +1665,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1334,7 +1676,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1343,7 +1687,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1352,7 +1698,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1362,7 +1710,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1371,7 +1721,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa-large",
+        "ansi-legible"
       ]
     },
     {
@@ -1379,7 +1731,9 @@
       "slug": "front-end-delight",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1388,7 +1742,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1397,7 +1753,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1406,7 +1764,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1416,7 +1776,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1425,6 +1788,8 @@
       "isDark": false,
       "tags": [
         "light",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -1434,6 +1799,8 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1444,6 +1811,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1454,6 +1824,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1463,6 +1836,9 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1473,6 +1849,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1483,6 +1862,9 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1493,6 +1875,9 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1503,6 +1888,9 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1513,7 +1901,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1523,7 +1914,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1532,7 +1926,10 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1541,7 +1938,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1549,7 +1948,9 @@
       "slug": "grape",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1558,7 +1959,8 @@
       "isDark": false,
       "tags": [
         "light",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa"
       ]
     },
     {
@@ -1568,7 +1970,10 @@
       "tags": [
         "dark",
         "vibrant",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1577,7 +1982,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1587,6 +1995,8 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -1597,6 +2007,8 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -1607,6 +2019,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -1617,6 +2031,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -1626,6 +2042,9 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1636,6 +2055,9 @@
       "tags": [
         "dark",
         "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1646,6 +2068,8 @@
       "tags": [
         "light",
         "muted",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -1655,7 +2079,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1665,7 +2092,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1673,7 +2102,10 @@
       "slug": "hardcore",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1682,7 +2114,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1691,7 +2126,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1700,7 +2137,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1708,7 +2148,10 @@
       "slug": "hax0r-blue",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1717,7 +2160,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "vibrant"
+        "vibrant",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1727,7 +2172,8 @@
       "tags": [
         "dark",
         "vibrant",
-        "low-contrast"
+        "low-contrast",
+        "wcag-fail"
       ]
     },
     {
@@ -1736,7 +2182,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1745,7 +2194,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1753,7 +2204,9 @@
       "slug": "hipster-green",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1763,7 +2216,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1773,7 +2228,9 @@
       "tags": [
         "dark",
         "vibrant",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1782,7 +2239,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -1790,7 +2248,9 @@
       "slug": "hopscotch-256",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1799,7 +2259,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1808,7 +2271,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1817,7 +2282,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa-large",
+        "ansi-legible"
       ]
     },
     {
@@ -1826,7 +2293,10 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1835,7 +2305,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1844,7 +2317,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1853,7 +2328,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1862,7 +2339,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1871,7 +2350,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1880,7 +2362,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1891,6 +2375,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -1900,6 +2387,8 @@
       "isDark": false,
       "tags": [
         "light",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -1908,7 +2397,9 @@
       "slug": "idea",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1917,7 +2408,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1927,7 +2421,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1936,7 +2433,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1946,7 +2445,9 @@
       "tags": [
         "dark",
         "vibrant",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1955,7 +2456,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1964,7 +2467,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1973,7 +2478,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -1983,7 +2490,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -1992,7 +2502,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2002,6 +2514,7 @@
       "tags": [
         "dark",
         "low-contrast",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2013,6 +2526,7 @@
         "light",
         "muted",
         "low-contrast",
+        "wcag-aa-large",
         "popular"
       ]
     },
@@ -2023,6 +2537,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2033,6 +2550,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2042,7 +2561,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2051,7 +2572,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2062,6 +2585,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2070,7 +2596,9 @@
       "slug": "jetbrains-darcula",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2078,7 +2606,9 @@
       "slug": "jubi",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2089,6 +2619,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2099,6 +2632,7 @@
       "tags": [
         "light",
         "muted",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2110,6 +2644,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2121,6 +2658,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2131,7 +2671,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2140,7 +2683,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2150,7 +2696,9 @@
       "tags": [
         "light",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2160,7 +2708,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2169,7 +2720,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2178,7 +2731,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2187,7 +2743,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2196,7 +2754,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2205,7 +2766,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2215,7 +2778,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2224,7 +2790,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2232,7 +2800,9 @@
       "slug": "laser",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2241,7 +2811,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -2250,7 +2821,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa-large"
       ]
     },
     {
@@ -2258,7 +2830,9 @@
       "slug": "light-owl",
       "isDark": false,
       "tags": [
-        "light"
+        "light",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2266,7 +2840,10 @@
       "slug": "liquid-carbon",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2275,7 +2852,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2284,7 +2864,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2293,7 +2876,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2302,7 +2887,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2312,6 +2900,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2322,6 +2912,8 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2332,6 +2924,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2342,6 +2937,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2351,6 +2949,8 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2360,7 +2960,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2369,7 +2972,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-fail"
       ]
     },
     {
@@ -2378,7 +2982,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2386,7 +2992,10 @@
       "slug": "medallion",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2396,7 +3005,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2405,7 +3017,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2415,7 +3029,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2425,7 +3042,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2434,7 +3054,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2443,7 +3065,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2451,7 +3076,9 @@
       "slug": "mirage",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2459,7 +3086,9 @@
       "slug": "misterioso",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2468,7 +3097,10 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2477,7 +3109,10 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2486,7 +3121,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2495,7 +3133,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2503,7 +3144,10 @@
       "slug": "molokai",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2512,7 +3156,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2522,6 +3168,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2532,6 +3181,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2542,6 +3194,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2552,6 +3206,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2562,6 +3218,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2572,6 +3231,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2582,6 +3244,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2592,6 +3257,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2602,6 +3270,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2611,6 +3282,9 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2621,6 +3295,8 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2629,7 +3305,10 @@
       "slug": "monospace-dark",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2637,7 +3316,10 @@
       "slug": "monospace-light",
       "isDark": false,
       "tags": [
-        "light"
+        "light",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2646,7 +3328,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2655,7 +3340,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -2665,7 +3351,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2674,7 +3363,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2683,7 +3374,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2692,7 +3385,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2702,7 +3397,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2711,7 +3408,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2719,7 +3419,9 @@
       "slug": "night-lion-v2",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2729,6 +3431,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2739,6 +3444,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2749,7 +3456,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2758,7 +3468,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2768,7 +3481,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2778,7 +3494,9 @@
       "tags": [
         "light",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2787,7 +3505,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2797,6 +3518,9 @@
       "tags": [
         "dark",
         "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2807,6 +3531,8 @@
       "tags": [
         "light",
         "muted",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2818,6 +3544,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2828,6 +3557,9 @@
       "tags": [
         "dark",
         "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2837,7 +3569,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2846,7 +3580,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2856,7 +3593,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2866,7 +3606,10 @@
       "tags": [
         "light",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2874,7 +3617,9 @@
       "slug": "obsidian",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2882,7 +3627,9 @@
       "slug": "ocean",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2891,6 +3638,8 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2901,6 +3650,9 @@
       "tags": [
         "dark",
         "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2910,7 +3662,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa"
       ]
     },
     {
@@ -2921,6 +3674,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2930,7 +3686,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2939,7 +3698,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -2949,6 +3710,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2959,6 +3723,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2970,6 +3736,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -2980,6 +3749,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -2989,7 +3760,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -2999,7 +3773,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3009,7 +3786,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3018,7 +3797,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3027,7 +3809,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3036,7 +3820,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3044,7 +3830,8 @@
       "slug": "paraiso-dark",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa"
       ]
     },
     {
@@ -3053,7 +3840,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3062,7 +3852,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3070,7 +3862,9 @@
       "slug": "pencil-light",
       "isDark": false,
       "tags": [
-        "light"
+        "light",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3080,7 +3874,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3090,7 +3887,9 @@
       "tags": [
         "dark",
         "vibrant",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3099,7 +3898,10 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3108,7 +3910,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3117,7 +3922,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3127,7 +3934,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3136,7 +3946,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3145,7 +3958,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3154,7 +3970,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3163,7 +3981,8 @@
       "isDark": false,
       "tags": [
         "light",
-        "low-contrast"
+        "low-contrast",
+        "wcag-fail"
       ]
     },
     {
@@ -3172,7 +3991,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3181,7 +4003,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3190,7 +4014,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3199,7 +4025,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3208,7 +4036,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3217,7 +4047,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3226,7 +4059,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3235,7 +4071,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3244,7 +4083,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3253,7 +4095,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3262,7 +4106,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3271,7 +4118,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3280,7 +4129,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3288,7 +4139,8 @@
       "slug": "red-sands",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa"
       ]
     },
     {
@@ -3297,7 +4149,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3306,7 +4160,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "vibrant"
+        "vibrant",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3316,7 +4172,10 @@
       "tags": [
         "dark",
         "vibrant",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3325,7 +4184,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3336,6 +4197,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -3346,6 +4210,7 @@
       "tags": [
         "light",
         "muted",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -3357,6 +4222,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -3366,7 +4234,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -3375,7 +4244,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-fail"
       ]
     },
     {
@@ -3385,7 +4255,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3393,7 +4265,9 @@
       "slug": "sakura",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3402,7 +4276,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa-large",
+        "ansi-legible"
       ]
     },
     {
@@ -3411,7 +4287,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3421,7 +4299,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3430,7 +4310,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3439,7 +4322,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3448,7 +4333,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3458,7 +4346,9 @@
       "tags": [
         "light",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3467,7 +4357,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3476,7 +4368,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3485,7 +4380,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3495,7 +4392,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3504,7 +4404,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3513,7 +4415,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3522,7 +4427,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3531,7 +4439,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3540,7 +4451,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3549,7 +4463,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3558,7 +4475,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3566,7 +4486,10 @@
       "slug": "selenized-black",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3574,7 +4497,9 @@
       "slug": "selenized-dark",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3582,7 +4507,8 @@
       "slug": "selenized-light",
       "isDark": false,
       "tags": [
-        "light"
+        "light",
+        "wcag-aa"
       ]
     },
     {
@@ -3591,7 +4517,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3600,7 +4528,8 @@
       "isDark": false,
       "tags": [
         "light",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -3609,7 +4538,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3618,7 +4550,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3627,7 +4561,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-fail"
       ]
     },
     {
@@ -3636,7 +4571,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -3644,7 +4580,9 @@
       "slug": "sleepy-hollow",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3653,7 +4591,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3662,7 +4603,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3671,7 +4615,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3680,7 +4627,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3689,6 +4638,8 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -3698,6 +4649,9 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -3708,6 +4662,7 @@
       "tags": [
         "dark",
         "low-contrast",
+        "wcag-aa-large",
         "popular"
       ]
     },
@@ -3718,6 +4673,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -3727,7 +4685,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3736,7 +4697,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3745,7 +4708,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3755,7 +4720,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3763,7 +4730,10 @@
       "slug": "spacegray-eighties",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3772,7 +4742,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3782,7 +4755,9 @@
       "tags": [
         "dark",
         "vibrant",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3790,7 +4765,9 @@
       "slug": "spring",
       "isDark": false,
       "tags": [
-        "light"
+        "light",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3799,7 +4776,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3807,7 +4786,8 @@
       "slug": "squirrelsong-dark",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa"
       ]
     },
     {
@@ -3816,7 +4796,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3825,7 +4808,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3833,7 +4819,10 @@
       "slug": "sublette",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3842,7 +4831,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3850,7 +4842,9 @@
       "slug": "sugarplum",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3860,7 +4854,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3869,7 +4865,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3878,7 +4877,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3887,7 +4889,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3896,7 +4901,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3905,7 +4912,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3915,6 +4925,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -3925,6 +4937,8 @@
       "tags": [
         "light",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -3934,7 +4948,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3943,7 +4960,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3953,7 +4973,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -3962,7 +4985,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3971,7 +4996,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3980,7 +5007,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3988,7 +5017,9 @@
       "slug": "the-hulk",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -3997,7 +5028,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4006,7 +5040,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4016,6 +5052,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -4026,6 +5065,7 @@
       "tags": [
         "light",
         "low-contrast",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -4036,6 +5076,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -4046,6 +5089,9 @@
       "tags": [
         "dark",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -4055,6 +5101,9 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -4064,6 +5113,8 @@
       "isDark": false,
       "tags": [
         "light",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -4074,6 +5125,9 @@
       "tags": [
         "dark",
         "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -4085,6 +5139,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -4096,6 +5153,9 @@
         "dark",
         "muted",
         "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -4105,6 +5165,8 @@
       "isDark": true,
       "tags": [
         "dark",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -4115,6 +5177,9 @@
       "tags": [
         "dark",
         "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -4123,7 +5188,8 @@
       "slug": "toy-chest",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa"
       ]
     },
     {
@@ -4132,7 +5198,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4141,7 +5209,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa-large"
       ]
     },
     {
@@ -4151,7 +5220,9 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4160,7 +5231,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4170,7 +5243,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4178,7 +5254,10 @@
       "slug": "ultra-violent",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4187,7 +5266,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4195,7 +5276,9 @@
       "slug": "unikitty",
       "isDark": false,
       "tags": [
-        "light"
+        "light",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4204,7 +5287,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -4213,7 +5297,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa-large"
       ]
     },
     {
@@ -4223,7 +5308,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4232,7 +5320,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4241,7 +5331,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4251,7 +5344,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4260,7 +5356,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4270,7 +5368,9 @@
       "tags": [
         "light",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4279,7 +5379,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "low-contrast"
+        "low-contrast",
+        "wcag-aa-large"
       ]
     },
     {
@@ -4287,7 +5388,8 @@
       "slug": "violet-light",
       "isDark": false,
       "tags": [
-        "light"
+        "light",
+        "wcag-aa"
       ]
     },
     {
@@ -4296,7 +5398,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4304,7 +5409,8 @@
       "slug": "warm-neon",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa"
       ]
     },
     {
@@ -4313,7 +5419,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4321,7 +5430,9 @@
       "slug": "whimsy",
       "isDark": true,
       "tags": [
-        "dark"
+        "dark",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4330,7 +5441,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4339,7 +5453,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4349,7 +5466,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4358,7 +5478,8 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aa"
       ]
     },
     {
@@ -4367,7 +5488,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4377,7 +5501,10 @@
       "tags": [
         "dark",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4386,7 +5513,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4395,7 +5524,9 @@
       "isDark": false,
       "tags": [
         "light",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4404,7 +5535,9 @@
       "isDark": true,
       "tags": [
         "dark",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4414,7 +5547,9 @@
       "tags": [
         "light",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4423,7 +5558,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4433,7 +5571,9 @@
       "tags": [
         "light",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     },
     {
@@ -4443,6 +5583,8 @@
       "tags": [
         "dark",
         "muted",
+        "wcag-aaa",
+        "wcag-aa",
         "popular"
       ]
     },
@@ -4453,6 +5595,9 @@
       "tags": [
         "dark",
         "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible",
         "popular"
       ]
     },
@@ -4462,7 +5607,10 @@
       "isDark": true,
       "tags": [
         "dark",
-        "muted"
+        "muted",
+        "wcag-aaa",
+        "wcag-aa",
+        "ansi-legible"
       ]
     },
     {
@@ -4472,7 +5620,9 @@
       "tags": [
         "light",
         "muted",
-        "high-contrast"
+        "high-contrast",
+        "wcag-aaa",
+        "wcag-aa"
       ]
     }
   ]

--- a/data/themes.json
+++ b/data/themes.json
@@ -5,12 +5,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/0x96f.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#262427",
@@ -192,6 +195,11 @@
         },
         "oklchCss": "oklch(0.991 0.003 106.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.98736223531605,
+      "minAnsi": 5.405457549496037,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -200,12 +208,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/12-bit Rainbow.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#040404",
@@ -387,6 +397,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 20.465226245727198,
+      "minAnsi": 2.173156742940344,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -395,12 +410,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/3024 Day.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f7f7f7",
@@ -582,6 +599,11 @@
         },
         "oklchCss": "oklch(0.976 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.816057552122258,
+      "minAnsi": 1.7892684123648972,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -590,12 +612,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/3024 Night.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#090300",
@@ -777,6 +801,11 @@
         },
         "oklchCss": "oklch(0.976 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.090376250999649,
+      "minAnsi": 2.0454139168455816,
+      "minAnsiSlot": "brightGreen"
     }
   },
   {
@@ -785,12 +814,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aardvark Blue.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#102040",
@@ -972,6 +1003,11 @@
         },
         "oklchCss": "oklch(0.976 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.868782411080737,
+      "minAnsi": 2.4870906408519557,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -980,12 +1016,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Abernathy.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#111416",
@@ -1167,6 +1206,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.919643988665126,
+      "minAnsi": 3.1667849280656473,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -1176,12 +1220,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adventure.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#040404",
@@ -1363,6 +1410,11 @@
         },
         "oklchCss": "oklch(0.881 0.025 65.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 20.465226245727198,
+      "minAnsi": 4.549050814459397,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -1371,12 +1423,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adventure Time.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1f1d45",
@@ -1558,6 +1612,11 @@
         },
         "oklchCss": "oklch(0.973 0.008 293.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.113966282696687,
+      "minAnsi": 2.1328725131315767,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -1566,12 +1625,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adwaita.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -1753,6 +1814,11 @@
         },
         "oklchCss": "oklch(0.971 0.002 67.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7544651015331638,
+      "minAnsiSlot": "brightCyan"
     }
   },
   {
@@ -1761,12 +1827,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adwaita Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d1d20",
@@ -1948,6 +2016,11 @@
         },
         "oklchCss": "oklch(0.971 0.002 67.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.8155377168847,
+      "minAnsi": 2.752972028782864,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -1957,12 +2030,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Afterglow.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#212121",
@@ -2144,6 +2219,11 @@
         },
         "oklchCss": "oklch(0.97 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.439697060587305,
+      "minAnsi": 2.7518794428131885,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -2153,12 +2233,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aizen Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1a1a1a",
@@ -2340,6 +2423,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.066055932105117,
+      "minAnsi": 7.19388524139549,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -2347,12 +2435,14 @@
     "slug": "aizen-light",
     "isDark": false,
     "tags": [
-      "light"
+      "light",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aizen Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f0f2f6",
@@ -2534,6 +2624,11 @@
         },
         "oklchCss": "oklch(0.428 0.042 279.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.363358729842013,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -2542,12 +2637,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Alabaster.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f7f7f7",
@@ -2729,6 +2826,11 @@
         },
         "oklchCss": "oklch(0.976 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 19.602217167508474,
+      "minAnsi": 1.778257050595166,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -2737,12 +2839,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa-large"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Alien Blood.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0f1610",
@@ -2924,6 +3027,11 @@
         },
         "oklchCss": "oklch(0.885 0.186 148.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.131824451082685,
+      "minAnsi": 1.9931186853570928,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -2932,12 +3040,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Andromeda.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#262a33",
@@ -3119,6 +3229,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.407365218447465,
+      "minAnsi": 2.791497587776118,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -3126,12 +3241,13 @@
     "slug": "apple-classic",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Apple Classic.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2c2b2b",
@@ -3313,6 +3429,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.048527078431232,
+      "minAnsi": 1.914333565863103,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -3321,12 +3442,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Apple System Colors.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1e1e1e",
@@ -3508,6 +3632,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.67115667431794,
+      "minAnsi": 3.090764391581366,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -3516,12 +3645,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Apple System Colors Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#feffff",
@@ -3703,6 +3834,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 20.962166116928003,
+      "minAnsi": 1.8188603147109128,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -3711,12 +3847,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Arcoiris.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#201f1e",
@@ -3898,6 +4037,11 @@
         },
         "oklchCss": "oklch(0.952 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.113383572161831,
+      "minAnsi": 3.346995540140267,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -3906,12 +4050,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ardoise.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1e1e1e",
@@ -4093,6 +4239,11 @@
         },
         "oklchCss": "oklch(0.997 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.857474337764968,
+      "minAnsi": 2.257962048740802,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -4101,12 +4252,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Argonaut.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0e1019",
@@ -4288,6 +4441,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 18.27980978944089,
+      "minAnsi": 2.713830325000255,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -4297,12 +4455,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Arthur.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1c1c1c",
@@ -4484,6 +4645,11 @@
         },
         "oklchCss": "oklch(0.855 0.03 67.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.078643157977426,
+      "minAnsi": 3.4530549565921453,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -4492,12 +4658,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atelier Sulphurpool.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#202746",
@@ -4679,6 +4846,11 @@
         },
         "oklchCss": "oklch(0.977 0.011 274.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.414841177867144,
+      "minAnsi": 2.0967078405880457,
+      "minAnsiSlot": "brightGreen"
     }
   },
   {
@@ -4687,12 +4859,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atom.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#161719",
@@ -4874,6 +5049,11 @@
         },
         "oklchCss": "oklch(0.907 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.635607286220665,
+      "minAnsi": 6.904856074987967,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -4883,12 +5063,15 @@
     "tags": [
       "dark",
       "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atom One Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#21252b",
@@ -5070,6 +5253,11 @@
         },
         "oklchCss": "oklch(0.762 0.02 263)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.22197939059332,
+      "minAnsi": 4.817082099235591,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -5079,12 +5267,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atom One Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f9f9f9",
@@ -5266,6 +5456,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.239833955316717,
+      "minAnsi": 1.8602032925263683,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -5274,12 +5469,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aura.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#15141b",
@@ -5461,6 +5659,11 @@
         },
         "oklchCss": "oklch(0.944 0.003 308.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.537628430566988,
+      "minAnsi": 5.766817550072907,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -5469,12 +5672,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "vibrant"
+      "vibrant",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aurora.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#23262e",
@@ -5656,6 +5861,11 @@
         },
         "oklchCss": "oklch(0.649 0.242 317.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.891393012270951,
+      "minAnsi": 1.824799856967808,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -5665,12 +5875,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ayu.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0b0e14",
@@ -5852,6 +6065,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.274416767856575,
+      "minAnsi": 6.33868001629521,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -5860,12 +6078,13 @@
     "isDark": false,
     "tags": [
       "light",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ayu Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f8f9fa",
@@ -6047,6 +6266,11 @@
         },
         "oklchCss": "oklch(0.861 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.934812759512011,
+      "minAnsi": 1.8233432417765811,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -6055,12 +6279,15 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ayu Mirage.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1f2430",
@@ -6242,6 +6469,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.454497337874741,
+      "minAnsi": 5.9456122299542065,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -6250,12 +6482,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Banana Blueberry.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#191323",
@@ -6437,6 +6672,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.285012520072431,
+      "minAnsi": 4.173883068640812,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -6446,12 +6686,13 @@
     "tags": [
       "dark",
       "muted",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa-large"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Batman.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1b1d1e",
@@ -6633,6 +6874,11 @@
         },
         "oklchCss": "oklch(0.889 0.007 115.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 3.367360421928134,
+      "minAnsi": 2.705453770745099,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -6641,12 +6887,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Belafonte Day.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#d5ccba",
@@ -6828,6 +7076,11 @@
         },
         "oklchCss": "oklch(0.848 0.026 84.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.065447991368135,
+      "minAnsi": 1.7715117803328628,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -6836,12 +7089,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Belafonte Night.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#20111b",
@@ -7023,6 +7277,11 @@
         },
         "oklchCss": "oklch(0.848 0.026 84.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.5086070861374195,
+      "minAnsi": 2.8251493881125196,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -7031,12 +7290,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Birds Of Paradise.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2a1f1d",
@@ -7218,6 +7479,11 @@
         },
         "oklchCss": "oklch(0.978 0.047 99.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.42053308730299,
+      "minAnsi": 2.7380088390241584,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -7227,12 +7493,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -7414,6 +7683,11 @@
         },
         "oklchCss": "oklch(0.811 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 3.7354550726829094,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -7423,12 +7697,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Bathory).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -7610,6 +7887,11 @@
         },
         "oklchCss": "oklch(0.811 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 5.302022326099849,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -7619,12 +7901,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Burzum).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -7806,6 +8091,11 @@
         },
         "oklchCss": "oklch(0.811 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 5.302022326099849,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -7815,12 +8105,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Dark Funeral).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -8002,6 +8295,11 @@
         },
         "oklchCss": "oklch(0.811 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 5.170004476038628,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -8011,12 +8309,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Gorgoroth).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -8198,6 +8499,11 @@
         },
         "oklchCss": "oklch(0.811 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 5.302022326099849,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -8207,12 +8513,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Immortal).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -8394,6 +8703,11 @@
         },
         "oklchCss": "oklch(0.811 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 3.553189319516299,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -8403,12 +8717,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Khold).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -8590,6 +8907,11 @@
         },
         "oklchCss": "oklch(0.811 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 3.41073197097461,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -8599,12 +8921,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Marduk).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -8786,6 +9111,11 @@
         },
         "oklchCss": "oklch(0.811 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 3.818266607523982,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -8795,12 +9125,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Mayhem).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -8982,6 +9315,11 @@
         },
         "oklchCss": "oklch(0.811 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 5.302022326099849,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -8991,12 +9329,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Nile).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -9178,6 +9519,11 @@
         },
         "oklchCss": "oklch(0.811 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 4.554293428899023,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -9187,12 +9533,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Venom).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -9374,6 +9722,11 @@
         },
         "oklchCss": "oklch(0.811 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 2.085125879935977,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -9383,12 +9736,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blazer.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0d1926",
@@ -9570,6 +9926,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.9772666218614,
+      "minAnsi": 4.478698684813335,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -9578,12 +9939,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blue Berry Pie.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1c0c28",
@@ -9765,6 +10128,11 @@
         },
         "oklchCss": "oklch(0.49 0.084 215)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.546087376536567,
+      "minAnsi": 2.06095558162547,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -9772,12 +10140,13 @@
     "slug": "blue-dolphin",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blue Dolphin.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#006984",
@@ -9959,6 +10328,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.223572571709242,
+      "minAnsi": 2.624043838476951,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -9966,12 +10340,14 @@
     "slug": "blue-matrix",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blue Matrix.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#101116",
@@ -10153,6 +10529,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.834399264935834,
+      "minAnsi": 4.843488536888253,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -10160,12 +10541,15 @@
     "slug": "bluloco-dark",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Bluloco Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282c34",
@@ -10347,6 +10731,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.6429594705314825,
+      "minAnsi": 3.3816564098969817,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -10355,12 +10744,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Bluloco Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f9f9f9",
@@ -10542,6 +10933,11 @@
         },
         "oklchCss": "oklch(0.867 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.816784394191304,
+      "minAnsi": 2.303514790146454,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -10550,12 +10946,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Borland.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0000a4",
@@ -10737,6 +11136,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.802832815575501,
+      "minAnsi": 4.925520462555745,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -10746,12 +11150,14 @@
     "tags": [
       "dark",
       "vibrant",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Box.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#141d2b",
@@ -10933,6 +11339,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.948642919560694,
+      "minAnsi": 2.8911886438272014,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -10941,12 +11352,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/branch.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#32221a",
@@ -11128,6 +11542,11 @@
         },
         "oklchCss": "oklch(0.816 0.036 81.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.593893421562631,
+      "minAnsi": 3.3804888513483955,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -11136,12 +11555,15 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Breadog.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f1ebe6",
@@ -11323,6 +11745,11 @@
         },
         "oklchCss": "oklch(0.915 0.014 60.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.516984728118752,
+      "minAnsi": 3.551081210057594,
+      "minAnsiSlot": "brightGreen"
     }
   },
   {
@@ -11331,12 +11758,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Breeze.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#31363b",
@@ -11518,6 +11947,11 @@
         },
         "oklchCss": "oklch(0.991 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.691418971163678,
+      "minAnsi": 2.0799367639426634,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -11526,12 +11960,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Bright Lights.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#191919",
@@ -11713,6 +12150,11 @@
         },
         "oklchCss": "oklch(0.833 0.022 268.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.258212000763624,
+      "minAnsi": 4.949922051401596,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -11722,12 +12164,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Broadcast.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2b2b2b",
@@ -11909,6 +12354,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.901201394892102,
+      "minAnsi": 3.366601690433081,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -11917,12 +12367,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Brogrammer.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#131313",
@@ -12104,6 +12556,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.38055610561519,
+      "minAnsi": 2.8452502311416352,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -12112,12 +12569,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -12299,6 +12758,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.938659901217408,
+      "minAnsi": 1.9087088049756329,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -12307,12 +12771,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -12494,6 +12960,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.8941005847454646,
+      "minAnsiSlot": "brightGreen"
     }
   },
   {
@@ -12502,12 +12973,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Pastel Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -12689,6 +13163,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.938659901217408,
+      "minAnsi": 7.565930477694234,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -12698,12 +13177,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Tango Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -12885,6 +13367,11 @@
         },
         "oklchCss": "oklch(0.949 0.003 106.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 3.189857951985112,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -12894,12 +13381,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Tango Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -13081,6 +13570,11 @@
         },
         "oklchCss": "oklch(0.949 0.003 106.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7952876128727326,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -13089,12 +13583,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-fail"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/C64.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#40318d",
@@ -13276,6 +13771,11 @@
         },
         "oklchCss": "oklch(0.976 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 2.2607656244342924,
+      "minAnsi": 1.7528273106950094,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -13283,12 +13783,15 @@
     "slug": "calamity",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Calamity.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2f2833",
@@ -13470,6 +13973,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.278505646168245,
+      "minAnsi": 3.2235122088779002,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -13478,12 +13986,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Carbonfox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#161616",
@@ -13665,6 +14176,11 @@
         },
         "oklchCss": "oklch(0.919 0.001 286.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.434104834959708,
+      "minAnsi": 5.44018049973752,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -13673,12 +14189,15 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Frappe.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#303446",
@@ -13860,6 +14379,11 @@
         },
         "oklchCss": "oklch(0.808 0.051 272.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.058361993601588,
+      "minAnsi": 4.087013150070628,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -13868,12 +14392,14 @@
     "isDark": false,
     "tags": [
       "light",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Latte.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#eff1f5",
@@ -14055,6 +14581,11 @@
         },
         "oklchCss": "oklch(0.808 0.017 271.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.0619995573104415,
+      "minAnsi": 1.9141888968694352,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -14063,12 +14594,15 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Macchiato.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#24273a",
@@ -14250,6 +14784,11 @@
         },
         "oklchCss": "oklch(0.812 0.046 274.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.91891243005997,
+      "minAnsi": 5.194473756643897,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -14260,12 +14799,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Mocha.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1e1e2e",
@@ -14447,6 +14989,11 @@
         },
         "oklchCss": "oklch(0.817 0.04 272.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.341133436863977,
+      "minAnsi": 6.177654146691573,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -14454,12 +15001,14 @@
     "slug": "cga",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/CGA.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -14641,6 +15190,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.039555596643915,
+      "minAnsi": 1.7584621294329432,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -14648,12 +15202,14 @@
     "slug": "chalk",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Chalk.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2b2d2e",
@@ -14835,6 +15391,11 @@
         },
         "oklchCss": "oklch(0.878 0.007 208.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.597623877390692,
+      "minAnsi": 2.385502309081929,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -14844,12 +15405,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Chalkboard.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#29262f",
@@ -15031,6 +15595,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.717055368088978,
+      "minAnsi": 3.4857732997160817,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -15039,12 +15608,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Challenger Deep.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1e1c31",
@@ -15226,6 +15798,11 @@
         },
         "oklchCss": "oklch(0.899 0.026 208.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.217613990801206,
+      "minAnsi": 4.56276031526616,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -15234,12 +15811,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Chester.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2c3643",
@@ -15421,6 +16000,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.239111925768343,
+      "minAnsi": 2.927915443263548,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -15429,12 +16013,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ciapre.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#191c27",
@@ -15616,6 +16201,11 @@
         },
         "oklchCss": "oklch(0.967 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.784768448344223,
+      "minAnsi": 1.7944955850844855,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -15624,12 +16214,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Citruszest.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -15811,6 +16404,11 @@
         },
         "oklchCss": "oklch(0.982 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.187465865194712,
+      "minAnsi": 5.046160960201738,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -15819,12 +16417,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/CLRS.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -16006,6 +16606,11 @@
         },
         "oklchCss": "oklch(0.949 0.003 106.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.133529408889883,
+      "minAnsi": 1.8120859440085175,
+      "minAnsiSlot": "brightCyan"
     }
   },
   {
@@ -16015,12 +16620,14 @@
     "tags": [
       "dark",
       "vibrant",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Neon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#142838",
@@ -16202,6 +16809,11 @@
         },
         "oklchCss": "oklch(0.882 0.176 142.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.200746748171563,
+      "minAnsi": 1.764991976970595,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -16211,12 +16823,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Next.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#162c35",
@@ -16398,6 +17013,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.738742024166898,
+      "minAnsi": 4.665202123018976,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -16406,12 +17026,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Next Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0b1c24",
@@ -16593,6 +17216,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.876057625515893,
+      "minAnsi": 5.122564749771748,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -16602,12 +17230,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Next Minimal.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0b1c24",
@@ -16789,6 +17420,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.876057625515893,
+      "minAnsi": 5.798179209508437,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -16797,12 +17433,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt2.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#132738",
@@ -16984,6 +17622,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.272707504267059,
+      "minAnsi": 2.642557726110494,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -16992,12 +17635,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Coffee Theme.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f5deb3",
@@ -17179,6 +17824,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.98194056409643,
+      "minAnsi": 1.7576534298401374,
+      "minAnsiSlot": "brightCyan"
     }
   },
   {
@@ -17187,12 +17837,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-fail"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Crayon Pony Fish.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#150707",
@@ -17374,6 +18025,11 @@
         },
         "oklchCss": "oklch(0.695 0.036 356.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 2.762639595886461,
+      "minAnsi": 1.992869950464761,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -17383,12 +18039,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cursor Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#141414",
@@ -17570,6 +18229,11 @@
         },
         "oklchCss": "oklch(0.919 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.428629164208074,
+      "minAnsi": 5.764803105478651,
+      "minAnsiSlot": "green"
     }
   },
   {
@@ -17579,12 +18243,14 @@
     "tags": [
       "light",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cursor Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f3f3f3",
@@ -17766,6 +18432,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.814106751785841,
+      "minAnsi": 2.6670308375679537,
+      "minAnsiSlot": "brightGreen"
     }
   },
   {
@@ -17775,12 +18446,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cutie Pro.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#181818",
@@ -17962,6 +18636,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.579609455685839,
+      "minAnsi": 6.273312690550735,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -17970,12 +18649,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cyberdyne.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#151144",
@@ -18157,6 +18839,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.148126605437431,
+      "minAnsi": 3.565804895020556,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -18165,12 +18852,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cyberpunk.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#332a57",
@@ -18352,6 +19042,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.357265239330985,
+      "minAnsi": 4.9607825757273964,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -18360,12 +19055,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa-large",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cyberpunk Scarlet Protocol.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#101116",
@@ -18547,6 +19244,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.091109353200948,
+      "minAnsi": 3.62733294554639,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -18555,12 +19257,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dalton Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1b1b1b",
@@ -18742,6 +19447,11 @@
         },
         "oklchCss": "oklch(0.882 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.40226118924566,
+      "minAnsi": 3.333491278285508,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -18750,12 +19460,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dark Modern.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1f1f1f",
@@ -18937,6 +19650,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.263829808673044,
+      "minAnsi": 3.1522225087832743,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -18945,12 +19663,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dark Pastel.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -19132,6 +19853,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 4.1296587927193125,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -19140,12 +19866,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dark+.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1e1e1e",
@@ -19327,6 +20056,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.38100762286638,
+      "minAnsi": 3.2385726181133854,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -19335,12 +20069,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-fail"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Darkermatrix.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#070c0e",
@@ -19522,6 +20257,11 @@
         },
         "oklchCss": "oklch(0.3 0.072 156.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 1.8891474483742787,
+      "minAnsi": 1.4835861328218996,
+      "minAnsiSlot": "brightWhite"
     }
   },
   {
@@ -19530,12 +20270,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-fail"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Darkmatrix.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#070c0e",
@@ -19717,6 +20458,11 @@
         },
         "oklchCss": "oklch(0.445 0.112 154.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 2.4148124528679924,
+      "minAnsi": 1.9971603474964532,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -19724,12 +20470,15 @@
     "slug": "darkside",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Darkside.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222324",
@@ -19911,6 +20660,11 @@
         },
         "oklchCss": "oklch(0.789 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.11184133931825,
+      "minAnsi": 3.702759687367773,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -19919,12 +20673,13 @@
     "isDark": false,
     "tags": [
       "light",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dawnfox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#faf4ed",
@@ -20106,6 +20861,11 @@
         },
         "oklchCss": "oklch(0.939 0.012 259.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.657280748896968,
+      "minAnsi": 1.8622861946636253,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -20114,12 +20874,15 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dayfox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f6f2ee",
@@ -20301,6 +21064,11 @@
         },
         "oklchCss": "oklch(0.948 0.012 59.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.145625973707121,
+      "minAnsi": 3.423765237278193,
+      "minAnsiSlot": "brightCyan"
     }
   },
   {
@@ -20309,12 +21077,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Deep.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#090909",
@@ -20496,6 +21267,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.525578239702938,
+      "minAnsi": 3.6900032458893013,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -20504,12 +21280,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Desert.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#333333",
@@ -20691,6 +21470,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.63465434445799,
+      "minAnsi": 3.3887553194646247,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -20699,12 +21483,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Detuned.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -20886,6 +21673,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.422496589297461,
+      "minAnsi": 4.384187804236253,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -20893,12 +21685,15 @@
     "slug": "dimidium",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dimidium.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#141414",
@@ -21080,6 +21875,11 @@
         },
         "oklchCss": "oklch(0.912 0.006 211)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.243459202609898,
+      "minAnsi": 3.9850072682445767,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -21088,12 +21888,14 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dimmed Monokai.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1f1f1f",
@@ -21275,6 +22077,11 @@
         },
         "oklchCss": "oklch(0.982 0.089 109.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.60660988107443,
+      "minAnsi": 2.7222691485480346,
+      "minAnsiSlot": "brightGreen"
     }
   },
   {
@@ -21284,12 +22091,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Django.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0b2f20",
@@ -21471,6 +22280,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.715626088537237,
+      "minAnsi": 1.9200420702527614,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -21479,12 +22293,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Django Reborn Again.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#051f14",
@@ -21666,6 +22482,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.75252191789214,
+      "minAnsi": 1.8708818052136582,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -21674,12 +22495,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Django Smooth.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#245032",
@@ -21861,6 +22685,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.716509923733199,
+      "minAnsi": 3.039571335883196,
+      "minAnsiSlot": "green"
     }
   },
   {
@@ -21869,12 +22698,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dogxi Misty.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282a36",
@@ -22056,6 +22888,11 @@
         },
         "oklchCss": "oklch(0.958 0.001 106.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.432422229651946,
+      "minAnsi": 4.69287905910325,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -22063,12 +22900,15 @@
     "slug": "doom-one",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Doom One.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282c34",
@@ -22250,6 +23090,11 @@
         },
         "oklchCss": "oklch(0.805 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.82001691967415,
+      "minAnsi": 4.754293214763805,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -22258,12 +23103,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Doom Peacock.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2b2a27",
@@ -22445,6 +23292,11 @@
         },
         "oklchCss": "oklch(0.904 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.040463008158579,
+      "minAnsi": 2.7739983953430367,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -22453,12 +23305,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dot Gov.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#262c35",
@@ -22640,6 +23494,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.790012195641419,
+      "minAnsi": 1.9063800181761583,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -22649,12 +23508,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dracula.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282a36",
@@ -22836,6 +23698,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.359134716531573,
+      "minAnsi": 4.531550766258277,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -22845,12 +23712,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dracula+.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#212121",
@@ -23032,6 +23902,11 @@
         },
         "oklchCss": "oklch(0.978 0.008 106.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.105706312919677,
+      "minAnsi": 5.1240051447700266,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -23040,12 +23915,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Duckbones.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0e101a",
@@ -23227,6 +24105,11 @@
         },
         "oklchCss": "oklch(0.764 0.05 111.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.924986427886736,
+      "minAnsi": 3.8058637916577545,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -23235,12 +24118,15 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Duotone Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1f1d27",
@@ -23422,6 +24308,11 @@
         },
         "oklchCss": "oklch(0.934 0.035 294.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.5638203903938415,
+      "minAnsi": 3.645325501787195,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -23431,12 +24322,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Duskfox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#232136",
@@ -23618,6 +24512,11 @@
         },
         "oklchCss": "oklch(0.915 0.031 289.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.86365608062847,
+      "minAnsi": 5.262685221829585,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -23625,12 +24524,15 @@
     "slug": "earthsong",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Earthsong.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#292520",
@@ -23812,6 +24714,11 @@
         },
         "oklchCss": "oklch(0.972 0.015 110.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.475427990413575,
+      "minAnsi": 3.125435442939281,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -23819,12 +24726,15 @@
     "slug": "electron-highlighter",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Electron Highlighter.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#23283d",
@@ -24006,6 +24916,11 @@
         },
         "oklchCss": "oklch(0.849 0.03 262.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.100651776346242,
+      "minAnsi": 4.3902870108206224,
+      "minAnsiSlot": "white"
     }
   },
   {
@@ -24013,12 +24928,15 @@
     "slug": "elegant",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Elegant.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#292b31",
@@ -24200,6 +25118,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.307474260490578,
+      "minAnsi": 3.6313709940352723,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -24208,12 +25131,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa-large"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Elemental.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#22211d",
@@ -24395,6 +25319,11 @@
         },
         "oklchCss": "oklch(0.967 0.019 52)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 3.80099836701166,
+      "minAnsi": 2.040322350568522,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -24403,12 +25332,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Elementary.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#181818",
@@ -24590,6 +25521,11 @@
         },
         "oklchCss": "oklch(0.526 0.279 301.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.442153532069472,
+      "minAnsi": 2.041646504087658,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -24598,12 +25534,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Embark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1e1c31",
@@ -24785,6 +25724,11 @@
         },
         "oklchCss": "oklch(0.765 0.039 263.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.10503538749257,
+      "minAnsi": 3.642765360796553,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -24793,12 +25737,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Embers Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#16130f",
@@ -24980,6 +25925,11 @@
         },
         "oklchCss": "oklch(0.879 0.009 67.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.685352943486375,
+      "minAnsi": 1.8100227598035976,
+      "minAnsiSlot": "brightGreen"
     }
   },
   {
@@ -24987,12 +25937,13 @@
     "slug": "encom",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/ENCOM.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -25174,6 +26125,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.816038646398305,
+      "minAnsi": 2.444,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -25183,12 +26139,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Espresso.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#323232",
@@ -25370,6 +26328,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.82113382786086,
+      "minAnsi": 2.907925115204386,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -25377,12 +26340,13 @@
     "slug": "espresso-libre",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Espresso Libre.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2a211c",
@@ -25564,6 +26528,11 @@
         },
         "oklchCss": "oklch(0.949 0.003 106.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.822331199348381,
+      "minAnsi": 2.6767588284314123,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -25573,12 +26542,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Everblush.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#141b1e",
@@ -25760,6 +26732,11 @@
         },
         "oklchCss": "oklch(0.812 0.007 185.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.463678735509065,
+      "minAnsi": 5.87584391665661,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -25768,12 +26745,15 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Everforest Dark Hard.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1e2326",
@@ -25955,6 +26935,11 @@
         },
         "oklchCss": "oklch(0.988 0.016 91.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.389409238303774,
+      "minAnsi": 4.700885040833118,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -25964,12 +26949,13 @@
     "tags": [
       "light",
       "low-contrast",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Everforest Light Med.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#efebd4",
@@ -26151,6 +27137,11 @@
         },
         "oklchCss": "oklch(0.988 0.016 91.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.655789215480987,
+      "minAnsi": 1.7645371424739247,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -26160,12 +27151,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fahrenheit.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -26347,6 +27340,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 20.447246276133974,
+      "minAnsi": 1.9721182882538013,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -26354,12 +27352,13 @@
     "slug": "fairyfloss",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fairyfloss.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#5a5475",
@@ -26541,6 +27540,11 @@
         },
         "oklchCss": "oklch(0.977 0.011 106.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.656147192335941,
+      "minAnsi": 1.8745525850950375,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -26549,12 +27553,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Farmhouse Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d2027",
@@ -26736,6 +27742,11 @@
         },
         "oklchCss": "oklch(0.954 0.007 354.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.89900514830556,
+      "minAnsi": 2.176443979144189,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -26744,12 +27755,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Farmhouse Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#e8e4e1",
@@ -26931,6 +27944,11 @@
         },
         "oklchCss": "oklch(0.954 0.007 354.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.89900514830556,
+      "minAnsi": 1.757259726600676,
+      "minAnsiSlot": "brightGreen"
     }
   },
   {
@@ -26938,12 +27956,14 @@
     "slug": "fideloper",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fideloper.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#292f33",
@@ -27125,6 +28145,11 @@
         },
         "oklchCss": "oklch(0.968 0.029 89.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.761096476981518,
+      "minAnsi": 2.3656552689423345,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -27133,12 +28158,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Firefly Traditional.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -27320,6 +28348,11 @@
         },
         "oklchCss": "oklch(0.94 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 19.261973035868383,
+      "minAnsi": 3.8611990287320728,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -27327,12 +28360,13 @@
     "slug": "firefox-dev",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Firefox Dev.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0e1011",
@@ -27514,6 +28548,11 @@
         },
         "oklchCss": "oklch(0.913 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.7427252530694535,
+      "minAnsi": 2.5351482722551846,
+      "minAnsiSlot": "brightCyan"
     }
   },
   {
@@ -27521,12 +28560,14 @@
     "slug": "firewatch",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Firewatch.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1e2027",
@@ -27708,6 +28749,11 @@
         },
         "oklchCss": "oklch(0.931 0.035 287.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.354799503682964,
+      "minAnsi": 3.8883243379757633,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -27716,12 +28762,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fish Tank.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#232537",
@@ -27903,6 +28951,11 @@
         },
         "oklchCss": "oklch(0.988 0.027 127.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.269820457575744,
+      "minAnsi": 2.515732324823122,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -27910,12 +28963,14 @@
     "slug": "flat",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flat.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#002240",
@@ -28097,6 +29152,11 @@
         },
         "oklchCss": "oklch(0.94 0.006 211)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.101124628561992,
+      "minAnsi": 1.8835598420354975,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -28105,12 +29165,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flatland.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d1f21",
@@ -28292,6 +29354,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.350259892661535,
+      "minAnsi": 2.983224496524538,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -28300,12 +29367,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flexoki Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#100f0f",
@@ -28487,6 +29556,11 @@
         },
         "oklchCss": "oklch(0.846 0.014 102.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.979773058854278,
+      "minAnsi": 2.8533476149486487,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -28495,12 +29569,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flexoki Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fffcf0",
@@ -28682,6 +29758,11 @@
         },
         "oklchCss": "oklch(0.846 0.014 102.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 18.623142284944873,
+      "minAnsi": 1.9997046436301846,
+      "minAnsiSlot": "brightBlack"
     }
   },
   {
@@ -28690,12 +29771,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Floraverse.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0e0d15",
@@ -28877,6 +29960,11 @@
         },
         "oklchCss": "oklch(0.971 0.036 89.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.72480043817595,
+      "minAnsi": 1.9532504412357568,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -28886,12 +29974,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Forest Blue.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#051519",
@@ -29073,6 +30163,11 @@
         },
         "oklchCss": "oklch(0.887 0.019 70.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.245458131110349,
+      "minAnsi": 2.421347169146018,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -29081,12 +30176,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa-large",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Framer.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#111111",
@@ -29268,6 +30365,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.216767253166575,
+      "minAnsi": 6.0089274371800805,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -29275,12 +30377,14 @@
     "slug": "front-end-delight",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Front End Delight.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1b1c1d",
@@ -29462,6 +30566,11 @@
         },
         "oklchCss": "oklch(0.573 0.047 65.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.605132393579298,
+      "minAnsi": 2.3161944434553474,
+      "minAnsiSlot": "green"
     }
   },
   {
@@ -29470,12 +30579,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fun Forrest.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#251200",
@@ -29657,6 +30768,11 @@
         },
         "oklchCss": "oklch(0.938 0.092 93.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.231694781477739,
+      "minAnsi": 2.557323542402356,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -29665,12 +30781,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Galaxy.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d2837",
@@ -29852,6 +30970,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.883842395618611,
+      "minAnsi": 2.661171519469546,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -29860,12 +30983,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Galizur.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#071317",
@@ -30047,6 +31172,11 @@
         },
         "oklchCss": "oklch(0.838 0.03 248.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.92405646818393,
+      "minAnsi": 2.52341646176751,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -30056,12 +31186,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ghostty Default Style Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282c34",
@@ -30243,6 +31376,11 @@
         },
         "oklchCss": "oklch(0.937 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.999227678845402,
+      "minAnsi": 3.362407270681048,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -30251,12 +31389,14 @@
     "isDark": false,
     "tags": [
       "light",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f4f4f4",
@@ -30438,6 +31578,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.724390698748637,
+      "minAnsi": 1.7500957400041959,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -30446,12 +31591,14 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#101216",
@@ -30633,6 +31780,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.095203207234266,
+      "minAnsi": 3.5371506775963657,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -30642,12 +31794,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark Colorblind.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0d1117",
@@ -30829,6 +31984,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.261031969575138,
+      "minAnsi": 7.491836480293032,
+      "minAnsiSlot": "green"
     }
   },
   {
@@ -30838,12 +31998,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark Default.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0d1117",
@@ -31025,6 +32188,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.016082890827004,
+      "minAnsi": 7.4497929930639835,
+      "minAnsiSlot": "green"
     }
   },
   {
@@ -31033,12 +32201,15 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark Dimmed.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#22272e",
@@ -31220,6 +32391,11 @@
         },
         "oklchCss": "oklch(0.88 0.021 248.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.601990586445604,
+      "minAnsi": 5.2593014228844295,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -31229,12 +32405,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark High Contrast.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0a0c10",
@@ -31416,6 +32595,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.57358905641591,
+      "minAnsi": 9.20247817686318,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -31425,12 +32609,15 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Light Colorblind.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -31612,6 +32799,11 @@
         },
         "oklchCss": "oklch(0.666 0.018 250.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.652157369459891,
+      "minAnsi": 3.235284115220877,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -31621,12 +32813,15 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Light Default.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -31808,6 +33003,11 @@
         },
         "oklchCss": "oklch(0.666 0.018 250.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.797619425332647,
+      "minAnsi": 3.235284115220877,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -31817,12 +33017,15 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Light High Contrast.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -32004,6 +33207,11 @@
         },
         "oklchCss": "oklch(0.655 0.02 250.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 18.911466369919406,
+      "minAnsi": 3.6066342162960927,
+      "minAnsiSlot": "brightCyan"
     }
   },
   {
@@ -32013,12 +33221,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitLab Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#28262b",
@@ -32200,6 +33411,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.974840721943796,
+      "minAnsi": 4.288462047023658,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -32209,12 +33425,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitLab Dark Grey.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -32396,6 +33615,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.909984431773273,
+      "minAnsi": 4.556266451930614,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -32404,12 +33628,15 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitLab Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fafaff",
@@ -32591,6 +33818,11 @@
         },
         "oklchCss": "oklch(0.309 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.684668567771666,
+      "minAnsi": 4.875209096305248,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -32599,12 +33831,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Glacier.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0c1115",
@@ -32786,6 +34020,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 18.976350018147606,
+      "minAnsi": 2.4372245185839745,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -32793,12 +34032,14 @@
     "slug": "grape",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Grape.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#171423",
@@ -32980,6 +34221,11 @@
         },
         "oklchCss": "oklch(0.698 0.16 292.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.847286081822569,
+      "minAnsi": 3.0025008281247483,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -32988,12 +34234,13 @@
     "isDark": false,
     "tags": [
       "light",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Grass.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#13773d",
@@ -33175,6 +34422,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.890282728037497,
+      "minAnsi": 1.8163650295143616,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -33184,12 +34436,15 @@
     "tags": [
       "dark",
       "vibrant",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Grey Green.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#002a1a",
@@ -33371,6 +34626,11 @@
         },
         "oklchCss": "oklch(0.95 0.01 17.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.600600680657527,
+      "minAnsi": 3.9553687462970113,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -33379,12 +34639,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruber Darker.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#181818",
@@ -33566,6 +34829,11 @@
         },
         "oklchCss": "oklch(0.97 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.965255158215777,
+      "minAnsi": 4.522507826699491,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -33575,12 +34843,14 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282828",
@@ -33762,6 +35032,11 @@
         },
         "oklchCss": "oklch(0.894 0.057 89.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.74706817440964,
+      "minAnsi": 2.6942006289764127,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -33771,12 +35046,14 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Dark Hard.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d2021",
@@ -33958,6 +35235,11 @@
         },
         "oklchCss": "oklch(0.894 0.057 89.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.95176123994368,
+      "minAnsi": 2.996207163429576,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -33967,12 +35249,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fbf1c7",
@@ -34154,6 +35438,11 @@
         },
         "oklchCss": "oklch(0.344 0.007 48.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.21974550734294,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -34163,12 +35452,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Light Hard.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f9f5d7",
@@ -34350,6 +35641,11 @@
         },
         "oklchCss": "oklch(0.344 0.007 48.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.529783804658695,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -34358,12 +35654,15 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Material.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d2021",
@@ -34545,6 +35844,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.070986340601117,
+      "minAnsi": 4.05697671141115,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -34554,12 +35858,15 @@
     "tags": [
       "dark",
       "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Material Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282828",
@@ -34741,6 +36048,11 @@
         },
         "oklchCss": "oklch(0.839 0.056 81.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.156664666774935,
+      "minAnsi": 4.700629435816308,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -34750,12 +36062,14 @@
     "tags": [
       "light",
       "muted",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Material Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fbf1c7",
@@ -34937,6 +36251,11 @@
         },
         "oklchCss": "oklch(0.363 0.041 54.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.385612446038595,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -34945,12 +36264,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Guezwhoz.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d1d1d",
@@ -35132,6 +36454,11 @@
         },
         "oklchCss": "oklch(0.946 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.942746828644987,
+      "minAnsi": 4.756351522702039,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -35141,12 +36468,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hacktober.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#141414",
@@ -35328,6 +36657,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.125078595062687,
+      "minAnsi": 2.6392882012686116,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -35335,12 +36669,15 @@
     "slug": "hardcore",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hardcore.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -35522,6 +36859,11 @@
         },
         "oklchCss": "oklch(0.978 0.008 106.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.163977871523068,
+      "minAnsi": 3.65293820151869,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -35530,12 +36872,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Harper.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#010101",
@@ -35717,6 +37062,11 @@
         },
         "oklchCss": "oklch(0.986 0.023 98.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.410955179933248,
+      "minAnsi": 6.222091885349799,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -35725,12 +37075,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Havn Daggry.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f8f9fb",
@@ -35912,6 +37264,11 @@
         },
         "oklchCss": "oklch(0.892 0.023 272)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.148195918236711,
+      "minAnsi": 1.9637061003022214,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -35920,12 +37277,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Havn Skumring.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#111522",
@@ -36107,6 +37467,11 @@
         },
         "oklchCss": "oklch(0.975 0.029 87.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.161914123850126,
+      "minAnsi": 4.083171817254882,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -36114,12 +37479,15 @@
     "slug": "hax0r-blue",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/HaX0R Blue.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#010515",
@@ -36301,6 +37669,11 @@
         },
         "oklchCss": "oklch(0.997 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.938850149710262,
+      "minAnsi": 8.50346924609034,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -36309,12 +37682,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "vibrant"
+      "vibrant",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/HaX0R Gr33N.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#020f01",
@@ -36496,6 +37871,11 @@
         },
         "oklchCss": "oklch(0.997 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.841199156356613,
+      "minAnsi": 9.390074925552794,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -36505,12 +37885,13 @@
     "tags": [
       "dark",
       "vibrant",
-      "low-contrast"
+      "low-contrast",
+      "wcag-fail"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/HaX0R R3D.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#200101",
@@ -36692,6 +38073,11 @@
         },
         "oklchCss": "oklch(0.997 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 2.756135861744877,
+      "minAnsi": 2.7287710521046282,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -36700,12 +38086,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Heeler.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#211f46",
@@ -36887,6 +38276,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.302796925075487,
+      "minAnsi": 3.9819301718588416,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -36895,12 +38289,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Highway.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222225",
@@ -37082,6 +38478,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.552626888705587,
+      "minAnsi": 1.9736076403036666,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -37089,12 +38490,14 @@
     "slug": "hipster-green",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hipster Green.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#100b05",
@@ -37276,6 +38679,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.016200138054561,
+      "minAnsi": 2.2796548460723143,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -37285,12 +38693,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hivacruz.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#132638",
@@ -37472,6 +38882,11 @@
         },
         "oklchCss": "oklch(0.977 0.011 274.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.348066049215886,
+      "minAnsi": 2.7358525149149737,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -37481,12 +38896,14 @@
     "tags": [
       "dark",
       "vibrant",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Homebrew.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -37668,6 +39085,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.303999999999998,
+      "minAnsi": 1.8270002567023051,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -37676,12 +39098,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hopscotch.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#322931",
@@ -37863,6 +39286,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.922862329946787,
+      "minAnsi": 1.9198229617709017,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -37870,12 +39298,14 @@
     "slug": "hopscotch-256",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hopscotch.256.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#322931",
@@ -38057,6 +39487,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.922862329946787,
+      "minAnsi": 3.3763238959414608,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -38065,12 +39500,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Horizon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1c1e26",
@@ -38252,6 +39690,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.609755119696096,
+      "minAnsi": 4.803410184690108,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -38260,12 +39703,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Horizon Bright.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fdf0ed",
@@ -38447,6 +39892,11 @@
         },
         "oklchCss": "oklch(0.971 0.015 33.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.169317016587108,
+      "minAnsi": 1.7804293458175173,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -38455,12 +39905,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa-large",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hot Dog Stand.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ea3323",
@@ -38642,6 +40094,11 @@
         },
         "oklchCss": "oklch(0.827 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.203122533935382,
+      "minAnsi": 3.9397305912370046,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -38650,12 +40107,15 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hot Dog Stand (Mustard).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffff54",
@@ -38837,6 +40297,11 @@
         },
         "oklchCss": "oklch(0.827 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 19.684018666596657,
+      "minAnsi": 3.9397305912370046,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -38845,12 +40310,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hurtado.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -39032,6 +40500,11 @@
         },
         "oklchCss": "oklch(0.891 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.167515597833736,
+      "minAnsi": 3.456016012905084,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -39040,12 +40513,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hybrid.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#161719",
@@ -39227,6 +40702,11 @@
         },
         "oklchCss": "oklch(0.492 0.016 248.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.324062360375843,
+      "minAnsi": 2.1947354930287886,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -39235,12 +40715,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IBM 5153 CGA.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#141414",
@@ -39422,6 +40904,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.70632091649946,
+      "minAnsi": 1.8547009332170838,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -39430,12 +40917,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IBM 5153 CGA (Black).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -39617,6 +41106,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.040228030240003,
+      "minAnsi": 1.7971044637833282,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -39625,12 +41119,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IC Green PPL.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2c2c2c",
@@ -39812,6 +41309,11 @@
         },
         "oklchCss": "oklch(0.94 0.033 139.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.827225506508844,
+      "minAnsi": 3.7210464701369617,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -39820,12 +41322,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IC Orange PPL.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#262626",
@@ -40007,6 +41511,11 @@
         },
         "oklchCss": "oklch(0.987 0.007 286.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.177019711731324,
+      "minAnsi": 2.776456575756782,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -40017,12 +41526,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Iceberg Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#161821",
@@ -40204,6 +41716,11 @@
         },
         "oklchCss": "oklch(0.871 0.014 277)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.603558844665839,
+      "minAnsi": 6.059976604928213,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -40212,12 +41729,14 @@
     "isDark": false,
     "tags": [
       "light",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Iceberg Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#e8e9ec",
@@ -40399,6 +41918,11 @@
         },
         "oklchCss": "oklch(0.291 0.039 275.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.655044494507733,
+      "minAnsi": 1.0981360061729746,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -40406,12 +41930,14 @@
     "slug": "idea",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Idea.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#202020",
@@ -40593,6 +42119,11 @@
         },
         "oklchCss": "oklch(0.209 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.260353274094703,
+      "minAnsi": 1.089792329672652,
+      "minAnsiSlot": "brightWhite"
     }
   },
   {
@@ -40601,12 +42132,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Idle Toes.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#323232",
@@ -40788,6 +42322,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.82113382786086,
+      "minAnsi": 3.0948288927602916,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -40797,12 +42336,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IR Black.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -40984,6 +42526,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 18.592447937756635,
+      "minAnsi": 7.378729175710199,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -40992,12 +42539,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IRIX Console.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0c0c0c",
@@ -41179,6 +42728,11 @@
         },
         "oklchCss": "oklch(0.961 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.47362420993011,
+      "minAnsi": 2.508064209720709,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -41188,12 +42742,14 @@
     "tags": [
       "dark",
       "vibrant",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IRIX Terminal.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000043",
@@ -41375,6 +42931,11 @@
         },
         "oklchCss": "oklch(0.97 0.193 109.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.352083942454144,
+      "minAnsi": 2.276830533343979,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -41383,12 +42944,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Dark Background.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -41570,6 +43133,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.422496589297461,
+      "minAnsi": 2.091912595931719,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -41578,12 +43146,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Default.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -41765,6 +43335,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 2.1297478518898183,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -41773,12 +43348,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Light Background.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -41960,6 +43537,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7541341704031068,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -41969,12 +43551,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Pastel Dark Background.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -42156,6 +43741,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.422496589297461,
+      "minAnsi": 8.746080804146642,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -42164,12 +43754,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Smoooooth.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#15191f",
@@ -42351,6 +43943,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.860973833303843,
+      "minAnsi": 2.2992902909975608,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -42360,12 +43957,13 @@
     "tags": [
       "dark",
       "low-contrast",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Solarized Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#002b36",
@@ -42547,6 +44145,11 @@
         },
         "oklchCss": "oklch(0.974 0.026 90.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.747877839876171,
+      "minAnsi": 2.789627547583178,
+      "minAnsiSlot": "brightGreen"
     }
   },
   {
@@ -42557,12 +44160,13 @@
       "light",
       "muted",
       "low-contrast",
+      "wcag-aa-large",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Solarized Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fdf6e3",
@@ -42744,6 +44348,11 @@
         },
         "oklchCss": "oklch(0.974 0.026 90.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.129605890896795,
+      "minAnsi": 2.4789959188576267,
+      "minAnsiSlot": "brightCyan"
     }
   },
   {
@@ -42753,12 +44362,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Tango Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -42940,6 +44552,11 @@
         },
         "oklchCss": "oklch(0.958 0.001 106.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 4.105495243097395,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -42949,12 +44566,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Tango Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -43136,6 +44755,11 @@
         },
         "oklchCss": "oklch(0.958 0.001 106.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7589311345907752,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -43144,12 +44768,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Jackie Brown.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2c1d16",
@@ -43331,6 +44957,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.761676622349576,
+      "minAnsi": 1.8880956497869026,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -43339,12 +44970,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Japanesque.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1e1e1e",
@@ -43526,6 +45159,11 @@
         },
         "oklchCss": "oklch(0.769 0.01 125.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.359981327860599,
+      "minAnsi": 2.1319328673578264,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -43536,12 +45174,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Jellybeans.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -43723,6 +45364,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.924656375487373,
+      "minAnsi": 5.247114925613579,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -43730,12 +45376,14 @@
     "slug": "jetbrains-darcula",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/JetBrains Darcula.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#202020",
@@ -43917,6 +45565,11 @@
         },
         "oklchCss": "oklch(0.949 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.260353274094703,
+      "minAnsi": 2.5263016552037088,
+      "minAnsiSlot": "green"
     }
   },
   {
@@ -43924,12 +45577,14 @@
     "slug": "jubi",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Jubi.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#262b33",
@@ -44111,6 +45766,11 @@
         },
         "oklchCss": "oklch(0.914 0.024 240.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.278499933441514,
+      "minAnsi": 2.836661760683309,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -44121,12 +45781,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawa Dragon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#181616",
@@ -44308,6 +45971,11 @@
         },
         "oklchCss": "oklch(0.832 0.007 145.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.757897010440683,
+      "minAnsi": 5.20986364962469,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -44317,12 +45985,13 @@
     "tags": [
       "light",
       "muted",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawa Lotus.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f2ecbc",
@@ -44504,6 +46173,11 @@
         },
         "oklchCss": "oklch(0.402 0.068 282.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.18561286722523,
+      "minAnsi": 2.6961088191135745,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -44514,12 +46188,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawa Wave.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1f1f28",
@@ -44701,6 +46378,11 @@
         },
         "oklchCss": "oklch(0.876 0.039 99.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.26343080332848,
+      "minAnsi": 3.218025386691309,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -44711,12 +46393,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawabones.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1f1f28",
@@ -44898,6 +46583,11 @@
         },
         "oklchCss": "oklch(0.716 0.033 99)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.373953362086501,
+      "minAnsi": 4.674151702669178,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -44907,12 +46597,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Ink.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#14171d",
@@ -45094,6 +46787,11 @@
         },
         "oklchCss": "oklch(0.832 0.005 165)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.729013943415868,
+      "minAnsi": 5.1882351630502175,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -45102,12 +46800,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Mist.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#22262d",
@@ -45289,6 +46990,11 @@
         },
         "oklchCss": "oklch(0.832 0.005 165)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.075942806509774,
+      "minAnsi": 4.3888586458090595,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -45298,12 +47004,14 @@
     "tags": [
       "light",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Pearl.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f2f1ef",
@@ -45485,6 +47193,11 @@
         },
         "oklchCss": "oklch(0.402 0.068 282.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.450395855946788,
+      "minAnsi": 2.86622271752278,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -45494,12 +47207,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Zen.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#090e13",
@@ -45681,6 +47397,11 @@
         },
         "oklchCss": "oklch(0.832 0.005 165)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.582424142032995,
+      "minAnsi": 5.600919201333923,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -45689,12 +47410,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kibble.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0e100a",
@@ -45876,6 +47599,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.866133591756054,
+      "minAnsi": 2.7522766186617584,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -45884,12 +47612,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kitty Default.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -46071,6 +47802,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.461102578439387,
+      "minAnsi": 3.5861553235963606,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -46079,12 +47815,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kitty Low Contrast.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#333333",
@@ -46266,6 +48004,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.63465434445799,
+      "minAnsi": 2.157611092341805,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -46274,12 +48017,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kolorit.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d1a1e",
@@ -46461,6 +48207,11 @@
         },
         "oklchCss": "oklch(0.946 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.670431939489694,
+      "minAnsi": 5.8016740392948085,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -46469,12 +48220,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Konsolas.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#060606",
@@ -46656,6 +48409,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.437324452164141,
+      "minAnsi": 1.790002483544427,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -46665,12 +48423,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kurokula.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#141515",
@@ -46852,6 +48613,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.086706945791647,
+      "minAnsi": 4.025378356397241,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -46860,12 +48626,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Lab Fox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2e2e2e",
@@ -47047,6 +48815,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.579770974464187,
+      "minAnsi": 1.8209701792863637,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -47054,12 +48827,14 @@
     "slug": "laser",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Laser.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#030d18",
@@ -47241,6 +49016,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.467379042591636,
+      "minAnsi": 5.266182758914931,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -47249,12 +49029,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Later This Evening.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -47436,6 +49217,11 @@
         },
         "oklchCss": "oklch(0.813 0.001 197.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.311567916009271,
+      "minAnsi": 1.7892578426663424,
+      "minAnsiSlot": "white"
     }
   },
   {
@@ -47444,12 +49230,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa-large"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Lavandula.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#050014",
@@ -47631,6 +49418,11 @@
         },
         "oklchCss": "oklch(0.699 0.152 279.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.186173978306482,
+      "minAnsi": 1.9806839109135272,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -47638,12 +49430,14 @@
     "slug": "light-owl",
     "isDark": false,
     "tags": [
-      "light"
+      "light",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Light Owl.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fbfbfb",
@@ -47825,6 +49619,11 @@
         },
         "oklchCss": "oklch(0.955 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.880546554670078,
+      "minAnsi": 1.9698200780183888,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -47832,12 +49631,15 @@
     "slug": "liquid-carbon",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Liquid Carbon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#303030",
@@ -48019,6 +49821,11 @@
         },
         "oklchCss": "oklch(0.833 0.017 196.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.113477468370681,
+      "minAnsi": 3.5933185810680217,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -48027,12 +49834,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Liquid Carbon Transparent.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -48214,6 +50024,11 @@
         },
         "oklchCss": "oklch(0.833 0.017 196.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.318514984564993,
+      "minAnsi": 5.717461028726613,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -48222,12 +50037,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Lovelace.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d1f28",
@@ -48409,6 +50227,11 @@
         },
         "oklchCss": "oklch(0.802 0.004 286.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.143077935691124,
+      "minAnsi": 3.5731138219092697,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -48417,12 +50240,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Man Page.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fef49c",
@@ -48604,6 +50429,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 18.63449957390289,
+      "minAnsi": 1.746832493323516,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -48612,12 +50442,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mariana.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#343d46",
@@ -48799,6 +50632,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.17315831400962,
+      "minAnsi": 3.362507076953814,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -48808,12 +50646,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#eaeaea",
@@ -48995,6 +50835,11 @@
         },
         "oklchCss": "oklch(0.885 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.07567402495151,
+      "minAnsi": 1.8513565192760821,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -49004,12 +50849,14 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#232322",
@@ -49191,6 +51038,11 @@
         },
         "oklchCss": "oklch(0.885 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.487679129242336,
+      "minAnsi": 1.7666483386118776,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -49200,12 +51052,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Darker.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#212121",
@@ -49387,6 +51242,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.629422591616345,
+      "minAnsi": 5.155211008020823,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -49396,12 +51256,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Design Colors.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d262a",
@@ -49583,6 +51446,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.843006590335344,
+      "minAnsi": 4.103729106434181,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -49591,12 +51459,14 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Ocean.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0f111a",
@@ -49778,6 +51648,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.153036408356529,
+      "minAnsi": 6.027638935261423,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -49786,12 +51661,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mathias.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -49973,6 +51851,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.938659901217408,
+      "minAnsi": 4.1296587927193125,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -49981,12 +51864,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-fail"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Matrix.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0f191c",
@@ -50168,6 +52052,11 @@
         },
         "oklchCss": "oklch(0.601 0.076 141.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 2.7341061213046127,
+      "minAnsi": 2.1230093292775423,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -50176,12 +52065,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Matte Black.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -50363,6 +52254,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.079026358071443,
+      "minAnsi": 2.0040940574500588,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -50370,12 +52266,15 @@
     "slug": "medallion",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Medallion.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d1908",
@@ -50557,6 +52456,11 @@
         },
         "oklchCss": "oklch(0.896 0.091 78.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.76600262805789,
+      "minAnsi": 3.3313326482129932,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -50566,12 +52470,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Melange Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#292522",
@@ -50753,6 +52660,11 @@
         },
         "oklchCss": "oklch(0.916 0.018 64.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.807387917777396,
+      "minAnsi": 4.772352822083565,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -50761,12 +52673,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Melange Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f1f1f1",
@@ -50948,6 +52862,11 @@
         },
         "oklchCss": "oklch(0.398 0.028 49.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.296780692978805,
+      "minAnsi": 1.143608204672927,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -50957,12 +52876,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mellifluous.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1a1a1a",
@@ -51144,6 +53066,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.449926988251232,
+      "minAnsi": 3.113042083214476,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -51153,12 +53080,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mellow.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#161617",
@@ -51340,6 +53270,11 @@
         },
         "oklchCss": "oklch(0.843 0.028 288.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.793901902326235,
+      "minAnsi": 7.137414070144248,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -51348,12 +53283,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Miasma.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -51535,6 +53472,11 @@
         },
         "oklchCss": "oklch(0.821 0.087 93.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.816782470109812,
+      "minAnsi": 2.296006786476582,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -51543,12 +53485,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Midnight In Mojave.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1e1e1e",
@@ -51730,6 +53675,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.67115667431794,
+      "minAnsi": 4.570605294259279,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -51737,12 +53687,14 @@
     "slug": "mirage",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mirage.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1b2738",
@@ -51924,6 +53876,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.995198775446447,
+      "minAnsi": 7.030176879732231,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -51931,12 +53888,14 @@
     "slug": "misterioso",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Misterioso.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2d3743",
@@ -52118,6 +54077,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.22772465949827,
+      "minAnsi": 2.0136112777163815,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -52126,12 +54090,15 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Operandi.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -52313,6 +54280,11 @@
         },
         "oklchCss": "oklch(0.464 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 7.000313923192387,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -52321,12 +54293,15 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Operandi Tinted.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fbf7f0",
@@ -52508,6 +54483,11 @@
         },
         "oklchCss": "oklch(0.464 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 19.66440576437239,
+      "minAnsi": 6.555095879220985,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -52516,12 +54496,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Vivendi.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -52703,6 +54686,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 7.033137350809865,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -52711,12 +54699,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Vivendi Tinted.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0d0e1c",
@@ -52898,6 +54889,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 19.14841760827243,
+      "minAnsi": 6.413021480459339,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -52905,12 +54901,15 @@
     "slug": "molokai",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Molokai.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -53092,6 +55091,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.758151339882987,
+      "minAnsi": 3.0992432360783924,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -53100,12 +55104,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mona Lisa.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#120b0d",
@@ -53287,6 +55293,11 @@
         },
         "oklchCss": "oklch(0.926 0.1 91.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.694253636827321,
+      "minAnsi": 2.4101140129278913,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -53296,12 +55307,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Classic.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#272822",
@@ -53483,6 +55497,11 @@
         },
         "oklchCss": "oklch(0.995 0.018 113.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.686788462138944,
+      "minAnsi": 3.9268476458761508,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -53492,12 +55511,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2d2a2e",
@@ -53679,6 +55701,11 @@
         },
         "oklchCss": "oklch(0.991 0.003 106.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.792654363958263,
+      "minAnsi": 4.936796222167998,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -53688,12 +55715,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#faf4f2",
@@ -53875,6 +55904,11 @@
         },
         "oklchCss": "oklch(0.268 0.013 320.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.975573957112271,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -53884,12 +55918,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Light Sun.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f8efe7",
@@ -54071,6 +56107,11 @@
         },
         "oklchCss": "oklch(0.271 0.024 320.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.332623545205923,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -54080,12 +56121,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Machine.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#273136",
@@ -54267,6 +56311,11 @@
         },
         "oklchCss": "oklch(0.99 0.014 180.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.974613609909985,
+      "minAnsi": 4.902730566835759,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -54276,12 +56325,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Octagon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282a3a",
@@ -54463,6 +56515,11 @@
         },
         "oklchCss": "oklch(0.955 0.009 188.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.458299554012848,
+      "minAnsi": 4.987836152714678,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -54472,12 +56529,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Ristretto.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2c2525",
@@ -54659,6 +56719,11 @@
         },
         "oklchCss": "oklch(0.97 0.015 7.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.678374839673454,
+      "minAnsi": 5.35197457474938,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -54668,12 +56733,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Spectrum.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -54855,6 +56923,11 @@
         },
         "oklchCss": "oklch(0.967 0.02 305.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.380315292688463,
+      "minAnsi": 5.306193260414424,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -54864,12 +56937,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Remastered.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0c0c0c",
@@ -55051,6 +57127,11 @@
         },
         "oklchCss": "oklch(0.971 0.009 106.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.858423328500182,
+      "minAnsi": 4.668582442464516,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -55059,12 +57140,15 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Soda.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1a1a1a",
@@ -55246,6 +57330,11 @@
         },
         "oklchCss": "oklch(0.971 0.009 106.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.946069785556245,
+      "minAnsi": 4.153720118535801,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -55255,12 +57344,14 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Vivid.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -55442,6 +57533,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.793529016500525,
+      "minAnsi": 2.901063352451498,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -55449,12 +57545,15 @@
     "slug": "monospace-dark",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monospace Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#10151d",
@@ -55636,6 +57735,11 @@
         },
         "oklchCss": "oklch(0.988 0.004 271.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.234515770436655,
+      "minAnsi": 6.156660025847598,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -55643,12 +57747,15 @@
     "slug": "monospace-light",
     "isDark": false,
     "tags": [
-      "light"
+      "light",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monospace Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f4f7fd",
@@ -55830,6 +57937,11 @@
         },
         "oklchCss": "oklch(0.439 0.034 258.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.266353531891272,
+      "minAnsi": 4.505357332424551,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -55838,12 +57950,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Moonfly.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#080808",
@@ -56025,6 +58140,11 @@
         },
         "oklchCss": "oklch(0.919 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.659933999239652,
+      "minAnsi": 6.340238803392663,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -56033,12 +58153,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/N0Tch2K.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -56220,6 +58341,11 @@
         },
         "oklchCss": "oklch(0.842 0.025 61.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.084168958953755,
+      "minAnsi": 2.7708877609388116,
+      "minAnsiSlot": "green"
     }
   },
   {
@@ -56229,12 +58355,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neobones Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0f191f",
@@ -56416,6 +58545,11 @@
         },
         "oklchCss": "oklch(0.705 0.014 167)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.720184438248431,
+      "minAnsi": 5.2426063355364,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -56424,12 +58558,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neobones Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#e5ede6",
@@ -56611,6 +58747,11 @@
         },
         "oklchCss": "oklch(0.434 0.065 135.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.00210015017332,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -56619,12 +58760,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#14161a",
@@ -56806,6 +58949,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.412025090407829,
+      "minAnsi": 1.8277614021550688,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -56814,12 +58962,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neopolitan.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#271f19",
@@ -57001,6 +59151,11 @@
         },
         "oklchCss": "oklch(0.979 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.19996616356344,
+      "minAnsi": 1.8439469394618435,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -57010,12 +59165,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neutron.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1c1e22",
@@ -57197,6 +59354,11 @@
         },
         "oklchCss": "oklch(0.946 0.007 268.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.633660688662903,
+      "minAnsi": 2.981583346060887,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -57205,12 +59367,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Lion V1.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -57392,6 +59557,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.938659901217408,
+      "minAnsi": 3.112959094998821,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -57399,12 +59569,14 @@
     "slug": "night-lion-v2",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Lion V2.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#171717",
@@ -57586,6 +59758,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.338407013867828,
+      "minAnsi": 2.657553969968964,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -57595,12 +59772,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Owl.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#011627",
@@ -57782,6 +59962,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.53940404990579,
+      "minAnsi": 5.258898207615183,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -57791,12 +59976,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Owlish Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -57978,6 +60165,11 @@
         },
         "oklchCss": "oklch(0.703 0.028 268.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.224415580610703,
+      "minAnsi": 1.763208306837443,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -57987,12 +60179,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nightfox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#192330",
@@ -58174,6 +60369,11 @@
         },
         "oklchCss": "oklch(0.919 0.001 286.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.0612149558544,
+      "minAnsi": 3.641362087864303,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -58182,12 +60382,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Niji.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#141515",
@@ -58369,6 +60572,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 18.295244886897216,
+      "minAnsi": 3.8619377765509926,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -58378,12 +60586,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/No Clown Fiesta.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#101010",
@@ -58565,6 +60776,11 @@
         },
         "oklchCss": "oklch(0.754 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.551821344102843,
+      "minAnsi": 4.623111343449321,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -58574,12 +60790,14 @@
     "tags": [
       "light",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/No Clown Fiesta Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#e1e1e1",
@@ -58761,6 +60979,11 @@
         },
         "oklchCss": "oklch(0.337 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.964447543611657,
+      "minAnsi": 1.1114261503387803,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -58769,12 +60992,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nocturnal Winter.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0d0d17",
@@ -58956,6 +61182,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.366059343122442,
+      "minAnsi": 4.817923666381618,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -58965,12 +61196,15 @@
     "tags": [
       "dark",
       "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nord.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2e3440",
@@ -59152,6 +61386,11 @@
         },
         "oklchCss": "oklch(0.951 0.007 260.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.245243340706116,
+      "minAnsi": 3.0529785210102194,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -59161,12 +61400,14 @@
     "tags": [
       "light",
       "muted",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nord Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#e5e9f0",
@@ -59348,6 +61589,11 @@
         },
         "oklchCss": "oklch(0.951 0.007 260.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.522127784995569,
+      "minAnsi": 1.8996402873179057,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -59358,12 +61604,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nord Wave.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#212121",
@@ -59545,6 +61794,11 @@
         },
         "oklchCss": "oklch(0.951 0.007 260.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.919405742162793,
+      "minAnsi": 3.9360445553453185,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -59554,12 +61808,15 @@
     "tags": [
       "dark",
       "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nordfox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2e3440",
@@ -59741,6 +61998,11 @@
         },
         "oklchCss": "oklch(0.942 0.012 259.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.925159685601855,
+      "minAnsi": 3.0529785210102194,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -59749,12 +62011,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Novel.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#dfdbc3",
@@ -59936,6 +62200,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.38876302397345,
+      "minAnsi": 2.602952294010411,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -59944,12 +62213,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/novmbr.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#241d1a",
@@ -60131,6 +62403,11 @@
         },
         "oklchCss": "oklch(0.792 0.024 61.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.596459173796818,
+      "minAnsi": 3.4332338892382444,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -60140,12 +62417,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nvim Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#14161b",
@@ -60327,6 +62607,11 @@
         },
         "oklchCss": "oklch(0.958 0.01 267.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.992604952689101,
+      "minAnsi": 11.62803481704881,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -60336,12 +62621,15 @@
     "tags": [
       "light",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nvim Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#e0e2ea",
@@ -60523,6 +62811,11 @@
         },
         "oklchCss": "oklch(0.958 0.01 267.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.992604952689101,
+      "minAnsi": 4.38830879526678,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -60530,12 +62823,14 @@
     "slug": "obsidian",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Obsidian.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#283033",
@@ -60717,6 +63012,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.463511117836331,
+      "minAnsi": 1.9096858460763608,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -60724,12 +63024,14 @@
     "slug": "ocean",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ocean.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#224fbc",
@@ -60911,6 +63213,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.210109398318694,
+      "minAnsi": 1.7728586167803841,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -60919,12 +63226,14 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Oceanic Material.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1c262b",
@@ -61106,6 +63415,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.208078041725516,
+      "minAnsi": 1.8762051225776182,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -61115,12 +63429,15 @@
     "tags": [
       "dark",
       "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Oceanic Next.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#162c35",
@@ -61302,6 +63619,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.38226331693684,
+      "minAnsi": 4.426151819457613,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -61310,12 +63632,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ollie.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222125",
@@ -61497,6 +63820,11 @@
         },
         "oklchCss": "oklch(0.548 0.092 269.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.954611624675583,
+      "minAnsi": 2.3398842060925027,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -61507,12 +63835,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Dark Two.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#21252b",
@@ -61694,6 +64025,11 @@
         },
         "oklchCss": "oklch(0.925 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.334143005151907,
+      "minAnsi": 5.305273709224045,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -61702,12 +64038,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Double Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282c34",
@@ -61889,6 +64228,11 @@
         },
         "oklchCss": "oklch(0.981 0.005 258.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.465097902118544,
+      "minAnsi": 4.511665445871898,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -61897,12 +64241,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Double Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fafafa",
@@ -62084,6 +64430,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.849451259037943,
+      "minAnsi": 2.2053403905397357,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -62093,12 +64444,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Half Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282c34",
@@ -62280,6 +64634,11 @@
         },
         "oklchCss": "oklch(0.903 0.008 260.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.478412941103713,
+      "minAnsi": 4.380661260730335,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -62289,12 +64648,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Half Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fafafa",
@@ -62476,6 +64837,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.863393658010082,
+      "minAnsi": 1.8993201372831612,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -62486,12 +64852,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Onenord.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2e3440",
@@ -62673,6 +65042,11 @@
         },
         "oklchCss": "oklch(0.951 0.007 260.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.25659652805605,
+      "minAnsi": 3.908267949467851,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -62682,12 +65056,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Onenord Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f7f8fa",
@@ -62869,6 +65245,11 @@
         },
         "oklchCss": "oklch(0.951 0.007 260.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.753443309657749,
+      "minAnsi": 1.960773395813948,
+      "minAnsiSlot": "brightCyan"
     }
   },
   {
@@ -62877,12 +65258,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Operator Mono Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#191919",
@@ -63064,6 +65448,11 @@
         },
         "oklchCss": "oklch(0.992 0.009 106.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.505178272829403,
+      "minAnsi": 3.4289982280025533,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -63073,12 +65462,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Overnight Slumber.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0e1729",
@@ -63260,6 +65652,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.77413845803145,
+      "minAnsi": 7.449058975558719,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -63269,12 +65666,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/owl.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2f2b2c",
@@ -63456,6 +65855,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.386836704362713,
+      "minAnsi": 2.0261237240353873,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -63464,12 +65868,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Oxocarbon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#161616",
@@ -63651,6 +66058,11 @@
         },
         "oklchCss": "oklch(0.967 0.006 264.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.434104834959708,
+      "minAnsi": 5.582387546659929,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -63659,12 +66071,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pale Night Hc.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#3e4251",
@@ -63846,6 +66260,11 @@
         },
         "oklchCss": "oklch(0.683 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.218254940110127,
+      "minAnsi": 3.4895700916505707,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -63854,12 +66273,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pandora.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#141e43",
@@ -64041,6 +66462,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.386273222738254,
+      "minAnsi": 2.70101622647231,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -64048,12 +66474,13 @@
     "slug": "paraiso-dark",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Paraiso Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2f1e2e",
@@ -64235,6 +66662,11 @@
         },
         "oklchCss": "oklch(0.929 0.019 113.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.884989370345183,
+      "minAnsi": 2.946392098596513,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -64243,12 +66675,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Paul Millr.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -64430,6 +66865,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 18.758462357639324,
+      "minAnsi": 4.258308763379725,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -64438,12 +66878,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pencil Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#212121",
@@ -64625,6 +67067,11 @@
         },
         "oklchCss": "oklch(0.958 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.256150521367877,
+      "minAnsi": 2.134569969193749,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -64632,12 +67079,14 @@
     "slug": "pencil-light",
     "isDark": false,
     "tags": [
-      "light"
+      "light",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pencil Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f1f1f1",
@@ -64819,6 +67268,11 @@
         },
         "oklchCss": "oklch(0.958 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.89758745422114,
+      "minAnsi": 1.8000751461131685,
+      "minAnsiSlot": "brightGreen"
     }
   },
   {
@@ -64828,12 +67282,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Peppermint.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -65015,6 +67472,11 @@
         },
         "oklchCss": "oklch(0.904 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.551608808593013,
+      "minAnsi": 5.477832594172877,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -65024,12 +67486,14 @@
     "tags": [
       "dark",
       "vibrant",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Phala Green Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -65211,6 +67675,11 @@
         },
         "oklchCss": "oklch(0.937 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.192967582604293,
+      "minAnsi": 2.0041481377565944,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -65219,12 +67688,15 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Piatto Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -65406,6 +67878,11 @@
         },
         "oklchCss": "oklch(0.961 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.207985564813495,
+      "minAnsi": 3.3777555423987504,
+      "minAnsiSlot": "brightGreen"
     }
   },
   {
@@ -65414,12 +67891,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pierre Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#070707",
@@ -65601,6 +68081,11 @@
         },
         "oklchCss": "oklch(0.988 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 19.466519025872614,
+      "minAnsi": 4.8256228680752455,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -65609,12 +68094,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pierre Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -65796,6 +68283,11 @@
         },
         "oklchCss": "oklch(0.892 0.003 286.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 20.144005124323062,
+      "minAnsi": 2.143605535002515,
+      "minAnsiSlot": "brightCyan"
     }
   },
   {
@@ -65805,12 +68297,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pnevma.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1c1c1c",
@@ -65992,6 +68487,11 @@
         },
         "oklchCss": "oklch(0.952 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.04905582259089,
+      "minAnsi": 3.773370334704558,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -66000,12 +68500,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1a1e28",
@@ -66187,6 +68690,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.461852439701996,
+      "minAnsi": 4.847321037417616,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -66195,12 +68703,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres Darker.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#16161e",
@@ -66382,6 +68893,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.05391830376466,
+      "minAnsi": 5.231935091581677,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -66390,12 +68906,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres Storm.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#252b37",
@@ -66577,6 +69095,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.356688691112879,
+      "minAnsi": 4.129391604797894,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -66585,12 +69108,13 @@
     "isDark": false,
     "tags": [
       "light",
-      "low-contrast"
+      "low-contrast",
+      "wcag-fail"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres White.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fefeff",
@@ -66772,6 +69296,11 @@
         },
         "oklchCss": "oklch(0 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 2.6755931412786236,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -66780,12 +69309,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Popping And Locking.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#181921",
@@ -66967,6 +69499,11 @@
         },
         "oklchCss": "oklch(0.894 0.057 89.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.758172497859183,
+      "minAnsi": 3.19836776044365,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -66975,12 +69512,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Powershell.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#052454",
@@ -67162,6 +69701,11 @@
         },
         "oklchCss": "oklch(0.812 0.003 308.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.020509235779741,
+      "minAnsi": 1.8069630733148705,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -67170,12 +69714,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Primary.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -67357,6 +69903,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.846133950253248,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -67365,12 +69916,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pro.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -67552,6 +70105,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 18.758462357639324,
+      "minAnsi": 2.1233846988883243,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -67560,12 +70118,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pro Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -67747,6 +70307,11 @@
         },
         "oklchCss": "oklch(0.961 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.581691183046004,
+      "minAnsi": 1.8107564747142557,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -67755,12 +70320,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Purple Rain.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#21084a",
@@ -67942,6 +70510,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.009044216336548,
+      "minAnsi": 3.419143255584005,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -67950,12 +70523,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Purplepeter.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2a1a4a",
@@ -68137,6 +70713,11 @@
         },
         "oklchCss": "oklch(0.772 0.053 298.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.919124689259478,
+      "minAnsi": 6.013488481454252,
+      "minAnsiSlot": "brightPurple"
     }
   },
   {
@@ -68145,12 +70726,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rapture.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#111e2a",
@@ -68332,6 +70916,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.239434034482036,
+      "minAnsi": 5.539149438155462,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -68340,12 +70929,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Raycast Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1a1a1a",
@@ -68527,6 +71119,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.40432753274219,
+      "minAnsi": 3.7403436061563577,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -68535,12 +71132,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Raycast Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -68722,6 +71321,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 2.0527520433423008,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -68730,12 +71334,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rebecca.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#292a44",
@@ -68917,6 +71524,11 @@
         },
         "oklchCss": "oklch(0.965 0.01 299.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.248141083660046,
+      "minAnsi": 4.535856617188583,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -68925,12 +71537,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Red Alert.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#762423",
@@ -69112,6 +71726,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.259262636372943,
+      "minAnsi": 2.13003691601782,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -69120,12 +71739,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Red Planet.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -69307,6 +71928,11 @@
         },
         "oklchCss": "oklch(0.822 0.028 37.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.9322520180450375,
+      "minAnsi": 2.009464569074746,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -69314,12 +71940,13 @@
     "slug": "red-sands",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Red Sands.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#7a251e",
@@ -69501,6 +72128,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.064777615087849,
+      "minAnsi": 1.8146520910097659,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -69509,12 +72141,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Relaxed.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#353a44",
@@ -69696,6 +72330,11 @@
         },
         "oklchCss": "oklch(0.976 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.085253934930217,
+      "minAnsi": 2.4968042890653295,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -69704,12 +72343,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "vibrant"
+      "vibrant",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Retro.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -69891,6 +72532,11 @@
         },
         "oklchCss": "oklch(0.685 0.228 142.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.131978314215707,
+      "minAnsi": 6.131978314215707,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -69900,12 +72546,15 @@
     "tags": [
       "dark",
       "vibrant",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Retro Legends.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0d0d0d",
@@ -70087,6 +72736,11 @@
         },
         "oklchCss": "oklch(0.987 0.022 145.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.237276805572264,
+      "minAnsi": 4.072864638260987,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -70095,12 +72749,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rippedcasts.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2b2b2b",
@@ -70282,6 +72938,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.159028077509387,
+      "minAnsi": 2.399531884329739,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -70292,12 +72953,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rose Pine.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#191724",
@@ -70479,6 +73143,11 @@
         },
         "oklchCss": "oklch(0.909 0.03 290)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.388874563413934,
+      "minAnsi": 3.3844729603705237,
+      "minAnsiSlot": "green"
     }
   },
   {
@@ -70488,12 +73157,13 @@
     "tags": [
       "light",
       "muted",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rose Pine Dawn.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#faf4ed",
@@ -70675,6 +73345,11 @@
         },
         "oklchCss": "oklch(0.46 0.063 289.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.657280748896968,
+      "minAnsi": 1.0975949529306095,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -70685,12 +73360,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rose Pine Moon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#232136",
@@ -70872,6 +73550,11 @@
         },
         "oklchCss": "oklch(0.909 0.03 290)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.86365608062847,
+      "minAnsi": 4.2917619544933325,
+      "minAnsiSlot": "green"
     }
   },
   {
@@ -70880,12 +73563,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rouge 2.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#17182b",
@@ -71067,6 +73751,11 @@
         },
         "oklchCss": "oklch(0.932 0.003 286.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.951602240413291,
+      "minAnsi": 2.2199150694626915,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -71075,12 +73764,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-fail"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Royal.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#100815",
@@ -71262,6 +73952,11 @@
         },
         "oklchCss": "oklch(0.674 0.074 301.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 2.344317840825611,
+      "minAnsi": 2.3451310575567703,
+      "minAnsiSlot": "white"
     }
   },
   {
@@ -71271,12 +73966,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ryuuko.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2c3941",
@@ -71458,6 +74155,11 @@
         },
         "oklchCss": "oklch(0.943 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.050443066375967,
+      "minAnsi": 2.1494132766980996,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -71465,12 +74167,14 @@
     "slug": "sakura",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sakura.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#18131e",
@@ -71652,6 +74356,11 @@
         },
         "oklchCss": "oklch(0.82 0.103 297.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.900875593125184,
+      "minAnsi": 3.4860996084218416,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -71660,12 +74369,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa-large",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Scarlet Protocol.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1c153d",
@@ -71847,6 +74558,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 3.722686705931152,
+      "minAnsi": 3.3006754326442884,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -71855,12 +74571,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sea Shells.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#09141b",
@@ -72042,6 +74760,11 @@
         },
         "oklchCss": "oklch(0.934 0.041 62.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.063584268094104,
+      "minAnsi": 1.8838589698587347,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -72051,12 +74774,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seafoam Pastel.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#243435",
@@ -72238,6 +74963,11 @@
         },
         "oklchCss": "oklch(0.907 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.002648131351295,
+      "minAnsi": 2.239137355390117,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -72246,12 +74976,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Abyss.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#050510",
@@ -72433,6 +75166,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.536212085927929,
+      "minAnsi": 5.3902549732184895,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -72441,12 +75179,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Amethyst.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f8f7f6",
@@ -72628,6 +75368,11 @@
         },
         "oklchCss": "oklch(0.193 0.069 300.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.41793666081968,
+      "minAnsi": 1.4148225725009902,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -72636,12 +75381,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Canopy.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0f1714",
@@ -72823,6 +75571,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.557596566165074,
+      "minAnsi": 4.808989972669291,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -72832,12 +75585,14 @@
     "tags": [
       "light",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Carbon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fafafa",
@@ -73019,6 +75774,11 @@
         },
         "oklchCss": "oklch(0 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 20.119467064985724,
+      "minAnsi": 1.4201145053585909,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -73027,12 +75787,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Coral.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -73214,6 +75976,11 @@
         },
         "oklchCss": "oklch(0.231 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.857588663262874,
+      "minAnsi": 1.4115336199566344,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -73222,12 +75989,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Ember.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0a0a0a",
@@ -73409,6 +76179,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.91088278219183,
+      "minAnsi": 5.2446309800109665,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -73417,12 +76192,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Glacier.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f8fafc",
@@ -73604,6 +76381,11 @@
         },
         "oklchCss": "oklch(0.208 0.04 265.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.062933971317335,
+      "minAnsi": 1.4499487730975231,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -73613,12 +76395,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Inkwell.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0a0a0a",
@@ -73800,6 +76585,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.64436712791649,
+      "minAnsi": 5.335962454984181,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -73808,12 +76598,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Ivory.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -73995,6 +76787,11 @@
         },
         "oklchCss": "oklch(0.26 0.06 251.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.537529558868556,
+      "minAnsi": 1.4115336199566344,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -74003,12 +76800,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Nightfall.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0a0a0f",
@@ -74190,6 +76990,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.565974491498903,
+      "minAnsi": 5.232225084839507,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -74198,12 +77003,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Phosphor.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0c0c0c",
@@ -74385,6 +77193,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.64757704069159,
+      "minAnsi": 5.181976866215178,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -74393,12 +77206,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Pulse.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -74580,6 +77396,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 18.733663902900595,
+      "minAnsi": 4.904182567407399,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -74588,12 +77409,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Ultraviolet.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0b0014",
@@ -74775,6 +77599,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.0221059320603,
+      "minAnsi": 5.430870724668883,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -74783,12 +77612,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Voltage.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0a0a0a",
@@ -74970,6 +77802,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.37272426550883,
+      "minAnsi": 5.2446309800109665,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -74978,12 +77815,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Wavelength.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0d1117",
@@ -75165,6 +78005,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.016082890827004,
+      "minAnsi": 5.004239886748117,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -75172,12 +78017,15 @@
     "slug": "selenized-black",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Selenized Black.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#181818",
@@ -75359,6 +78207,11 @@
         },
         "oklchCss": "oklch(0.901 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.049775236144459,
+      "minAnsi": 4.793224199856737,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -75366,12 +78219,14 @@
     "slug": "selenized-dark",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Selenized Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#103c48",
@@ -75553,6 +78408,11 @@
         },
         "oklchCss": "oklch(0.872 0.015 202)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.070714842078603,
+      "minAnsi": 3.714015544132306,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -75560,12 +78420,13 @@
     "slug": "selenized-light",
     "isDark": false,
     "tags": [
-      "light"
+      "light",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Selenized Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fbf3db",
@@ -75747,6 +78608,11 @@
         },
         "oklchCss": "oklch(0.407 0.026 219.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.368789066610502,
+      "minAnsi": 1.1533436464304379,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -75755,12 +78621,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seoulbones Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#4b4b4b",
@@ -75942,6 +78810,11 @@
         },
         "oklchCss": "oklch(0.732 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.4228523951217955,
+      "minAnsi": 3.454928793150346,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -75950,12 +78823,13 @@
     "isDark": false,
     "tags": [
       "light",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seoulbones Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#e2e2e2",
@@ -76137,6 +79011,11 @@
         },
         "oklchCss": "oklch(0.569 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.75486124007544,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -76145,12 +79024,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seti.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#111213",
@@ -76332,6 +79214,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.807341305446808,
+      "minAnsi": 3.253769633312443,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -76340,12 +79227,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Shades Of Purple.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1e1d40",
@@ -76527,6 +79416,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.092165121757127,
+      "minAnsi": 2.948324833991461,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -76535,12 +79429,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-fail"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Shaman.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#001015",
@@ -76722,6 +79617,11 @@
         },
         "oklchCss": "oklch(0.894 0.145 174.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 2.4412048193974893,
+      "minAnsi": 2.4412048193974893,
+      "minAnsiSlot": "white"
     }
   },
   {
@@ -76730,12 +79630,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Slate.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -76917,6 +79818,11 @@
         },
         "oklchCss": "oklch(0.907 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.341918037634301,
+      "minAnsi": 2.02361972704601,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -76924,12 +79830,14 @@
     "slug": "sleepy-hollow",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sleepy Hollow.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#121214",
@@ -77111,6 +80019,11 @@
         },
         "oklchCss": "oklch(0.831 0.042 90.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.997767716208966,
+      "minAnsi": 3.3168617734467447,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -77119,12 +80032,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Smyck.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1b1b1b",
@@ -77306,6 +80222,11 @@
         },
         "oklchCss": "oklch(0.976 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.077909234705352,
+      "minAnsi": 3.14840256472224,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -77314,12 +80235,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Snazzy.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1e1f29",
@@ -77501,6 +80425,11 @@
         },
         "oklchCss": "oklch(0.946 0.001 106.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.772605398339516,
+      "minAnsi": 4.699429687603196,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -77509,12 +80438,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Snazzy Soft.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282a36",
@@ -77696,6 +80628,11 @@
         },
         "oklchCss": "oklch(0.958 0.001 106.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.432422229651946,
+      "minAnsi": 4.69287905910325,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -77704,12 +80641,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Soft Server.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#242626",
@@ -77891,6 +80830,11 @@
         },
         "oklchCss": "oklch(0.896 0.015 186.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.879429518296938,
+      "minAnsi": 3.2630057380542925,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -77899,12 +80843,14 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Darcula.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#3d3f41",
@@ -78086,6 +81032,11 @@
         },
         "oklchCss": "oklch(0.878 0.007 208.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.334558680660561,
+      "minAnsi": 2.231211230420756,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -78094,12 +81045,15 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Dark Higher Contrast.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#001e27",
@@ -78281,6 +81235,11 @@
         },
         "oklchCss": "oklch(0.967 0.033 91.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.986231218796952,
+      "minAnsi": 3.1249182198659002,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -78290,12 +81249,13 @@
     "tags": [
       "dark",
       "low-contrast",
+      "wcag-aa-large",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Dark Patched.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#001e27",
@@ -78477,6 +81437,11 @@
         },
         "oklchCss": "oklch(0.967 0.033 91.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.292316518586955,
+      "minAnsi": 2.4203347306846625,
+      "minAnsiSlot": "brightGreen"
     }
   },
   {
@@ -78486,12 +81451,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Osaka Night.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1a1b26",
@@ -78673,6 +81641,11 @@
         },
         "oklchCss": "oklch(0.846 0.061 274.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.586955488631288,
+      "minAnsi": 6.459598504862066,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -78681,12 +81654,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sonokai.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2c2e34",
@@ -78868,6 +81844,11 @@
         },
         "oklchCss": "oklch(0.913 0.001 286.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.482533479806625,
+      "minAnsi": 4.520821168756997,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -78876,12 +81857,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacedust.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0a1e24",
@@ -79063,6 +82046,11 @@
         },
         "oklchCss": "oklch(0.996 0.018 110)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.541950548199733,
+      "minAnsi": 2.1740694075162947,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -79071,12 +82059,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#20242d",
@@ -79258,6 +82248,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.81333937048496,
+      "minAnsi": 2.951986272858967,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -79267,12 +82262,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray Bright.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2a2e3a",
@@ -79454,6 +82451,11 @@
         },
         "oklchCss": "oklch(0.976 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.2072193118411,
+      "minAnsi": 2.942947011543349,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -79461,12 +82463,15 @@
     "slug": "spacegray-eighties",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray Eighties.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -79648,6 +82653,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.181159560092757,
+      "minAnsi": 4.194744394376575,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -79656,12 +82666,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray Eighties Dull.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -79843,6 +82856,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.309085578355408,
+      "minAnsi": 3.0356889444505972,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -79852,12 +82870,14 @@
     "tags": [
       "dark",
       "vibrant",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spiderman.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1b1d1e",
@@ -80039,6 +83059,11 @@
         },
         "oklchCss": "oklch(0.998 0.008 106.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.184335675121535,
+      "minAnsi": 2.100683552485315,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -80046,12 +83071,14 @@
     "slug": "spring",
     "isDark": false,
     "tags": [
-      "light"
+      "light",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spring.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -80233,6 +83260,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.462734156064165,
+      "minAnsi": 1.8096338111861874,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -80241,12 +83273,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Square.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1a1a1a",
@@ -80428,6 +83462,11 @@
         },
         "oklchCss": "oklch(0.913 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.660552557276896,
+      "minAnsi": 2.6436825037748144,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -80435,12 +83474,13 @@
     "slug": "squirrelsong-dark",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Squirrelsong Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#372920",
@@ -80622,6 +83662,11 @@
         },
         "oklchCss": "oklch(0.889 0.047 62)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.2777803385124376,
+      "minAnsi": 2.5998690630068184,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -80630,12 +83675,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Srcery.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1c1b19",
@@ -80817,6 +83865,11 @@
         },
         "oklchCss": "oklch(0.938 0.053 82.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.317294396222751,
+      "minAnsi": 3.7256622149750083,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -80825,12 +83878,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Starlight.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#242424",
@@ -81012,6 +84068,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.522910417680388,
+      "minAnsi": 4.00029384939123,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -81019,12 +84080,15 @@
     "slug": "sublette",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sublette.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#202535",
@@ -81206,6 +84270,11 @@
         },
         "oklchCss": "oklch(0.996 0.022 106.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.660461971394787,
+      "minAnsi": 4.501947279840205,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -81214,12 +84283,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Subliminal.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282c35",
@@ -81401,6 +84473,11 @@
         },
         "oklchCss": "oklch(0.87 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.433021582474693,
+      "minAnsi": 3.8836571842058842,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -81408,12 +84485,14 @@
     "slug": "sugarplum",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sugarplum.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#111147",
@@ -81595,6 +84674,11 @@
         },
         "oklchCss": "oklch(0.691 0.195 303)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.685816665804914,
+      "minAnsi": 5.0298091929605615,
+      "minAnsiSlot": "white"
     }
   },
   {
@@ -81604,12 +84688,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sundried.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1a1818",
@@ -81791,6 +84877,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.676827770199447,
+      "minAnsi": 2.2853991383298307,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -81799,12 +84890,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sunset Drive.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#0f0f1a",
@@ -81986,6 +85080,11 @@
         },
         "oklchCss": "oklch(0.981 0.009 286.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.442942518787937,
+      "minAnsi": 4.922417664339642,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -81994,12 +85093,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Symfonic.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -82181,6 +85283,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 4.3325819930115825,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -82189,12 +85296,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Synthwave.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -82376,6 +85486,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.730931171766903,
+      "minAnsi": 5.445853667182818,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -82384,12 +85499,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Synthwave Alpha.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#241b30",
@@ -82571,6 +85688,11 @@
         },
         "oklchCss": "oklch(0.957 0.02 106.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.582969904906374,
+      "minAnsi": 2.027201120274542,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -82579,12 +85701,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Synthwave Everything.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2a2139",
@@ -82766,6 +85891,11 @@
         },
         "oklchCss": "oklch(0.997 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.324266084774642,
+      "minAnsi": 3.5924708673024863,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -82775,12 +85905,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tango Adapted.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -82962,6 +86094,11 @@
         },
         "oklchCss": "oklch(0.973 0.003 106.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7728242657985633,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -82971,12 +86108,14 @@
     "tags": [
       "light",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tango Half Adapted.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -83158,6 +86297,11 @@
         },
         "oklchCss": "oklch(0.967 0.003 106.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7459296405192763,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -83166,12 +86310,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tearout.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#34392d",
@@ -83353,6 +86500,11 @@
         },
         "oklchCss": "oklch(0.687 0.082 80.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.295737558769867,
+      "minAnsi": 3.56188855262931,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -83361,12 +86513,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Teerb.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#262626",
@@ -83548,6 +86703,11 @@
         },
         "oklchCss": "oklch(0.952 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.81167442210102,
+      "minAnsi": 5.486634636507461,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -83557,12 +86717,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Terafox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#152528",
@@ -83744,6 +86907,11 @@
         },
         "oklchCss": "oklch(0.949 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 13.051867566503034,
+      "minAnsi": 3.465125748737453,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -83752,12 +86920,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Terminal Basic.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -83939,6 +87109,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7775640487086088,
+      "minAnsiSlot": "brightCyan"
     }
   },
   {
@@ -83947,12 +87122,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Terminal Basic Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d1e1d",
@@ -84134,6 +87311,11 @@
         },
         "oklchCss": "oklch(0.946 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.72383121302713,
+      "minAnsi": 2.8602520349675142,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -84142,12 +87324,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Thayer Bright.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1b1d1e",
@@ -84329,6 +87513,11 @@
         },
         "oklchCss": "oklch(0.978 0.008 106.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.932465003618038,
+      "minAnsi": 2.7560749420902746,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -84336,12 +87525,14 @@
     "slug": "the-hulk",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/The Hulk.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1b1d1e",
@@ -84523,6 +87714,11 @@
         },
         "oklchCss": "oklch(0.923 0.007 115.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.252014407932334,
+      "minAnsi": 1.9171854932336487,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -84531,12 +87727,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tinacious Design Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d1d26",
@@ -84718,6 +87917,11 @@
         },
         "oklchCss": "oklch(0.884 0.04 284)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.62116497814062,
+      "minAnsi": 4.835816637339798,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -84726,12 +87930,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tinacious Design Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f8f8ff",
@@ -84913,6 +88119,11 @@
         },
         "oklchCss": "oklch(0.884 0.04 284)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.814194778398958,
+      "minAnsi": 1.8078987379182248,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -84922,12 +88133,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1a1b26",
@@ -85109,6 +88323,11 @@
         },
         "oklchCss": "oklch(0.846 0.061 274.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.586955488631288,
+      "minAnsi": 6.459598504862066,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -85118,12 +88337,13 @@
     "tags": [
       "light",
       "low-contrast",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Day.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#e1e2e7",
@@ -85305,6 +88525,11 @@
         },
         "oklchCss": "oklch(0.512 0.156 264.1)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.524626461068713,
+      "minAnsi": 1.0683271955280342,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -85314,12 +88539,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Moon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#222436",
@@ -85501,6 +88729,11 @@
         },
         "oklchCss": "oklch(0.869 0.049 271.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.258978159440368,
+      "minAnsi": 4.611378263479609,
+      "minAnsiSlot": "white"
     }
   },
   {
@@ -85510,12 +88743,15 @@
     "tags": [
       "dark",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Night.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1a1b26",
@@ -85697,6 +88933,11 @@
         },
         "oklchCss": "oklch(0.846 0.061 274.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.586955488631288,
+      "minAnsi": 6.459598504862066,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -85705,12 +88946,15 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Storm.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#24283b",
@@ -85892,6 +89136,11 @@
         },
         "oklchCss": "oklch(0.846 0.061 274.8)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.022797368046596,
+      "minAnsi": 5.505232212499105,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -85900,12 +89149,14 @@
     "isDark": false,
     "tags": [
       "light",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -86087,6 +89338,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.462734156064165,
+      "minAnsi": 1.8630433291508341,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -86096,12 +89352,15 @@
     "tags": [
       "dark",
       "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1d1f21",
@@ -86283,6 +89542,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.802581130534,
+      "minAnsi": 4.455907574271388,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -86293,12 +89557,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Blue.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#002451",
@@ -86480,6 +89747,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.315423933501545,
+      "minAnsi": 7.73855958107012,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -86490,12 +89762,15 @@
       "dark",
       "muted",
       "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Bright.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -86677,6 +89952,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.455715087925668,
+      "minAnsi": 5.043889156185626,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -86685,12 +89965,14 @@
     "isDark": true,
     "tags": [
       "dark",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Burns.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#151515",
@@ -86872,6 +90154,11 @@
         },
         "oklchCss": "oklch(0.97 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.189429486456223,
+      "minAnsi": 2.087171779793005,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -86881,12 +90168,15 @@
     "tags": [
       "dark",
       "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Eighties.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#2d2d2d",
@@ -87068,6 +90358,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.57577203782333,
+      "minAnsi": 4.586348251671749,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -87075,12 +90370,13 @@
     "slug": "toy-chest",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Toy Chest.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#24364b",
@@ -87262,6 +90558,11 @@
         },
         "oklchCss": "oklch(0.873 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.12514029490876,
+      "minAnsi": 1.843454967804912,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -87270,12 +90571,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/traffic.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#272c30",
@@ -87457,6 +90760,11 @@
         },
         "oklchCss": "oklch(0.86 0.024 61.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.492577249349715,
+      "minAnsi": 2.113054016108762,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -87465,12 +90773,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa-large"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Treehouse.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#191919",
@@ -87652,6 +90961,11 @@
         },
         "oklchCss": "oklch(0.858 0.175 88.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 3.3711625379246564,
+      "minAnsi": 2.437084401192714,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -87661,12 +90975,14 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Twilight.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#141414",
@@ -87848,6 +91164,11 @@
         },
         "oklchCss": "oklch(0.989 0.055 107.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 17.989775991412532,
+      "minAnsi": 1.9703046715158683,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -87856,12 +91177,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ubuntu.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#300a24",
@@ -88043,6 +91366,11 @@
         },
         "oklchCss": "oklch(0.949 0.003 106.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.132233235942888,
+      "minAnsi": 2.6703044473030277,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -88052,12 +91380,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ultra Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -88239,6 +91570,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 7.3383170961873185,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -88246,12 +91582,15 @@
     "slug": "ultra-violent",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ultra Violent.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#242728",
@@ -88433,6 +91772,11 @@
         },
         "oklchCss": "oklch(0.981 0.005 106.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.357224924929971,
+      "minAnsi": 4.051063468277669,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -88441,12 +91785,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Under The Sea.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#011116",
@@ -88628,6 +91974,11 @@
         },
         "oklchCss": "oklch(0.894 0.145 174.7)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 19.212197278249175,
+      "minAnsi": 2.4230908129799236,
+      "minAnsiSlot": "white"
     }
   },
   {
@@ -88635,12 +91986,14 @@
     "slug": "unikitty",
     "isDark": false,
     "tags": [
-      "light"
+      "light",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Unikitty.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ff8cd9",
@@ -88822,6 +92175,11 @@
         },
         "oklchCss": "oklch(0.977 0.019 328.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.377538846094247,
+      "minAnsi": 1.7705259390552852,
+      "minAnsiSlot": "brightYellow"
     }
   },
   {
@@ -88830,12 +92188,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/urban.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#312e39",
@@ -89017,6 +92376,11 @@
         },
         "oklchCss": "oklch(0.747 0.035 49.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.843439340558473,
+      "minAnsi": 1.819986830276663,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -89025,12 +92389,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa-large"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Urple.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1b1b23",
@@ -89212,6 +92577,11 @@
         },
         "oklchCss": "oklch(0.775 0.131 297.2)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.306866255422723,
+      "minAnsi": 2.279660237886026,
+      "minAnsiSlot": "purple"
     }
   },
   {
@@ -89221,12 +92591,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vague.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#141415",
@@ -89408,6 +92781,11 @@
         },
         "oklchCss": "oklch(0.879 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.581186263208878,
+      "minAnsi": 5.298736117887128,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -89416,12 +92794,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vaughn.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#25234f",
@@ -89603,6 +92983,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.58140024072453,
+      "minAnsi": 2.0616588151758917,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -89611,12 +92996,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vercel.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#101010",
@@ -89798,6 +93186,11 @@
         },
         "oklchCss": "oklch(0.997 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 18.230259212984933,
+      "minAnsi": 4.082538788719744,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -89807,12 +93200,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vesper.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#101010",
@@ -89994,6 +93390,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 19.028110547666497,
+      "minAnsi": 7.276577801701197,
+      "minAnsiSlot": "white"
     }
   },
   {
@@ -90002,12 +93403,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vibrant Ink.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -90189,6 +93592,11 @@
         },
         "oklchCss": "oklch(0.922 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 2.444,
+      "minAnsiSlot": "brightBlue"
     }
   },
   {
@@ -90198,12 +93606,14 @@
     "tags": [
       "light",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vimbones.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f0f0ca",
@@ -90385,6 +93795,11 @@
         },
         "oklchCss": "oklch(0.475 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.526673507558153,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -90393,12 +93808,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "low-contrast"
+      "low-contrast",
+      "wcag-aa-large"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Violet Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1c1d1f",
@@ -90580,6 +93996,11 @@
         },
         "oklchCss": "oklch(0.826 0.013 91.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 4.189220737359681,
+      "minAnsi": 2.9727791091037665,
+      "minAnsiSlot": "brightRed"
     }
   },
   {
@@ -90587,12 +94008,13 @@
     "slug": "violet-light",
     "isDark": false,
     "tags": [
-      "light"
+      "light",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Violet Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#fcf4dc",
@@ -90774,6 +94196,11 @@
         },
         "oklchCss": "oklch(0.826 0.013 91.5)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 5.335951445041022,
+      "minAnsi": 2.858219229105977,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -90782,12 +94209,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Violite.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#241c36",
@@ -90969,6 +94399,11 @@
         },
         "oklchCss": "oklch(0.984 0.003 247.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 14.606541287543338,
+      "minAnsi": 5.124584655833913,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -90976,12 +94411,13 @@
     "slug": "warm-neon",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Warm Neon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#404040",
@@ -91163,6 +94599,11 @@
         },
         "oklchCss": "oklch(0.842 0.025 61.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.678634147244857,
+      "minAnsi": 1.85039566330447,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -91171,12 +94612,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wez.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -91358,6 +94802,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.015715656764469,
+      "minAnsi": 3.557585470026421,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -91365,12 +94814,14 @@
     "slug": "whimsy",
     "isDark": true,
     "tags": [
-      "dark"
+      "dark",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Whimsy.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#29283b",
@@ -91552,6 +95003,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.911844163669688,
+      "minAnsi": 4.683836383729729,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -91560,12 +95016,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wild Cherry.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1f1726",
@@ -91747,6 +95206,11 @@
         },
         "oklchCss": "oklch(0.717 0.119 13.9)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.800135652275895,
+      "minAnsi": 3.082915872408531,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -91755,12 +95219,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wilmersdorf.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#282b33",
@@ -91942,6 +95409,11 @@
         },
         "oklchCss": "oklch(0.867 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.28688211956369,
+      "minAnsi": 4.2254933570537805,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -91951,12 +95423,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wombat.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#171717",
@@ -92138,6 +95613,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 12.835889125683005,
+      "minAnsi": 6.069440212997957,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -92146,12 +95626,13 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wryan.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#101010",
@@ -92333,6 +95814,11 @@
         },
         "oklchCss": "oklch(0.808 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 6.6437742847642784,
+      "minAnsi": 2.4654380362095925,
+      "minAnsiSlot": "blue"
     }
   },
   {
@@ -92341,12 +95827,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#292a30",
@@ -92528,6 +96017,11 @@
         },
         "oklchCss": "oklch(0.904 0.001 286.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.74075405420282,
+      "minAnsi": 4.926427134221313,
+      "minAnsiSlot": "cyan"
     }
   },
   {
@@ -92537,12 +96031,15 @@
     "tags": [
       "dark",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Dark hc.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1f1f24",
@@ -92724,6 +96221,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 16.409700712545998,
+      "minAnsi": 7.164334445585376,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -92732,12 +96234,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -92919,6 +96423,11 @@
         },
         "oklchCss": "oklch(0.269 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 15.133529408889883,
+      "minAnsi": 1.4808153836317437,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -92927,12 +96436,14 @@
     "isDark": false,
     "tags": [
       "light",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Light hc.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -93114,6 +96625,11 @@
         },
         "oklchCss": "oklch(0 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.4808153836317437,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -93122,12 +96638,14 @@
     "isDark": true,
     "tags": [
       "dark",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode WWDC.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#292c36",
@@ -93309,6 +96827,11 @@
         },
         "oklchCss": "oklch(0.931 0.004 271.4)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 11.367411063502368,
+      "minAnsi": 2.4802130228261756,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -93318,12 +96841,14 @@
     "tags": [
       "light",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenbones.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f0edec",
@@ -93505,6 +97030,11 @@
         },
         "oklchCss": "oklch(0.473 0.025 237.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.605791939903588,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -93513,12 +97043,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenbones Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#1c1917",
@@ -93700,6 +97233,11 @@
         },
         "oklchCss": "oklch(0.646 0.011 238.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.166992692840367,
+      "minAnsi": 5.148083003418225,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -93709,12 +97247,14 @@
     "tags": [
       "light",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenbones Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#f0edec",
@@ -93896,6 +97436,11 @@
         },
         "oklchCss": "oklch(0.473 0.025 237.3)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.605791939903588,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   },
   {
@@ -93905,12 +97450,14 @@
     "tags": [
       "dark",
       "muted",
+      "wcag-aaa",
+      "wcag-aa",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenburn.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#3f3f3f",
@@ -94092,6 +97639,11 @@
         },
         "oklchCss": "oklch(1 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 7.598464114749242,
+      "minAnsi": 1.803190077291759,
+      "minAnsiSlot": "red"
     }
   },
   {
@@ -94101,12 +97653,15 @@
     "tags": [
       "dark",
       "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible",
       "popular"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenburned.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#404040",
@@ -94288,6 +97843,11 @@
         },
         "oklchCss": "oklch(0.75 0.056 81.6)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 8.247013993858703,
+      "minAnsi": 3.0521629235417307,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -94296,12 +97856,15 @@
     "isDark": true,
     "tags": [
       "dark",
-      "muted"
+      "muted",
+      "wcag-aaa",
+      "wcag-aa",
+      "ansi-legible"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenwritten Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#191919",
@@ -94483,6 +98046,11 @@
         },
         "oklchCss": "oklch(0.647 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 9.158101920932046,
+      "minAnsi": 5.175562388137477,
+      "minAnsiSlot": "yellow"
     }
   },
   {
@@ -94492,12 +98060,14 @@
     "tags": [
       "light",
       "muted",
-      "high-contrast"
+      "high-contrast",
+      "wcag-aaa",
+      "wcag-aa"
     ],
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenwritten Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-20T11:34:00.030Z",
+    "updatedAt": "2026-04-21T01:55:56.860Z",
     "colors": {
       "background": {
         "hex": "#eeeeee",
@@ -94679,6 +98249,11 @@
         },
         "oklchCss": "oklch(0.475 0 0)"
       }
+    },
+    "contrast": {
+      "fgOnBg": 10.572181156861216,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
     }
   }
 ]

--- a/src/classify.ts
+++ b/src/classify.ts
@@ -1,5 +1,31 @@
-import type { Colors, TerminalColorTheme } from './types.js';
+import type { ColorKey, Colors, TerminalColorTheme } from './types.js';
 import { COLOR_KEYS } from './types.js';
+
+// 16 ANSI slots (no bg/fg/cursor/selection). minAnsi contrast runs over a
+// subset of these depending on isDark — see DARK_BG_BLENDS / LIGHT_BG_BLENDS.
+const ANSI_KEYS: readonly ColorKey[] = [
+  'black',
+  'red',
+  'green',
+  'yellow',
+  'blue',
+  'purple',
+  'cyan',
+  'white',
+  'brightBlack',
+  'brightRed',
+  'brightGreen',
+  'brightYellow',
+  'brightBlue',
+  'brightPurple',
+  'brightCyan',
+  'brightWhite',
+] as const;
+
+// ANSI slots that are expected to be near-bg by convention — excluded from the
+// "worst ANSI slot vs bg" calculation so we don't false-flag well-formed themes.
+const DARK_BG_BLENDS: ReadonlySet<ColorKey> = new Set(['black', 'brightBlack']);
+const LIGHT_BG_BLENDS: ReadonlySet<ColorKey> = new Set(['white', 'brightWhite']);
 
 // Substring keywords that flag a theme as "popular". Intentionally liberal —
 // we'd rather over-tag than miss well-known families. Covered variants:
@@ -46,7 +72,8 @@ function averageChroma(colors: Colors): number {
   return sum / COLOR_KEYS.length;
 }
 
-function wcagContrast(bgHex: string, fgHex: string): number {
+/** WCAG 2.x relative luminance, then contrast ratio. Exported for tests. */
+export function wcagContrast(aHex: string, bHex: string): number {
   const lum = (hex: string): number => {
     const h = hex.slice(1);
     const part = (i: number): number => {
@@ -58,26 +85,70 @@ function wcagContrast(bgHex: string, fgHex: string): number {
     const b = part(4);
     return 0.2126 * r + 0.7152 * g + 0.0722 * b;
   };
-  const l1 = lum(bgHex);
-  const l2 = lum(fgHex);
+  const l1 = lum(aHex);
+  const l2 = lum(bHex);
   const [hi, lo] = l1 > l2 ? [l1, l2] : [l2, l1];
   return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Worst-case contrast of any ANSI slot against the background, excluding the
+ * slot(s) that conventionally blend with the background (see DARK_BG_BLENDS /
+ * LIGHT_BG_BLENDS). Returns the ratio AND the slot that hit the minimum, so
+ * tests can pin exact values.
+ */
+function minAnsiContrast(colors: Colors, isDark: boolean): { ratio: number; slot: ColorKey } {
+  const blends = isDark ? DARK_BG_BLENDS : LIGHT_BG_BLENDS;
+  const bgHex = colors.background.hex;
+  let min = Infinity;
+  let minSlot: ColorKey = 'foreground';
+  for (const k of ANSI_KEYS) {
+    if (blends.has(k)) continue;
+    const ratio = wcagContrast(bgHex, colors[k].hex);
+    if (ratio < min) {
+      min = ratio;
+      minSlot = k;
+    }
+  }
+  return { ratio: min, slot: minSlot };
+}
+
+function contrastTags(fgOnBg: number, minAnsi: number): string[] {
+  const tags: string[] = [];
+  // Existing coarse tags — kept for backwards compat with downstream
+  // consumers that already filter on them.
+  if (fgOnBg > 10) tags.push('high-contrast');
+  else if (fgOnBg < 5) tags.push('low-contrast');
+  // WCAG 2.x body-text tiers (foreground vs background only — does NOT
+  // certify ANSI-slot legibility; use `ansi-legible` for that).
+  if (fgOnBg >= 7) tags.push('wcag-aaa');
+  if (fgOnBg >= 4.5) tags.push('wcag-aa');
+  else if (fgOnBg >= 3) tags.push('wcag-aa-large');
+  else tags.push('wcag-fail');
+  // Separate signal: every non-blending ANSI slot clears AA-large (3:1) — a
+  // floor for colored terminal output readability.
+  if (minAnsi >= 3) tags.push('ansi-legible');
+  return tags;
+}
+
+function chromaTag(colors: Colors): string | null {
+  const avgC = averageChroma(colors);
+  if (avgC > 0.15) return 'vibrant';
+  if (avgC < 0.08) return 'muted';
+  return null;
 }
 
 export function classifyTheme(theme: TerminalColorTheme): void {
   theme.isDark = theme.colors.background.oklch.l < 0.5;
 
-  const tags: string[] = [];
-  tags.push(theme.isDark ? 'dark' : 'light');
+  const fgOnBg = wcagContrast(theme.colors.background.hex, theme.colors.foreground.hex);
+  const { ratio: minAnsi, slot: minAnsiSlot } = minAnsiContrast(theme.colors, theme.isDark);
+  theme.contrast = { fgOnBg, minAnsi, minAnsiSlot };
 
-  const avgC = averageChroma(theme.colors);
-  if (avgC > 0.15) tags.push('vibrant');
-  else if (avgC < 0.08) tags.push('muted');
-
-  const contrast = wcagContrast(theme.colors.background.hex, theme.colors.foreground.hex);
-  if (contrast > 10) tags.push('high-contrast');
-  else if (contrast < 5) tags.push('low-contrast');
-
+  const tags: string[] = [theme.isDark ? 'dark' : 'light'];
+  const chroma = chromaTag(theme.colors);
+  if (chroma !== null) tags.push(chroma);
+  tags.push(...contrastTags(fgOnBg, minAnsi));
   if (POPULAR_KEYWORDS.some((p) => theme.slug.includes(p))) tags.push('popular');
 
   theme.tags = tags;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export type {
   ColorValue,
   ColorKey,
   Colors,
+  Contrast,
   TerminalColorTheme,
   SlimTheme,
   ThemeIndexEntry,
@@ -10,13 +11,14 @@ export type {
 } from './types.js';
 export { COLOR_KEYS } from './types.js';
 export { convertHexToColor, roundTripDeltaE, hexFromOklch, round } from './convert.js';
-export { classifyTheme } from './classify.js';
+export { classifyTheme, wcagContrast } from './classify.js';
 export { toSlug } from './slug.js';
 export {
   HexSchema,
   OklchSchema,
   ColorValueSchema,
   ColorsSchema,
+  ContrastSchema,
   TerminalColorThemeSchema,
   UpstreamSchemeSchema,
 } from './schema.js';

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { ColorKey } from './types.js';
 import { COLOR_KEYS } from './types.js';
 
 export const HexSchema = z
@@ -24,6 +25,12 @@ const colorsShape = Object.fromEntries(COLOR_KEYS.map((k) => [k, ColorValueSchem
 
 export const ColorsSchema = z.object(colorsShape);
 
+export const ContrastSchema = z.object({
+  fgOnBg: z.number().positive(),
+  minAnsi: z.number().positive(),
+  minAnsiSlot: z.enum(COLOR_KEYS as unknown as readonly [ColorKey, ...ColorKey[]]),
+});
+
 export const TerminalColorThemeSchema = z.object({
   name: z.string().min(1),
   slug: z
@@ -37,6 +44,7 @@ export const TerminalColorThemeSchema = z.object({
   upstreamSha: z.string().regex(/^[a-f0-9]{7,40}$/),
   updatedAt: z.iso.datetime(),
   colors: ColorsSchema,
+  contrast: ContrastSchema,
 });
 
 export const UpstreamSchemeSchema = z

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,22 @@ export type ColorKey = (typeof COLOR_KEYS)[number];
 
 export type Colors = Record<ColorKey, ColorValue>;
 
+/**
+ * WCAG 2.x contrast summary for a theme.
+ *
+ * - `fgOnBg` is the body-text contrast (foreground vs background).
+ * - `minAnsi` is the worst-case contrast of any ANSI-palette slot against the
+ *   background, EXCLUDING the slot that is supposed to blend with the
+ *   background by design (`black` + `brightBlack` on dark themes, `white` +
+ *   `brightWhite` on light themes). Surfaces legibility problems in
+ *   command-prompt output without false-flagging intentional near-bg slots.
+ */
+export interface Contrast {
+  fgOnBg: number;
+  minAnsi: number;
+  minAnsiSlot: ColorKey;
+}
+
 export interface TerminalColorTheme {
   name: string;
   slug: string;
@@ -47,6 +63,7 @@ export interface TerminalColorTheme {
   upstreamSha: string;
   updatedAt: string;
   colors: Colors;
+  contrast: Contrast;
 }
 
 export interface SlimTheme {

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { convertHexToColor, roundTripDeltaE } from '../src/convert.js';
-import { classifyTheme } from '../src/classify.js';
+import { classifyTheme, wcagContrast } from '../src/classify.js';
 import { toSlug } from '../src/slug.js';
 import { COLOR_KEYS } from '../src/types.js';
 import type { TerminalColorTheme } from '../src/types.js';
@@ -73,16 +73,19 @@ describe('toSlug', () => {
 });
 
 describe('classifyTheme', () => {
+  // Per-ANSI-slot overrides let tests drive minAnsi / minAnsiSlot deterministically.
   const makeTheme = (
     bgHex: string,
     fgHex: string,
+    ansi: Partial<Record<string, string>> = {},
     overrides: Partial<TerminalColorTheme> = {},
   ): TerminalColorTheme => {
     const colors = Object.fromEntries(
       COLOR_KEYS.map((k) => {
         if (k === 'background') return [k, convertHexToColor(bgHex)];
         if (k === 'foreground') return [k, convertHexToColor(fgHex)];
-        return [k, convertHexToColor('#808080')];
+        const hex = ansi[k] ?? '#808080';
+        return [k, convertHexToColor(hex)];
       }),
     ) as TerminalColorTheme['colors'];
     return {
@@ -95,6 +98,7 @@ describe('classifyTheme', () => {
       upstreamSha: 'abc1234',
       updatedAt: '2026-04-14T00:00:00.000Z',
       colors,
+      contrast: { fgOnBg: 0, minAnsi: 0, minAnsiSlot: 'foreground' },
       ...overrides,
     };
   };
@@ -115,8 +119,83 @@ describe('classifyTheme', () => {
   });
 
   it('marks popular themes by slug keyword', () => {
-    const t = makeTheme('#282a36', '#f8f8f2', { slug: 'dracula' });
+    const t = makeTheme('#282a36', '#f8f8f2', {}, { slug: 'dracula' });
     classifyTheme(t);
     expect(t.tags).toContain('popular');
+  });
+
+  it('populates contrast.fgOnBg with the WCAG body-text ratio', () => {
+    const t = makeTheme('#000000', '#ffffff');
+    classifyTheme(t);
+    // Pure black on pure white is the 21:1 theoretical maximum.
+    expect(t.contrast.fgOnBg).toBeCloseTo(21, 1);
+    expect(t.tags).toContain('wcag-aaa');
+    expect(t.tags).toContain('wcag-aa');
+  });
+
+  it('tags wcag-aa but not wcag-aaa for a ratio between 4.5 and 7', () => {
+    // #767676 on #ffffff is ~4.54:1 — just above AA, below AAA.
+    const t = makeTheme('#ffffff', '#767676');
+    classifyTheme(t);
+    expect(t.contrast.fgOnBg).toBeGreaterThanOrEqual(4.5);
+    expect(t.contrast.fgOnBg).toBeLessThan(7);
+    expect(t.tags).toContain('wcag-aa');
+    expect(t.tags).not.toContain('wcag-aaa');
+  });
+
+  it('tags wcag-aa-large (not wcag-aa) for a ratio between 3 and 4.5', () => {
+    // #949494 on #ffffff is ~3.03:1 — AA-large only.
+    const t = makeTheme('#ffffff', '#949494');
+    classifyTheme(t);
+    expect(t.contrast.fgOnBg).toBeGreaterThanOrEqual(3);
+    expect(t.contrast.fgOnBg).toBeLessThan(4.5);
+    expect(t.tags).toContain('wcag-aa-large');
+    expect(t.tags).not.toContain('wcag-aa');
+  });
+
+  it('tags wcag-fail when fg/bg contrast drops below 3:1', () => {
+    const t = makeTheme('#ffffff', '#c0c0c0');
+    classifyTheme(t);
+    expect(t.contrast.fgOnBg).toBeLessThan(3);
+    expect(t.tags).toContain('wcag-fail');
+  });
+
+  it('minAnsi excludes black + brightBlack on dark themes', () => {
+    // bg=#000. black/brightBlack identical to bg (would zero out minAnsi
+    // if included). Red = #c00 gives a specific ratio we can pin.
+    const t = makeTheme('#000000', '#ffffff', {
+      black: '#000000',
+      brightBlack: '#000000',
+      red: '#cc0000',
+    });
+    classifyTheme(t);
+    expect(t.contrast.minAnsiSlot).not.toBe('black');
+    expect(t.contrast.minAnsiSlot).not.toBe('brightBlack');
+    // Red is the worst non-blend slot here.
+    expect(t.contrast.minAnsiSlot).toBe('red');
+    const expected = wcagContrast('#000000', '#cc0000');
+    expect(t.contrast.minAnsi).toBeCloseTo(expected, 5);
+  });
+
+  it('minAnsi excludes white + brightWhite on light themes', () => {
+    const t = makeTheme('#ffffff', '#000000', {
+      white: '#ffffff',
+      brightWhite: '#ffffff',
+      yellow: '#ffdd00',
+    });
+    classifyTheme(t);
+    expect(t.contrast.minAnsiSlot).not.toBe('white');
+    expect(t.contrast.minAnsiSlot).not.toBe('brightWhite');
+  });
+
+  it('tags ansi-legible when all non-blend ANSI slots clear 3:1', () => {
+    const t = makeTheme('#000000', '#ffffff', {
+      black: '#000000',
+      brightBlack: '#000000',
+      // The remaining 14 slots default to #808080 ≈ 5.3:1 on pure black.
+    });
+    classifyTheme(t);
+    expect(t.contrast.minAnsi).toBeGreaterThanOrEqual(3);
+    expect(t.tags).toContain('ansi-legible');
   });
 });


### PR DESCRIPTION
Closes #55. Part 1 of #54 (accessibility + popularity evaluation).

## Summary
Adds a \`contrast: { fgOnBg, minAnsi, minAnsiSlot }\` object to every theme and emits WCAG-tier tags alongside the existing coarse tags:

| Tag | Condition |
| --- | --- |
| \`wcag-aaa\` | \`fgOnBg ≥ 7\` |
| \`wcag-aa\` | \`fgOnBg ≥ 4.5\` |
| \`wcag-aa-large\` | \`3 ≤ fgOnBg < 4.5\` |
| \`wcag-fail\` | \`fgOnBg < 3\` |
| \`ansi-legible\` | min non-blend ANSI slot vs bg ≥ 3 |

\`minAnsi\` excludes the slot(s) that conventionally blend with the background — \`black\` + \`brightBlack\` on dark themes, \`white\` + \`brightWhite\` on light ones — so intentional near-bg slots don't false-flag otherwise well-formed themes.

Existing \`high-contrast\` / \`low-contrast\` tags stay for backwards compatibility. This is purely additive — no consumers have to migrate.

### Distribution across 485 themes
- **410 AAA**, **463 AA** (so 53 AA-only), **22 AA-large-only**
- **9 wcag-fail** — \`c64\`, \`crayon-pony-fish\`, \`darkmatrix\`/\`darkermatrix\`, \`hax0r-r3d\`, \`matrix\`, \`poimandres-white\`, \`royal\` (stylistic choices where text intentionally blends with bg)
- **255 ansi-legible** — ~53% of the corpus clears 3:1 on every non-blend ANSI slot

### Validated via nexus-agents
Used \`consensus_vote\` (higher-order strategy) to pressure-test the scope. Initial proposal was rejected (3/6) with actionable feedback; the revised plan incorporated every rejection point:
- no \`avgAnsi\` (averaging ratios hides invisible slots)
- no breaking tag removal (\`high-contrast\`/\`low-contrast\` preserved)
- \`minAnsi\` split by \`isDark\` so white/brightWhite are excluded on light themes too
- popularity deferred to #57 (spike only, no code pressure)

## Test plan
- [x] \`pnpm typecheck\` + \`pnpm lint\` + \`pnpm test\` green locally (31/31 tests, incl. 7 new)
- [x] Schema validates every regenerated \`data/by-name/*.json\` via \`scripts/build.ts\`
- [x] Dracula, Solarized, Nord, Gruvbox, Builtin-Dark all tagged \`wcag-aa\` or better (sanity check)
- [ ] CI green: lint, typecheck, test, build-validate-dataset, site build, Lighthouse, axe, Scorecard

Note: the huge line count is the regenerated \`data/by-name/*.json\` dataset — pure output from a ~30-line source change. Source diff is ~210 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)