### PR TITLE
feat(site): surface WCAG contrast badge + filter chips

### DIFF
--- a/data/by-name/0x96f.json
+++ b/data/by-name/0x96f.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/0x96f.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#262427",

--- a/data/by-name/12-bit-rainbow.json
+++ b/data/by-name/12-bit-rainbow.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/12-bit Rainbow.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#040404",

--- a/data/by-name/3024-day.json
+++ b/data/by-name/3024-day.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/3024 Day.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f7f7f7",

--- a/data/by-name/3024-night.json
+++ b/data/by-name/3024-night.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/3024 Night.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#090300",

--- a/data/by-name/aardvark-blue.json
+++ b/data/by-name/aardvark-blue.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aardvark Blue.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#102040",

--- a/data/by-name/abernathy.json
+++ b/data/by-name/abernathy.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Abernathy.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#111416",

--- a/data/by-name/adventure-time.json
+++ b/data/by-name/adventure-time.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adventure Time.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1f1d45",

--- a/data/by-name/adventure.json
+++ b/data/by-name/adventure.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adventure.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#040404",

--- a/data/by-name/adwaita-dark.json
+++ b/data/by-name/adwaita-dark.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adwaita Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d1d20",

--- a/data/by-name/adwaita.json
+++ b/data/by-name/adwaita.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adwaita.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/afterglow.json
+++ b/data/by-name/afterglow.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Afterglow.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#212121",

--- a/data/by-name/aizen-dark.json
+++ b/data/by-name/aizen-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aizen Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1a1a1a",

--- a/data/by-name/aizen-light.json
+++ b/data/by-name/aizen-light.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aizen Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f0f2f6",

--- a/data/by-name/alabaster.json
+++ b/data/by-name/alabaster.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Alabaster.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f7f7f7",

--- a/data/by-name/alien-blood.json
+++ b/data/by-name/alien-blood.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Alien Blood.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0f1610",

--- a/data/by-name/andromeda.json
+++ b/data/by-name/andromeda.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Andromeda.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#262a33",

--- a/data/by-name/apple-classic.json
+++ b/data/by-name/apple-classic.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Apple Classic.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2c2b2b",

--- a/data/by-name/apple-system-colors-light.json
+++ b/data/by-name/apple-system-colors-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Apple System Colors Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#feffff",

--- a/data/by-name/apple-system-colors.json
+++ b/data/by-name/apple-system-colors.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Apple System Colors.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1e1e1e",

--- a/data/by-name/arcoiris.json
+++ b/data/by-name/arcoiris.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Arcoiris.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#201f1e",

--- a/data/by-name/ardoise.json
+++ b/data/by-name/ardoise.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ardoise.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1e1e1e",

--- a/data/by-name/argonaut.json
+++ b/data/by-name/argonaut.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Argonaut.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0e1019",

--- a/data/by-name/arthur.json
+++ b/data/by-name/arthur.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Arthur.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1c1c1c",

--- a/data/by-name/atelier-sulphurpool.json
+++ b/data/by-name/atelier-sulphurpool.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atelier Sulphurpool.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#202746",

--- a/data/by-name/atom-one-dark.json
+++ b/data/by-name/atom-one-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atom One Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#21252b",

--- a/data/by-name/atom-one-light.json
+++ b/data/by-name/atom-one-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atom One Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f9f9f9",

--- a/data/by-name/atom.json
+++ b/data/by-name/atom.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atom.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#161719",

--- a/data/by-name/aura.json
+++ b/data/by-name/aura.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aura.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#15141b",

--- a/data/by-name/aurora.json
+++ b/data/by-name/aurora.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aurora.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#23262e",

--- a/data/by-name/ayu-light.json
+++ b/data/by-name/ayu-light.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ayu Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f8f9fa",

--- a/data/by-name/ayu-mirage.json
+++ b/data/by-name/ayu-mirage.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ayu Mirage.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1f2430",

--- a/data/by-name/ayu.json
+++ b/data/by-name/ayu.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ayu.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0b0e14",

--- a/data/by-name/banana-blueberry.json
+++ b/data/by-name/banana-blueberry.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Banana Blueberry.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#191323",

--- a/data/by-name/batman.json
+++ b/data/by-name/batman.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Batman.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1b1d1e",

--- a/data/by-name/belafonte-day.json
+++ b/data/by-name/belafonte-day.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Belafonte Day.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#d5ccba",

--- a/data/by-name/belafonte-night.json
+++ b/data/by-name/belafonte-night.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Belafonte Night.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#20111b",

--- a/data/by-name/birds-of-paradise.json
+++ b/data/by-name/birds-of-paradise.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Birds Of Paradise.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2a1f1d",

--- a/data/by-name/black-metal-bathory.json
+++ b/data/by-name/black-metal-bathory.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Bathory).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/black-metal-burzum.json
+++ b/data/by-name/black-metal-burzum.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Burzum).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/black-metal-dark-funeral.json
+++ b/data/by-name/black-metal-dark-funeral.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Dark Funeral).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/black-metal-gorgoroth.json
+++ b/data/by-name/black-metal-gorgoroth.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Gorgoroth).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/black-metal-immortal.json
+++ b/data/by-name/black-metal-immortal.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Immortal).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/black-metal-khold.json
+++ b/data/by-name/black-metal-khold.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Khold).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/black-metal-marduk.json
+++ b/data/by-name/black-metal-marduk.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Marduk).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/black-metal-mayhem.json
+++ b/data/by-name/black-metal-mayhem.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Mayhem).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/black-metal-nile.json
+++ b/data/by-name/black-metal-nile.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Nile).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/black-metal-venom.json
+++ b/data/by-name/black-metal-venom.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Venom).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/black-metal.json
+++ b/data/by-name/black-metal.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/blazer.json
+++ b/data/by-name/blazer.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blazer.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0d1926",

--- a/data/by-name/blue-berry-pie.json
+++ b/data/by-name/blue-berry-pie.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blue Berry Pie.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1c0c28",

--- a/data/by-name/blue-dolphin.json
+++ b/data/by-name/blue-dolphin.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blue Dolphin.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#006984",

--- a/data/by-name/blue-matrix.json
+++ b/data/by-name/blue-matrix.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blue Matrix.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#101116",

--- a/data/by-name/bluloco-dark.json
+++ b/data/by-name/bluloco-dark.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Bluloco Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282c34",

--- a/data/by-name/bluloco-light.json
+++ b/data/by-name/bluloco-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Bluloco Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f9f9f9",

--- a/data/by-name/borland.json
+++ b/data/by-name/borland.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Borland.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0000a4",

--- a/data/by-name/box.json
+++ b/data/by-name/box.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Box.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#141d2b",

--- a/data/by-name/branch.json
+++ b/data/by-name/branch.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/branch.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#32221a",

--- a/data/by-name/breadog.json
+++ b/data/by-name/breadog.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Breadog.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f1ebe6",

--- a/data/by-name/breeze.json
+++ b/data/by-name/breeze.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Breeze.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#31363b",

--- a/data/by-name/bright-lights.json
+++ b/data/by-name/bright-lights.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Bright Lights.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#191919",

--- a/data/by-name/broadcast.json
+++ b/data/by-name/broadcast.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Broadcast.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2b2b2b",

--- a/data/by-name/brogrammer.json
+++ b/data/by-name/brogrammer.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Brogrammer.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#131313",

--- a/data/by-name/builtin-dark.json
+++ b/data/by-name/builtin-dark.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/builtin-light.json
+++ b/data/by-name/builtin-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/builtin-pastel-dark.json
+++ b/data/by-name/builtin-pastel-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Pastel Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/builtin-tango-dark.json
+++ b/data/by-name/builtin-tango-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Tango Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/builtin-tango-light.json
+++ b/data/by-name/builtin-tango-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Tango Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/c64.json
+++ b/data/by-name/c64.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/C64.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#40318d",

--- a/data/by-name/calamity.json
+++ b/data/by-name/calamity.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Calamity.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2f2833",

--- a/data/by-name/carbonfox.json
+++ b/data/by-name/carbonfox.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Carbonfox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#161616",

--- a/data/by-name/catppuccin-frappe.json
+++ b/data/by-name/catppuccin-frappe.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Frappe.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#303446",

--- a/data/by-name/catppuccin-latte.json
+++ b/data/by-name/catppuccin-latte.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Latte.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#eff1f5",

--- a/data/by-name/catppuccin-macchiato.json
+++ b/data/by-name/catppuccin-macchiato.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Macchiato.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#24273a",

--- a/data/by-name/catppuccin-mocha.json
+++ b/data/by-name/catppuccin-mocha.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Mocha.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1e1e2e",

--- a/data/by-name/cga.json
+++ b/data/by-name/cga.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/CGA.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/chalk.json
+++ b/data/by-name/chalk.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Chalk.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2b2d2e",

--- a/data/by-name/chalkboard.json
+++ b/data/by-name/chalkboard.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Chalkboard.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#29262f",

--- a/data/by-name/challenger-deep.json
+++ b/data/by-name/challenger-deep.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Challenger Deep.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1e1c31",

--- a/data/by-name/chester.json
+++ b/data/by-name/chester.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Chester.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2c3643",

--- a/data/by-name/ciapre.json
+++ b/data/by-name/ciapre.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ciapre.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#191c27",

--- a/data/by-name/citruszest.json
+++ b/data/by-name/citruszest.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Citruszest.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#121212",

--- a/data/by-name/clrs.json
+++ b/data/by-name/clrs.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/CLRS.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/cobalt-neon.json
+++ b/data/by-name/cobalt-neon.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Neon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#142838",

--- a/data/by-name/cobalt-next-dark.json
+++ b/data/by-name/cobalt-next-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Next Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0b1c24",

--- a/data/by-name/cobalt-next-minimal.json
+++ b/data/by-name/cobalt-next-minimal.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Next Minimal.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0b1c24",

--- a/data/by-name/cobalt-next.json
+++ b/data/by-name/cobalt-next.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Next.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#162c35",

--- a/data/by-name/cobalt2.json
+++ b/data/by-name/cobalt2.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt2.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#132738",

--- a/data/by-name/coffee-theme.json
+++ b/data/by-name/coffee-theme.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Coffee Theme.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f5deb3",

--- a/data/by-name/crayon-pony-fish.json
+++ b/data/by-name/crayon-pony-fish.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Crayon Pony Fish.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#150707",

--- a/data/by-name/cursor-dark.json
+++ b/data/by-name/cursor-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cursor Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#141414",

--- a/data/by-name/cursor-light.json
+++ b/data/by-name/cursor-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cursor Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f3f3f3",

--- a/data/by-name/cutie-pro.json
+++ b/data/by-name/cutie-pro.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cutie Pro.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#181818",

--- a/data/by-name/cyberdyne.json
+++ b/data/by-name/cyberdyne.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cyberdyne.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#151144",

--- a/data/by-name/cyberpunk-scarlet-protocol.json
+++ b/data/by-name/cyberpunk-scarlet-protocol.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cyberpunk Scarlet Protocol.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#101116",

--- a/data/by-name/cyberpunk.json
+++ b/data/by-name/cyberpunk.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cyberpunk.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#332a57",

--- a/data/by-name/dalton-dark.json
+++ b/data/by-name/dalton-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dalton Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1b1b1b",

--- a/data/by-name/dark-modern.json
+++ b/data/by-name/dark-modern.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dark Modern.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1f1f1f",

--- a/data/by-name/dark-pastel.json
+++ b/data/by-name/dark-pastel.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dark Pastel.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/dark-plus.json
+++ b/data/by-name/dark-plus.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dark+.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1e1e1e",

--- a/data/by-name/darkermatrix.json
+++ b/data/by-name/darkermatrix.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Darkermatrix.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#070c0e",

--- a/data/by-name/darkmatrix.json
+++ b/data/by-name/darkmatrix.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Darkmatrix.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#070c0e",

--- a/data/by-name/darkside.json
+++ b/data/by-name/darkside.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Darkside.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222324",

--- a/data/by-name/dawnfox.json
+++ b/data/by-name/dawnfox.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dawnfox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#faf4ed",

--- a/data/by-name/dayfox.json
+++ b/data/by-name/dayfox.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dayfox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f6f2ee",

--- a/data/by-name/deep.json
+++ b/data/by-name/deep.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Deep.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#090909",

--- a/data/by-name/desert.json
+++ b/data/by-name/desert.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Desert.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#333333",

--- a/data/by-name/detuned.json
+++ b/data/by-name/detuned.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Detuned.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/dimidium.json
+++ b/data/by-name/dimidium.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dimidium.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#141414",

--- a/data/by-name/dimmed-monokai.json
+++ b/data/by-name/dimmed-monokai.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dimmed Monokai.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1f1f1f",

--- a/data/by-name/django-reborn-again.json
+++ b/data/by-name/django-reborn-again.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Django Reborn Again.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#051f14",

--- a/data/by-name/django-smooth.json
+++ b/data/by-name/django-smooth.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Django Smooth.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#245032",

--- a/data/by-name/django.json
+++ b/data/by-name/django.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Django.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0b2f20",

--- a/data/by-name/dogxi-misty.json
+++ b/data/by-name/dogxi-misty.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dogxi Misty.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282a36",

--- a/data/by-name/doom-one.json
+++ b/data/by-name/doom-one.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Doom One.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282c34",

--- a/data/by-name/doom-peacock.json
+++ b/data/by-name/doom-peacock.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Doom Peacock.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2b2a27",

--- a/data/by-name/dot-gov.json
+++ b/data/by-name/dot-gov.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dot Gov.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#262c35",

--- a/data/by-name/dracula-plus.json
+++ b/data/by-name/dracula-plus.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dracula+.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#212121",

--- a/data/by-name/dracula.json
+++ b/data/by-name/dracula.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dracula.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282a36",

--- a/data/by-name/duckbones.json
+++ b/data/by-name/duckbones.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Duckbones.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0e101a",

--- a/data/by-name/duotone-dark.json
+++ b/data/by-name/duotone-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Duotone Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1f1d27",

--- a/data/by-name/duskfox.json
+++ b/data/by-name/duskfox.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Duskfox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#232136",

--- a/data/by-name/earthsong.json
+++ b/data/by-name/earthsong.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Earthsong.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#292520",

--- a/data/by-name/electron-highlighter.json
+++ b/data/by-name/electron-highlighter.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Electron Highlighter.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#23283d",

--- a/data/by-name/elegant.json
+++ b/data/by-name/elegant.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Elegant.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#292b31",

--- a/data/by-name/elemental.json
+++ b/data/by-name/elemental.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Elemental.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#22211d",

--- a/data/by-name/elementary.json
+++ b/data/by-name/elementary.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Elementary.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#181818",

--- a/data/by-name/embark.json
+++ b/data/by-name/embark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Embark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1e1c31",

--- a/data/by-name/embers-dark.json
+++ b/data/by-name/embers-dark.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Embers Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#16130f",

--- a/data/by-name/encom.json
+++ b/data/by-name/encom.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/ENCOM.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/espresso-libre.json
+++ b/data/by-name/espresso-libre.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Espresso Libre.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2a211c",

--- a/data/by-name/espresso.json
+++ b/data/by-name/espresso.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Espresso.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#323232",

--- a/data/by-name/everblush.json
+++ b/data/by-name/everblush.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Everblush.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#141b1e",

--- a/data/by-name/everforest-dark-hard.json
+++ b/data/by-name/everforest-dark-hard.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Everforest Dark Hard.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1e2326",

--- a/data/by-name/everforest-light-med.json
+++ b/data/by-name/everforest-light-med.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Everforest Light Med.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#efebd4",

--- a/data/by-name/fahrenheit.json
+++ b/data/by-name/fahrenheit.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fahrenheit.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/fairyfloss.json
+++ b/data/by-name/fairyfloss.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fairyfloss.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#5a5475",

--- a/data/by-name/farmhouse-dark.json
+++ b/data/by-name/farmhouse-dark.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Farmhouse Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d2027",

--- a/data/by-name/farmhouse-light.json
+++ b/data/by-name/farmhouse-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Farmhouse Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#e8e4e1",

--- a/data/by-name/fideloper.json
+++ b/data/by-name/fideloper.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fideloper.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#292f33",

--- a/data/by-name/firefly-traditional.json
+++ b/data/by-name/firefly-traditional.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Firefly Traditional.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/firefox-dev.json
+++ b/data/by-name/firefox-dev.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Firefox Dev.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0e1011",

--- a/data/by-name/firewatch.json
+++ b/data/by-name/firewatch.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Firewatch.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1e2027",

--- a/data/by-name/fish-tank.json
+++ b/data/by-name/fish-tank.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fish Tank.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#232537",

--- a/data/by-name/flat.json
+++ b/data/by-name/flat.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flat.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#002240",

--- a/data/by-name/flatland.json
+++ b/data/by-name/flatland.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flatland.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d1f21",

--- a/data/by-name/flexoki-dark.json
+++ b/data/by-name/flexoki-dark.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flexoki Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#100f0f",

--- a/data/by-name/flexoki-light.json
+++ b/data/by-name/flexoki-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flexoki Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fffcf0",

--- a/data/by-name/floraverse.json
+++ b/data/by-name/floraverse.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Floraverse.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0e0d15",

--- a/data/by-name/forest-blue.json
+++ b/data/by-name/forest-blue.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Forest Blue.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#051519",

--- a/data/by-name/framer.json
+++ b/data/by-name/framer.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Framer.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#111111",

--- a/data/by-name/front-end-delight.json
+++ b/data/by-name/front-end-delight.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Front End Delight.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1b1c1d",

--- a/data/by-name/fun-forrest.json
+++ b/data/by-name/fun-forrest.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fun Forrest.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#251200",

--- a/data/by-name/galaxy.json
+++ b/data/by-name/galaxy.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Galaxy.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d2837",

--- a/data/by-name/galizur.json
+++ b/data/by-name/galizur.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Galizur.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#071317",

--- a/data/by-name/ghostty-default-style-dark.json
+++ b/data/by-name/ghostty-default-style-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ghostty Default Style Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282c34",

--- a/data/by-name/github-dark-colorblind.json
+++ b/data/by-name/github-dark-colorblind.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark Colorblind.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0d1117",

--- a/data/by-name/github-dark-default.json
+++ b/data/by-name/github-dark-default.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark Default.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0d1117",

--- a/data/by-name/github-dark-dimmed.json
+++ b/data/by-name/github-dark-dimmed.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark Dimmed.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#22272e",

--- a/data/by-name/github-dark-high-contrast.json
+++ b/data/by-name/github-dark-high-contrast.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark High Contrast.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0a0c10",

--- a/data/by-name/github-dark.json
+++ b/data/by-name/github-dark.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#101216",

--- a/data/by-name/github-light-colorblind.json
+++ b/data/by-name/github-light-colorblind.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Light Colorblind.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/github-light-default.json
+++ b/data/by-name/github-light-default.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Light Default.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/github-light-high-contrast.json
+++ b/data/by-name/github-light-high-contrast.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Light High Contrast.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/github.json
+++ b/data/by-name/github.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f4f4f4",

--- a/data/by-name/gitlab-dark-grey.json
+++ b/data/by-name/gitlab-dark-grey.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitLab Dark Grey.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222222",

--- a/data/by-name/gitlab-dark.json
+++ b/data/by-name/gitlab-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitLab Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#28262b",

--- a/data/by-name/gitlab-light.json
+++ b/data/by-name/gitlab-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitLab Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fafaff",

--- a/data/by-name/glacier.json
+++ b/data/by-name/glacier.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Glacier.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0c1115",

--- a/data/by-name/grape.json
+++ b/data/by-name/grape.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Grape.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#171423",

--- a/data/by-name/grass.json
+++ b/data/by-name/grass.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Grass.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#13773d",

--- a/data/by-name/grey-green.json
+++ b/data/by-name/grey-green.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Grey Green.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#002a1a",

--- a/data/by-name/gruber-darker.json
+++ b/data/by-name/gruber-darker.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruber Darker.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#181818",

--- a/data/by-name/gruvbox-dark-hard.json
+++ b/data/by-name/gruvbox-dark-hard.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Dark Hard.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d2021",

--- a/data/by-name/gruvbox-dark.json
+++ b/data/by-name/gruvbox-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282828",

--- a/data/by-name/gruvbox-light-hard.json
+++ b/data/by-name/gruvbox-light-hard.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Light Hard.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f9f5d7",

--- a/data/by-name/gruvbox-light.json
+++ b/data/by-name/gruvbox-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fbf1c7",

--- a/data/by-name/gruvbox-material-dark.json
+++ b/data/by-name/gruvbox-material-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Material Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282828",

--- a/data/by-name/gruvbox-material-light.json
+++ b/data/by-name/gruvbox-material-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Material Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fbf1c7",

--- a/data/by-name/gruvbox-material.json
+++ b/data/by-name/gruvbox-material.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Material.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d2021",

--- a/data/by-name/guezwhoz.json
+++ b/data/by-name/guezwhoz.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Guezwhoz.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d1d1d",

--- a/data/by-name/hacktober.json
+++ b/data/by-name/hacktober.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hacktober.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#141414",

--- a/data/by-name/hardcore.json
+++ b/data/by-name/hardcore.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hardcore.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#121212",

--- a/data/by-name/harper.json
+++ b/data/by-name/harper.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Harper.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#010101",

--- a/data/by-name/havn-daggry.json
+++ b/data/by-name/havn-daggry.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Havn Daggry.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f8f9fb",

--- a/data/by-name/havn-skumring.json
+++ b/data/by-name/havn-skumring.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Havn Skumring.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#111522",

--- a/data/by-name/hax0r-blue.json
+++ b/data/by-name/hax0r-blue.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/HaX0R Blue.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#010515",

--- a/data/by-name/hax0r-gr33n.json
+++ b/data/by-name/hax0r-gr33n.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/HaX0R Gr33N.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#020f01",

--- a/data/by-name/hax0r-r3d.json
+++ b/data/by-name/hax0r-r3d.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/HaX0R R3D.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#200101",

--- a/data/by-name/heeler.json
+++ b/data/by-name/heeler.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Heeler.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#211f46",

--- a/data/by-name/highway.json
+++ b/data/by-name/highway.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Highway.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222225",

--- a/data/by-name/hipster-green.json
+++ b/data/by-name/hipster-green.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hipster Green.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#100b05",

--- a/data/by-name/hivacruz.json
+++ b/data/by-name/hivacruz.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hivacruz.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#132638",

--- a/data/by-name/homebrew.json
+++ b/data/by-name/homebrew.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Homebrew.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/hopscotch-256.json
+++ b/data/by-name/hopscotch-256.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hopscotch.256.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#322931",

--- a/data/by-name/hopscotch.json
+++ b/data/by-name/hopscotch.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hopscotch.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#322931",

--- a/data/by-name/horizon-bright.json
+++ b/data/by-name/horizon-bright.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Horizon Bright.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fdf0ed",

--- a/data/by-name/horizon.json
+++ b/data/by-name/horizon.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Horizon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1c1e26",

--- a/data/by-name/hot-dog-stand-mustard.json
+++ b/data/by-name/hot-dog-stand-mustard.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hot Dog Stand (Mustard).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffff54",

--- a/data/by-name/hot-dog-stand.json
+++ b/data/by-name/hot-dog-stand.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hot Dog Stand.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ea3323",

--- a/data/by-name/hurtado.json
+++ b/data/by-name/hurtado.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hurtado.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/hybrid.json
+++ b/data/by-name/hybrid.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hybrid.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#161719",

--- a/data/by-name/ibm-5153-cga-black.json
+++ b/data/by-name/ibm-5153-cga-black.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IBM 5153 CGA (Black).json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/ibm-5153-cga.json
+++ b/data/by-name/ibm-5153-cga.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IBM 5153 CGA.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#141414",

--- a/data/by-name/ic-green-ppl.json
+++ b/data/by-name/ic-green-ppl.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IC Green PPL.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2c2c2c",

--- a/data/by-name/ic-orange-ppl.json
+++ b/data/by-name/ic-orange-ppl.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IC Orange PPL.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#262626",

--- a/data/by-name/iceberg-dark.json
+++ b/data/by-name/iceberg-dark.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Iceberg Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#161821",

--- a/data/by-name/iceberg-light.json
+++ b/data/by-name/iceberg-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Iceberg Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#e8e9ec",

--- a/data/by-name/idea.json
+++ b/data/by-name/idea.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Idea.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#202020",

--- a/data/by-name/idle-toes.json
+++ b/data/by-name/idle-toes.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Idle Toes.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#323232",

--- a/data/by-name/ir-black.json
+++ b/data/by-name/ir-black.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IR Black.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/irix-console.json
+++ b/data/by-name/irix-console.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IRIX Console.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0c0c0c",

--- a/data/by-name/irix-terminal.json
+++ b/data/by-name/irix-terminal.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IRIX Terminal.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000043",

--- a/data/by-name/iterm2-dark-background.json
+++ b/data/by-name/iterm2-dark-background.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Dark Background.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/iterm2-default.json
+++ b/data/by-name/iterm2-default.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Default.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/iterm2-light-background.json
+++ b/data/by-name/iterm2-light-background.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Light Background.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/iterm2-pastel-dark-background.json
+++ b/data/by-name/iterm2-pastel-dark-background.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Pastel Dark Background.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/iterm2-smoooooth.json
+++ b/data/by-name/iterm2-smoooooth.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Smoooooth.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#15191f",

--- a/data/by-name/iterm2-solarized-dark.json
+++ b/data/by-name/iterm2-solarized-dark.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Solarized Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#002b36",

--- a/data/by-name/iterm2-solarized-light.json
+++ b/data/by-name/iterm2-solarized-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Solarized Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fdf6e3",

--- a/data/by-name/iterm2-tango-dark.json
+++ b/data/by-name/iterm2-tango-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Tango Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/iterm2-tango-light.json
+++ b/data/by-name/iterm2-tango-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Tango Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/jackie-brown.json
+++ b/data/by-name/jackie-brown.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Jackie Brown.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2c1d16",

--- a/data/by-name/japanesque.json
+++ b/data/by-name/japanesque.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Japanesque.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1e1e1e",

--- a/data/by-name/jellybeans.json
+++ b/data/by-name/jellybeans.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Jellybeans.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#121212",

--- a/data/by-name/jetbrains-darcula.json
+++ b/data/by-name/jetbrains-darcula.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/JetBrains Darcula.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#202020",

--- a/data/by-name/jubi.json
+++ b/data/by-name/jubi.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Jubi.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#262b33",

--- a/data/by-name/kanagawa-dragon.json
+++ b/data/by-name/kanagawa-dragon.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawa Dragon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#181616",

--- a/data/by-name/kanagawa-lotus.json
+++ b/data/by-name/kanagawa-lotus.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawa Lotus.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f2ecbc",

--- a/data/by-name/kanagawa-wave.json
+++ b/data/by-name/kanagawa-wave.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawa Wave.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1f1f28",

--- a/data/by-name/kanagawabones.json
+++ b/data/by-name/kanagawabones.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawabones.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1f1f28",

--- a/data/by-name/kanso-ink.json
+++ b/data/by-name/kanso-ink.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Ink.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#14171d",

--- a/data/by-name/kanso-mist.json
+++ b/data/by-name/kanso-mist.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Mist.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#22262d",

--- a/data/by-name/kanso-pearl.json
+++ b/data/by-name/kanso-pearl.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Pearl.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f2f1ef",

--- a/data/by-name/kanso-zen.json
+++ b/data/by-name/kanso-zen.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Zen.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#090e13",

--- a/data/by-name/kibble.json
+++ b/data/by-name/kibble.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kibble.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0e100a",

--- a/data/by-name/kitty-default.json
+++ b/data/by-name/kitty-default.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kitty Default.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/kitty-low-contrast.json
+++ b/data/by-name/kitty-low-contrast.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kitty Low Contrast.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#333333",

--- a/data/by-name/kolorit.json
+++ b/data/by-name/kolorit.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kolorit.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d1a1e",

--- a/data/by-name/konsolas.json
+++ b/data/by-name/konsolas.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Konsolas.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#060606",

--- a/data/by-name/kurokula.json
+++ b/data/by-name/kurokula.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kurokula.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#141515",

--- a/data/by-name/lab-fox.json
+++ b/data/by-name/lab-fox.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Lab Fox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2e2e2e",

--- a/data/by-name/laser.json
+++ b/data/by-name/laser.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Laser.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#030d18",

--- a/data/by-name/later-this-evening.json
+++ b/data/by-name/later-this-evening.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Later This Evening.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222222",

--- a/data/by-name/lavandula.json
+++ b/data/by-name/lavandula.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Lavandula.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#050014",

--- a/data/by-name/light-owl.json
+++ b/data/by-name/light-owl.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Light Owl.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fbfbfb",

--- a/data/by-name/liquid-carbon-transparent.json
+++ b/data/by-name/liquid-carbon-transparent.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Liquid Carbon Transparent.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/liquid-carbon.json
+++ b/data/by-name/liquid-carbon.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Liquid Carbon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#303030",

--- a/data/by-name/lovelace.json
+++ b/data/by-name/lovelace.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Lovelace.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d1f28",

--- a/data/by-name/man-page.json
+++ b/data/by-name/man-page.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Man Page.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fef49c",

--- a/data/by-name/mariana.json
+++ b/data/by-name/mariana.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mariana.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#343d46",

--- a/data/by-name/material-dark.json
+++ b/data/by-name/material-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#232322",

--- a/data/by-name/material-darker.json
+++ b/data/by-name/material-darker.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Darker.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#212121",

--- a/data/by-name/material-design-colors.json
+++ b/data/by-name/material-design-colors.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Design Colors.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d262a",

--- a/data/by-name/material-ocean.json
+++ b/data/by-name/material-ocean.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Ocean.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0f111a",

--- a/data/by-name/material.json
+++ b/data/by-name/material.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#eaeaea",

--- a/data/by-name/mathias.json
+++ b/data/by-name/mathias.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mathias.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/matrix.json
+++ b/data/by-name/matrix.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Matrix.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0f191c",

--- a/data/by-name/matte-black.json
+++ b/data/by-name/matte-black.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Matte Black.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#121212",

--- a/data/by-name/medallion.json
+++ b/data/by-name/medallion.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Medallion.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d1908",

--- a/data/by-name/melange-dark.json
+++ b/data/by-name/melange-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Melange Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#292522",

--- a/data/by-name/melange-light.json
+++ b/data/by-name/melange-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Melange Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f1f1f1",

--- a/data/by-name/mellifluous.json
+++ b/data/by-name/mellifluous.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mellifluous.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1a1a1a",

--- a/data/by-name/mellow.json
+++ b/data/by-name/mellow.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mellow.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#161617",

--- a/data/by-name/miasma.json
+++ b/data/by-name/miasma.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Miasma.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222222",

--- a/data/by-name/midnight-in-mojave.json
+++ b/data/by-name/midnight-in-mojave.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Midnight In Mojave.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1e1e1e",

--- a/data/by-name/mirage.json
+++ b/data/by-name/mirage.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mirage.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1b2738",

--- a/data/by-name/misterioso.json
+++ b/data/by-name/misterioso.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Misterioso.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2d3743",

--- a/data/by-name/modus-operandi-tinted.json
+++ b/data/by-name/modus-operandi-tinted.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Operandi Tinted.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fbf7f0",

--- a/data/by-name/modus-operandi.json
+++ b/data/by-name/modus-operandi.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Operandi.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/modus-vivendi-tinted.json
+++ b/data/by-name/modus-vivendi-tinted.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Vivendi Tinted.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0d0e1c",

--- a/data/by-name/modus-vivendi.json
+++ b/data/by-name/modus-vivendi.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Vivendi.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/molokai.json
+++ b/data/by-name/molokai.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Molokai.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#121212",

--- a/data/by-name/mona-lisa.json
+++ b/data/by-name/mona-lisa.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mona Lisa.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#120b0d",

--- a/data/by-name/monokai-classic.json
+++ b/data/by-name/monokai-classic.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Classic.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#272822",

--- a/data/by-name/monokai-pro-light-sun.json
+++ b/data/by-name/monokai-pro-light-sun.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Light Sun.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f8efe7",

--- a/data/by-name/monokai-pro-light.json
+++ b/data/by-name/monokai-pro-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#faf4f2",

--- a/data/by-name/monokai-pro-machine.json
+++ b/data/by-name/monokai-pro-machine.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Machine.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#273136",

--- a/data/by-name/monokai-pro-octagon.json
+++ b/data/by-name/monokai-pro-octagon.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Octagon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282a3a",

--- a/data/by-name/monokai-pro-ristretto.json
+++ b/data/by-name/monokai-pro-ristretto.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Ristretto.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2c2525",

--- a/data/by-name/monokai-pro-spectrum.json
+++ b/data/by-name/monokai-pro-spectrum.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Spectrum.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222222",

--- a/data/by-name/monokai-pro.json
+++ b/data/by-name/monokai-pro.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2d2a2e",

--- a/data/by-name/monokai-remastered.json
+++ b/data/by-name/monokai-remastered.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Remastered.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0c0c0c",

--- a/data/by-name/monokai-soda.json
+++ b/data/by-name/monokai-soda.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Soda.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1a1a1a",

--- a/data/by-name/monokai-vivid.json
+++ b/data/by-name/monokai-vivid.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Vivid.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#121212",

--- a/data/by-name/monospace-dark.json
+++ b/data/by-name/monospace-dark.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monospace Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#10151d",

--- a/data/by-name/monospace-light.json
+++ b/data/by-name/monospace-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monospace Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f4f7fd",

--- a/data/by-name/moonfly.json
+++ b/data/by-name/moonfly.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Moonfly.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#080808",

--- a/data/by-name/n0tch2k.json
+++ b/data/by-name/n0tch2k.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/N0Tch2K.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222222",

--- a/data/by-name/neobones-dark.json
+++ b/data/by-name/neobones-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neobones Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0f191f",

--- a/data/by-name/neobones-light.json
+++ b/data/by-name/neobones-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neobones Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#e5ede6",

--- a/data/by-name/neon.json
+++ b/data/by-name/neon.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#14161a",

--- a/data/by-name/neopolitan.json
+++ b/data/by-name/neopolitan.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neopolitan.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#271f19",

--- a/data/by-name/neutron.json
+++ b/data/by-name/neutron.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neutron.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1c1e22",

--- a/data/by-name/night-lion-v1.json
+++ b/data/by-name/night-lion-v1.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Lion V1.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/night-lion-v2.json
+++ b/data/by-name/night-lion-v2.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Lion V2.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#171717",

--- a/data/by-name/night-owl.json
+++ b/data/by-name/night-owl.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Owl.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#011627",

--- a/data/by-name/night-owlish-light.json
+++ b/data/by-name/night-owlish-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Owlish Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/nightfox.json
+++ b/data/by-name/nightfox.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nightfox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#192330",

--- a/data/by-name/niji.json
+++ b/data/by-name/niji.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Niji.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#141515",

--- a/data/by-name/no-clown-fiesta-light.json
+++ b/data/by-name/no-clown-fiesta-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/No Clown Fiesta Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#e1e1e1",

--- a/data/by-name/no-clown-fiesta.json
+++ b/data/by-name/no-clown-fiesta.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/No Clown Fiesta.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#101010",

--- a/data/by-name/nocturnal-winter.json
+++ b/data/by-name/nocturnal-winter.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nocturnal Winter.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0d0d17",

--- a/data/by-name/nord-light.json
+++ b/data/by-name/nord-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nord Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#e5e9f0",

--- a/data/by-name/nord-wave.json
+++ b/data/by-name/nord-wave.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nord Wave.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#212121",

--- a/data/by-name/nord.json
+++ b/data/by-name/nord.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nord.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2e3440",

--- a/data/by-name/nordfox.json
+++ b/data/by-name/nordfox.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nordfox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2e3440",

--- a/data/by-name/novel.json
+++ b/data/by-name/novel.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Novel.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#dfdbc3",

--- a/data/by-name/novmbr.json
+++ b/data/by-name/novmbr.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/novmbr.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#241d1a",

--- a/data/by-name/nvim-dark.json
+++ b/data/by-name/nvim-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nvim Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#14161b",

--- a/data/by-name/nvim-light.json
+++ b/data/by-name/nvim-light.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nvim Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#e0e2ea",

--- a/data/by-name/obsidian.json
+++ b/data/by-name/obsidian.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Obsidian.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#283033",

--- a/data/by-name/ocean.json
+++ b/data/by-name/ocean.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ocean.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#224fbc",

--- a/data/by-name/oceanic-material.json
+++ b/data/by-name/oceanic-material.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Oceanic Material.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1c262b",

--- a/data/by-name/oceanic-next.json
+++ b/data/by-name/oceanic-next.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Oceanic Next.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#162c35",

--- a/data/by-name/ollie.json
+++ b/data/by-name/ollie.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ollie.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222125",

--- a/data/by-name/one-dark-two.json
+++ b/data/by-name/one-dark-two.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Dark Two.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#21252b",

--- a/data/by-name/one-double-dark.json
+++ b/data/by-name/one-double-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Double Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282c34",

--- a/data/by-name/one-double-light.json
+++ b/data/by-name/one-double-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Double Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fafafa",

--- a/data/by-name/one-half-dark.json
+++ b/data/by-name/one-half-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Half Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282c34",

--- a/data/by-name/one-half-light.json
+++ b/data/by-name/one-half-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Half Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fafafa",

--- a/data/by-name/onenord-light.json
+++ b/data/by-name/onenord-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Onenord Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f7f8fa",

--- a/data/by-name/onenord.json
+++ b/data/by-name/onenord.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Onenord.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2e3440",

--- a/data/by-name/operator-mono-dark.json
+++ b/data/by-name/operator-mono-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Operator Mono Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#191919",

--- a/data/by-name/overnight-slumber.json
+++ b/data/by-name/overnight-slumber.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Overnight Slumber.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0e1729",

--- a/data/by-name/owl.json
+++ b/data/by-name/owl.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/owl.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2f2b2c",

--- a/data/by-name/oxocarbon.json
+++ b/data/by-name/oxocarbon.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Oxocarbon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#161616",

--- a/data/by-name/pale-night-hc.json
+++ b/data/by-name/pale-night-hc.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pale Night Hc.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#3e4251",

--- a/data/by-name/pandora.json
+++ b/data/by-name/pandora.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pandora.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#141e43",

--- a/data/by-name/paraiso-dark.json
+++ b/data/by-name/paraiso-dark.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Paraiso Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2f1e2e",

--- a/data/by-name/paul-millr.json
+++ b/data/by-name/paul-millr.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Paul Millr.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/pencil-dark.json
+++ b/data/by-name/pencil-dark.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pencil Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#212121",

--- a/data/by-name/pencil-light.json
+++ b/data/by-name/pencil-light.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pencil Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f1f1f1",

--- a/data/by-name/peppermint.json
+++ b/data/by-name/peppermint.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Peppermint.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/phala-green-dark.json
+++ b/data/by-name/phala-green-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Phala Green Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/piatto-light.json
+++ b/data/by-name/piatto-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Piatto Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/pierre-dark.json
+++ b/data/by-name/pierre-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pierre Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#070707",

--- a/data/by-name/pierre-light.json
+++ b/data/by-name/pierre-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pierre Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/pnevma.json
+++ b/data/by-name/pnevma.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pnevma.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1c1c1c",

--- a/data/by-name/poimandres-darker.json
+++ b/data/by-name/poimandres-darker.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres Darker.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#16161e",

--- a/data/by-name/poimandres-storm.json
+++ b/data/by-name/poimandres-storm.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres Storm.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#252b37",

--- a/data/by-name/poimandres-white.json
+++ b/data/by-name/poimandres-white.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres White.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fefeff",

--- a/data/by-name/poimandres.json
+++ b/data/by-name/poimandres.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1a1e28",

--- a/data/by-name/popping-and-locking.json
+++ b/data/by-name/popping-and-locking.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Popping And Locking.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#181921",

--- a/data/by-name/powershell.json
+++ b/data/by-name/powershell.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Powershell.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#052454",

--- a/data/by-name/primary.json
+++ b/data/by-name/primary.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Primary.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/pro-light.json
+++ b/data/by-name/pro-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pro Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/pro.json
+++ b/data/by-name/pro.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pro.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/purple-rain.json
+++ b/data/by-name/purple-rain.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Purple Rain.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#21084a",

--- a/data/by-name/purplepeter.json
+++ b/data/by-name/purplepeter.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Purplepeter.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2a1a4a",

--- a/data/by-name/rapture.json
+++ b/data/by-name/rapture.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rapture.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#111e2a",

--- a/data/by-name/raycast-dark.json
+++ b/data/by-name/raycast-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Raycast Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1a1a1a",

--- a/data/by-name/raycast-light.json
+++ b/data/by-name/raycast-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Raycast Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/rebecca.json
+++ b/data/by-name/rebecca.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rebecca.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#292a44",

--- a/data/by-name/red-alert.json
+++ b/data/by-name/red-alert.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Red Alert.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#762423",

--- a/data/by-name/red-planet.json
+++ b/data/by-name/red-planet.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Red Planet.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222222",

--- a/data/by-name/red-sands.json
+++ b/data/by-name/red-sands.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Red Sands.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#7a251e",

--- a/data/by-name/relaxed.json
+++ b/data/by-name/relaxed.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Relaxed.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#353a44",

--- a/data/by-name/retro-legends.json
+++ b/data/by-name/retro-legends.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Retro Legends.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0d0d0d",

--- a/data/by-name/retro.json
+++ b/data/by-name/retro.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Retro.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/rippedcasts.json
+++ b/data/by-name/rippedcasts.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rippedcasts.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2b2b2b",

--- a/data/by-name/rose-pine-dawn.json
+++ b/data/by-name/rose-pine-dawn.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rose Pine Dawn.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#faf4ed",

--- a/data/by-name/rose-pine-moon.json
+++ b/data/by-name/rose-pine-moon.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rose Pine Moon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#232136",

--- a/data/by-name/rose-pine.json
+++ b/data/by-name/rose-pine.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rose Pine.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#191724",

--- a/data/by-name/rouge-2.json
+++ b/data/by-name/rouge-2.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rouge 2.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#17182b",

--- a/data/by-name/royal.json
+++ b/data/by-name/royal.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Royal.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#100815",

--- a/data/by-name/ryuuko.json
+++ b/data/by-name/ryuuko.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ryuuko.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2c3941",

--- a/data/by-name/sakura.json
+++ b/data/by-name/sakura.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sakura.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#18131e",

--- a/data/by-name/scarlet-protocol.json
+++ b/data/by-name/scarlet-protocol.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Scarlet Protocol.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1c153d",

--- a/data/by-name/sea-shells.json
+++ b/data/by-name/sea-shells.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sea Shells.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#09141b",

--- a/data/by-name/seafoam-pastel.json
+++ b/data/by-name/seafoam-pastel.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seafoam Pastel.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#243435",

--- a/data/by-name/seedflip-abyss.json
+++ b/data/by-name/seedflip-abyss.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Abyss.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#050510",

--- a/data/by-name/seedflip-amethyst.json
+++ b/data/by-name/seedflip-amethyst.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Amethyst.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f8f7f6",

--- a/data/by-name/seedflip-canopy.json
+++ b/data/by-name/seedflip-canopy.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Canopy.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0f1714",

--- a/data/by-name/seedflip-carbon.json
+++ b/data/by-name/seedflip-carbon.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Carbon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fafafa",

--- a/data/by-name/seedflip-coral.json
+++ b/data/by-name/seedflip-coral.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Coral.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/seedflip-ember.json
+++ b/data/by-name/seedflip-ember.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Ember.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0a0a0a",

--- a/data/by-name/seedflip-glacier.json
+++ b/data/by-name/seedflip-glacier.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Glacier.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f8fafc",

--- a/data/by-name/seedflip-inkwell.json
+++ b/data/by-name/seedflip-inkwell.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Inkwell.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0a0a0a",

--- a/data/by-name/seedflip-ivory.json
+++ b/data/by-name/seedflip-ivory.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Ivory.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/seedflip-nightfall.json
+++ b/data/by-name/seedflip-nightfall.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Nightfall.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0a0a0f",

--- a/data/by-name/seedflip-phosphor.json
+++ b/data/by-name/seedflip-phosphor.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Phosphor.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0c0c0c",

--- a/data/by-name/seedflip-pulse.json
+++ b/data/by-name/seedflip-pulse.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Pulse.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#121212",

--- a/data/by-name/seedflip-ultraviolet.json
+++ b/data/by-name/seedflip-ultraviolet.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Ultraviolet.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0b0014",

--- a/data/by-name/seedflip-voltage.json
+++ b/data/by-name/seedflip-voltage.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Voltage.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0a0a0a",

--- a/data/by-name/seedflip-wavelength.json
+++ b/data/by-name/seedflip-wavelength.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Wavelength.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0d1117",

--- a/data/by-name/selenized-black.json
+++ b/data/by-name/selenized-black.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Selenized Black.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#181818",

--- a/data/by-name/selenized-dark.json
+++ b/data/by-name/selenized-dark.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Selenized Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#103c48",

--- a/data/by-name/selenized-light.json
+++ b/data/by-name/selenized-light.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Selenized Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fbf3db",

--- a/data/by-name/seoulbones-dark.json
+++ b/data/by-name/seoulbones-dark.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seoulbones Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#4b4b4b",

--- a/data/by-name/seoulbones-light.json
+++ b/data/by-name/seoulbones-light.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seoulbones Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#e2e2e2",

--- a/data/by-name/seti.json
+++ b/data/by-name/seti.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seti.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#111213",

--- a/data/by-name/shades-of-purple.json
+++ b/data/by-name/shades-of-purple.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Shades Of Purple.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1e1d40",

--- a/data/by-name/shaman.json
+++ b/data/by-name/shaman.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Shaman.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#001015",

--- a/data/by-name/slate.json
+++ b/data/by-name/slate.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Slate.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222222",

--- a/data/by-name/sleepy-hollow.json
+++ b/data/by-name/sleepy-hollow.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sleepy Hollow.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#121214",

--- a/data/by-name/smyck.json
+++ b/data/by-name/smyck.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Smyck.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1b1b1b",

--- a/data/by-name/snazzy-soft.json
+++ b/data/by-name/snazzy-soft.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Snazzy Soft.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282a36",

--- a/data/by-name/snazzy.json
+++ b/data/by-name/snazzy.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Snazzy.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1e1f29",

--- a/data/by-name/soft-server.json
+++ b/data/by-name/soft-server.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Soft Server.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#242626",

--- a/data/by-name/solarized-darcula.json
+++ b/data/by-name/solarized-darcula.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Darcula.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#3d3f41",

--- a/data/by-name/solarized-dark-higher-contrast.json
+++ b/data/by-name/solarized-dark-higher-contrast.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Dark Higher Contrast.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#001e27",

--- a/data/by-name/solarized-dark-patched.json
+++ b/data/by-name/solarized-dark-patched.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Dark Patched.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#001e27",

--- a/data/by-name/solarized-osaka-night.json
+++ b/data/by-name/solarized-osaka-night.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Osaka Night.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1a1b26",

--- a/data/by-name/sonokai.json
+++ b/data/by-name/sonokai.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sonokai.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2c2e34",

--- a/data/by-name/spacedust.json
+++ b/data/by-name/spacedust.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacedust.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0a1e24",

--- a/data/by-name/spacegray-bright.json
+++ b/data/by-name/spacegray-bright.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray Bright.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2a2e3a",

--- a/data/by-name/spacegray-eighties-dull.json
+++ b/data/by-name/spacegray-eighties-dull.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray Eighties Dull.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222222",

--- a/data/by-name/spacegray-eighties.json
+++ b/data/by-name/spacegray-eighties.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray Eighties.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222222",

--- a/data/by-name/spacegray.json
+++ b/data/by-name/spacegray.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#20242d",

--- a/data/by-name/spiderman.json
+++ b/data/by-name/spiderman.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spiderman.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1b1d1e",

--- a/data/by-name/spring.json
+++ b/data/by-name/spring.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spring.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/square.json
+++ b/data/by-name/square.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Square.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1a1a1a",

--- a/data/by-name/squirrelsong-dark.json
+++ b/data/by-name/squirrelsong-dark.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Squirrelsong Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#372920",

--- a/data/by-name/srcery.json
+++ b/data/by-name/srcery.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Srcery.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1c1b19",

--- a/data/by-name/starlight.json
+++ b/data/by-name/starlight.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Starlight.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#242424",

--- a/data/by-name/sublette.json
+++ b/data/by-name/sublette.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sublette.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#202535",

--- a/data/by-name/subliminal.json
+++ b/data/by-name/subliminal.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Subliminal.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282c35",

--- a/data/by-name/sugarplum.json
+++ b/data/by-name/sugarplum.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sugarplum.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#111147",

--- a/data/by-name/sundried.json
+++ b/data/by-name/sundried.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sundried.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1a1818",

--- a/data/by-name/sunset-drive.json
+++ b/data/by-name/sunset-drive.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sunset Drive.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#0f0f1a",

--- a/data/by-name/symfonic.json
+++ b/data/by-name/symfonic.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Symfonic.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/synthwave-alpha.json
+++ b/data/by-name/synthwave-alpha.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Synthwave Alpha.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#241b30",

--- a/data/by-name/synthwave-everything.json
+++ b/data/by-name/synthwave-everything.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Synthwave Everything.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2a2139",

--- a/data/by-name/synthwave.json
+++ b/data/by-name/synthwave.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Synthwave.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/tango-adapted.json
+++ b/data/by-name/tango-adapted.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tango Adapted.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/tango-half-adapted.json
+++ b/data/by-name/tango-half-adapted.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tango Half Adapted.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/tearout.json
+++ b/data/by-name/tearout.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tearout.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#34392d",

--- a/data/by-name/teerb.json
+++ b/data/by-name/teerb.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Teerb.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#262626",

--- a/data/by-name/terafox.json
+++ b/data/by-name/terafox.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Terafox.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#152528",

--- a/data/by-name/terminal-basic-dark.json
+++ b/data/by-name/terminal-basic-dark.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Terminal Basic Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d1e1d",

--- a/data/by-name/terminal-basic.json
+++ b/data/by-name/terminal-basic.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Terminal Basic.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/thayer-bright.json
+++ b/data/by-name/thayer-bright.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Thayer Bright.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1b1d1e",

--- a/data/by-name/the-hulk.json
+++ b/data/by-name/the-hulk.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/The Hulk.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1b1d1e",

--- a/data/by-name/tinacious-design-dark.json
+++ b/data/by-name/tinacious-design-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tinacious Design Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d1d26",

--- a/data/by-name/tinacious-design-light.json
+++ b/data/by-name/tinacious-design-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tinacious Design Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f8f8ff",

--- a/data/by-name/tokyonight-day.json
+++ b/data/by-name/tokyonight-day.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Day.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#e1e2e7",

--- a/data/by-name/tokyonight-moon.json
+++ b/data/by-name/tokyonight-moon.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Moon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#222436",

--- a/data/by-name/tokyonight-night.json
+++ b/data/by-name/tokyonight-night.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Night.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1a1b26",

--- a/data/by-name/tokyonight-storm.json
+++ b/data/by-name/tokyonight-storm.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Storm.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#24283b",

--- a/data/by-name/tokyonight.json
+++ b/data/by-name/tokyonight.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1a1b26",

--- a/data/by-name/tomorrow-night-blue.json
+++ b/data/by-name/tomorrow-night-blue.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Blue.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#002451",

--- a/data/by-name/tomorrow-night-bright.json
+++ b/data/by-name/tomorrow-night-bright.json
@@ -14,7 +14,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Bright.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/tomorrow-night-burns.json
+++ b/data/by-name/tomorrow-night-burns.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Burns.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#151515",

--- a/data/by-name/tomorrow-night-eighties.json
+++ b/data/by-name/tomorrow-night-eighties.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Eighties.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#2d2d2d",

--- a/data/by-name/tomorrow-night.json
+++ b/data/by-name/tomorrow-night.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1d1f21",

--- a/data/by-name/tomorrow.json
+++ b/data/by-name/tomorrow.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/toy-chest.json
+++ b/data/by-name/toy-chest.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Toy Chest.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#24364b",

--- a/data/by-name/traffic.json
+++ b/data/by-name/traffic.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/traffic.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#272c30",

--- a/data/by-name/treehouse.json
+++ b/data/by-name/treehouse.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Treehouse.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#191919",

--- a/data/by-name/twilight.json
+++ b/data/by-name/twilight.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Twilight.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#141414",

--- a/data/by-name/ubuntu.json
+++ b/data/by-name/ubuntu.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ubuntu.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#300a24",

--- a/data/by-name/ultra-dark.json
+++ b/data/by-name/ultra-dark.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ultra Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/ultra-violent.json
+++ b/data/by-name/ultra-violent.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ultra Violent.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#242728",

--- a/data/by-name/under-the-sea.json
+++ b/data/by-name/under-the-sea.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Under The Sea.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#011116",

--- a/data/by-name/unikitty.json
+++ b/data/by-name/unikitty.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Unikitty.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ff8cd9",

--- a/data/by-name/urban.json
+++ b/data/by-name/urban.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/urban.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#312e39",

--- a/data/by-name/urple.json
+++ b/data/by-name/urple.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Urple.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1b1b23",

--- a/data/by-name/vague.json
+++ b/data/by-name/vague.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vague.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#141415",

--- a/data/by-name/vaughn.json
+++ b/data/by-name/vaughn.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vaughn.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#25234f",

--- a/data/by-name/vercel.json
+++ b/data/by-name/vercel.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vercel.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#101010",

--- a/data/by-name/vesper.json
+++ b/data/by-name/vesper.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vesper.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#101010",

--- a/data/by-name/vibrant-ink.json
+++ b/data/by-name/vibrant-ink.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vibrant Ink.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/vimbones.json
+++ b/data/by-name/vimbones.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vimbones.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f0f0ca",

--- a/data/by-name/violet-dark.json
+++ b/data/by-name/violet-dark.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Violet Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1c1d1f",

--- a/data/by-name/violet-light.json
+++ b/data/by-name/violet-light.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Violet Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#fcf4dc",

--- a/data/by-name/violite.json
+++ b/data/by-name/violite.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Violite.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#241c36",

--- a/data/by-name/warm-neon.json
+++ b/data/by-name/warm-neon.json
@@ -9,7 +9,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Warm Neon.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#404040",

--- a/data/by-name/wez.json
+++ b/data/by-name/wez.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wez.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#000000",

--- a/data/by-name/whimsy.json
+++ b/data/by-name/whimsy.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Whimsy.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#29283b",

--- a/data/by-name/wild-cherry.json
+++ b/data/by-name/wild-cherry.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wild Cherry.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1f1726",

--- a/data/by-name/wilmersdorf.json
+++ b/data/by-name/wilmersdorf.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wilmersdorf.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#282b33",

--- a/data/by-name/wombat.json
+++ b/data/by-name/wombat.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wombat.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#171717",

--- a/data/by-name/wryan.json
+++ b/data/by-name/wryan.json
@@ -10,7 +10,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wryan.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#101010",

--- a/data/by-name/xcode-dark-hc.json
+++ b/data/by-name/xcode-dark-hc.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Dark hc.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1f1f24",

--- a/data/by-name/xcode-dark.json
+++ b/data/by-name/xcode-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#292a30",

--- a/data/by-name/xcode-light-hc.json
+++ b/data/by-name/xcode-light-hc.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Light hc.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/xcode-light.json
+++ b/data/by-name/xcode-light.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#ffffff",

--- a/data/by-name/xcode-wwdc.json
+++ b/data/by-name/xcode-wwdc.json
@@ -11,7 +11,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode WWDC.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#292c36",

--- a/data/by-name/zenbones-dark.json
+++ b/data/by-name/zenbones-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenbones Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#1c1917",

--- a/data/by-name/zenbones-light.json
+++ b/data/by-name/zenbones-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenbones Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f0edec",

--- a/data/by-name/zenbones.json
+++ b/data/by-name/zenbones.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenbones.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#f0edec",

--- a/data/by-name/zenburn.json
+++ b/data/by-name/zenburn.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenburn.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#3f3f3f",

--- a/data/by-name/zenburned.json
+++ b/data/by-name/zenburned.json
@@ -13,7 +13,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenburned.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#404040",

--- a/data/by-name/zenwritten-dark.json
+++ b/data/by-name/zenwritten-dark.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenwritten Dark.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#191919",

--- a/data/by-name/zenwritten-light.json
+++ b/data/by-name/zenwritten-light.json
@@ -12,7 +12,7 @@
   "source": "iterm2-color-schemes",
   "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenwritten Light.json",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-  "updatedAt": "2026-04-21T01:55:56.860Z",
+  "updatedAt": "2026-04-21T02:02:19.058Z",
   "colors": {
     "background": {
       "hex": "#eeeeee",

--- a/data/index.json
+++ b/data/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-21T01:55:56.860Z",
+  "generatedAt": "2026-04-21T02:02:19.058Z",
   "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
   "count": 485,
   "themes": [

--- a/data/themes-slim.json
+++ b/data/themes-slim.json
@@ -3,6 +3,11 @@
     "name": "0x96f",
     "slug": "0x96f",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.98736223531605,
+      "minAnsi": 5.405457549496037,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.264 0.006 314.7)",
       "foreground": "oklch(0.991 0.003 106.4)",
@@ -30,6 +35,11 @@
     "name": "12-bit Rainbow",
     "slug": "12-bit-rainbow",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 20.465226245727198,
+      "minAnsi": 2.173156742940344,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(0.107 0 0)",
       "foreground": "oklch(0.999 0.001 197.1)",
@@ -57,6 +67,11 @@
     "name": "3024 Day",
     "slug": "3024-day",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 8.816057552122258,
+      "minAnsi": 1.7892684123648972,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(0.976 0 0)",
       "foreground": "oklch(0.395 0.008 43.2)",
@@ -84,6 +99,11 @@
     "name": "3024 Night",
     "slug": "3024-night",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.090376250999649,
+      "minAnsi": 2.0454139168455816,
+      "minAnsiSlot": "brightGreen"
+    },
     "colors": {
       "background": "oklch(0.109 0.024 66.2)",
       "foreground": "oklch(0.715 0.004 17.2)",
@@ -111,6 +131,11 @@
     "name": "Aardvark Blue",
     "slug": "aardvark-blue",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.868782411080737,
+      "minAnsi": 2.4870906408519557,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.249 0.065 262.6)",
       "foreground": "oklch(0.898 0 0)",
@@ -138,6 +163,11 @@
     "name": "Abernathy",
     "slug": "abernathy",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.919643988665126,
+      "minAnsi": 3.1667849280656473,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.189 0.006 236.9)",
       "foreground": "oklch(0.949 0.003 106.5)",
@@ -165,6 +195,11 @@
     "name": "Adventure",
     "slug": "adventure",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 20.465226245727198,
+      "minAnsi": 4.549050814459397,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.107 0 0)",
       "foreground": "oklch(0.999 0.001 197.1)",
@@ -192,6 +227,11 @@
     "name": "Adventure Time",
     "slug": "adventure-time",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.113966282696687,
+      "minAnsi": 2.1328725131315767,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.258 0.073 282.2)",
       "foreground": "oklch(0.91 0.048 67.2)",
@@ -219,6 +259,11 @@
     "name": "Adwaita",
     "slug": "adwaita",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7544651015331638,
+      "minAnsiSlot": "brightCyan"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -246,6 +291,11 @@
     "name": "Adwaita Dark",
     "slug": "adwaita-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.8155377168847,
+      "minAnsi": 2.752972028782864,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.232 0.006 285.9)",
       "foreground": "oklch(1 0 0)",
@@ -273,6 +323,11 @@
     "name": "Afterglow",
     "slug": "afterglow",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.439697060587305,
+      "minAnsi": 2.7518794428131885,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.248 0 0)",
       "foreground": "oklch(0.858 0 0)",
@@ -300,6 +355,11 @@
     "name": "Aizen Dark",
     "slug": "aizen-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.066055932105117,
+      "minAnsi": 7.19388524139549,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.218 0 0)",
       "foreground": "oklch(0.88 0.036 275.3)",
@@ -327,6 +387,11 @@
     "name": "Aizen Light",
     "slug": "aizen-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 7.363358729842013,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.961 0.006 264.5)",
       "foreground": "oklch(0.428 0.042 279.2)",
@@ -354,6 +419,11 @@
     "name": "Alabaster",
     "slug": "alabaster",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 19.602217167508474,
+      "minAnsi": 1.778257050595166,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.976 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -381,6 +451,11 @@
     "name": "Alien Blood",
     "slug": "alien-blood",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 4.131824451082685,
+      "minAnsi": 1.9931186853570928,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.191 0.016 148.9)",
       "foreground": "oklch(0.567 0.033 174.4)",
@@ -408,6 +483,11 @@
     "name": "Andromeda",
     "slug": "andromeda",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.407365218447465,
+      "minAnsi": 2.791497587776118,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.285 0.018 266.3)",
       "foreground": "oklch(0.922 0 0)",
@@ -435,6 +515,11 @@
     "name": "Apple Classic",
     "slug": "apple-classic",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.048527078431232,
+      "minAnsi": 1.914333565863103,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.29 0.001 17.2)",
       "foreground": "oklch(0.74 0.151 85.8)",
@@ -462,6 +547,11 @@
     "name": "Apple System Colors",
     "slug": "apple-system-colors",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.67115667431794,
+      "minAnsi": 3.090764391581366,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.235 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -489,6 +579,11 @@
     "name": "Apple System Colors Light",
     "slug": "apple-system-colors-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 20.962166116928003,
+      "minAnsi": 1.8188603147109128,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.999 0.001 197.1)",
       "foreground": "oklch(0 0 0)",
@@ -516,6 +611,11 @@
     "name": "Arcoiris",
     "slug": "arcoiris",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.113383572161831,
+      "minAnsi": 3.346995540140267,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.24 0.002 67.7)",
       "foreground": "oklch(0.924 0.018 70.2)",
@@ -543,6 +643,11 @@
     "name": "Ardoise",
     "slug": "ardoise",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.857474337764968,
+      "minAnsi": 2.257962048740802,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.235 0 0)",
       "foreground": "oklch(0.937 0 0)",
@@ -570,6 +675,11 @@
     "name": "Argonaut",
     "slug": "argonaut",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 18.27980978944089,
+      "minAnsi": 2.713830325000255,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.176 0.019 274.6)",
       "foreground": "oklch(0.987 0.01 72.7)",
@@ -597,6 +707,11 @@
     "name": "Arthur",
     "slug": "arthur",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.078643157977426,
+      "minAnsi": 3.4530549565921453,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(0.226 0 0)",
       "foreground": "oklch(0.932 0.029 145.3)",
@@ -624,6 +739,11 @@
     "name": "Atelier Sulphurpool",
     "slug": "atelier-sulphurpool",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 5.414841177867144,
+      "minAnsi": 2.0967078405880457,
+      "minAnsiSlot": "brightGreen"
+    },
     "colors": {
       "background": "oklch(0.283 0.058 272.6)",
       "foreground": "oklch(0.699 0.034 273.9)",
@@ -651,6 +771,11 @@
     "name": "Atom",
     "slug": "atom",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.635607286220665,
+      "minAnsi": 6.904856074987967,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.204 0.004 264.5)",
       "foreground": "oklch(0.83 0.004 157.2)",
@@ -678,6 +803,11 @@
     "name": "Atom One Dark",
     "slug": "atom-one-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.22197939059332,
+      "minAnsi": 4.817082099235591,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.263 0.013 258.4)",
       "foreground": "oklch(0.762 0.02 263)",
@@ -705,6 +835,11 @@
     "name": "Atom One Light",
     "slug": "atom-one-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 13.239833955316717,
+      "minAnsi": 1.8602032925263683,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0.982 0 0)",
       "foreground": "oklch(0.294 0.013 272.9)",
@@ -732,6 +867,11 @@
     "name": "Aura",
     "slug": "aura",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.537628430566988,
+      "minAnsi": 5.766817550072907,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.196 0.014 291.6)",
       "foreground": "oklch(0.944 0.003 308.4)",
@@ -759,6 +899,11 @@
     "name": "Aurora",
     "slug": "aurora",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.891393012270951,
+      "minAnsi": 1.824799856967808,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.269 0.016 269.1)",
       "foreground": "oklch(0.862 0.168 88.3)",
@@ -786,6 +931,11 @@
     "name": "Ayu",
     "slug": "ayu",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.274416767856575,
+      "minAnsi": 6.33868001629521,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.164 0.014 264.1)",
       "foreground": "oklch(0.798 0.01 93.6)",
@@ -813,6 +963,11 @@
     "name": "Ayu Light",
     "slug": "ayu-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 5.934812759512011,
+      "minAnsi": 1.8233432417765811,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.982 0.002 247.8)",
       "foreground": "oklch(0.49 0.01 248)",
@@ -840,6 +995,11 @@
     "name": "Ayu Mirage",
     "slug": "ayu-mirage",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.454497337874741,
+      "minAnsi": 5.9456122299542065,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.261 0.024 267.1)",
       "foreground": "oklch(0.838 0.011 95.2)",
@@ -867,6 +1027,11 @@
     "name": "Banana Blueberry",
     "slug": "banana-blueberry",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.285012520072431,
+      "minAnsi": 4.173883068640812,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.202 0.032 300.8)",
       "foreground": "oklch(0.845 0 0)",
@@ -894,6 +1059,11 @@
     "name": "Batman",
     "slug": "batman",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 3.367360421928134,
+      "minAnsi": 2.705453770745099,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.229 0.004 229)",
       "foreground": "oklch(0.542 0 0)",
@@ -921,6 +1091,11 @@
     "name": "Belafonte Day",
     "slug": "belafonte-day",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 7.065447991368135,
+      "minAnsi": 1.7715117803328628,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.848 0.026 84.6)",
       "foreground": "oklch(0.354 0.021 354.8)",
@@ -948,6 +1123,11 @@
     "name": "Belafonte Night",
     "slug": "belafonte-night",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 5.5086070861374195,
+      "minAnsi": 2.8251493881125196,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.203 0.031 340.1)",
       "foreground": "oklch(0.646 0.018 64.5)",
@@ -975,6 +1155,11 @@
     "name": "Birds Of Paradise",
     "slug": "birds-of-paradise",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.42053308730299,
+      "minAnsi": 2.7380088390241584,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.252 0.018 30.2)",
       "foreground": "oklch(0.886 0.048 100.8)",
@@ -1002,6 +1187,11 @@
     "name": "Black Metal",
     "slug": "black-metal",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 3.7354550726829094,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.811 0 0)",
@@ -1029,6 +1219,11 @@
     "name": "Black Metal (Bathory)",
     "slug": "black-metal-bathory",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 5.302022326099849,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.811 0 0)",
@@ -1056,6 +1251,11 @@
     "name": "Black Metal (Burzum)",
     "slug": "black-metal-burzum",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 5.302022326099849,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.811 0 0)",
@@ -1083,6 +1283,11 @@
     "name": "Black Metal (Dark Funeral)",
     "slug": "black-metal-dark-funeral",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 5.170004476038628,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.811 0 0)",
@@ -1110,6 +1315,11 @@
     "name": "Black Metal (Gorgoroth)",
     "slug": "black-metal-gorgoroth",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 5.302022326099849,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.811 0 0)",
@@ -1137,6 +1347,11 @@
     "name": "Black Metal (Immortal)",
     "slug": "black-metal-immortal",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 3.553189319516299,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.811 0 0)",
@@ -1164,6 +1379,11 @@
     "name": "Black Metal (Khold)",
     "slug": "black-metal-khold",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 3.41073197097461,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.811 0 0)",
@@ -1191,6 +1411,11 @@
     "name": "Black Metal (Marduk)",
     "slug": "black-metal-marduk",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 3.818266607523982,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.811 0 0)",
@@ -1218,6 +1443,11 @@
     "name": "Black Metal (Mayhem)",
     "slug": "black-metal-mayhem",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 5.302022326099849,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.811 0 0)",
@@ -1245,6 +1475,11 @@
     "name": "Black Metal (Nile)",
     "slug": "black-metal-nile",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 4.554293428899023,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.811 0 0)",
@@ -1272,6 +1507,11 @@
     "name": "Black Metal (Venom)",
     "slug": "black-metal-venom",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.665528080210105,
+      "minAnsi": 2.085125879935977,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.811 0 0)",
@@ -1299,6 +1539,11 @@
     "name": "Blazer",
     "slug": "blazer",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.9772666218614,
+      "minAnsi": 4.478698684813335,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.209 0.031 251.4)",
       "foreground": "oklch(0.919 0.022 245.9)",
@@ -1326,6 +1571,11 @@
     "name": "Blue Berry Pie",
     "slug": "blue-berry-pie",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.546087376536567,
+      "minAnsi": 2.06095558162547,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0.194 0.057 308.4)",
       "foreground": "oklch(0.789 0.001 106.4)",
@@ -1353,6 +1603,11 @@
     "name": "Blue Dolphin",
     "slug": "blue-dolphin",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 5.223572571709242,
+      "minAnsi": 2.624043838476951,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.484 0.091 223.5)",
       "foreground": "oklch(0.934 0.049 217.2)",
@@ -1380,6 +1635,11 @@
     "name": "Blue Matrix",
     "slug": "blue-matrix",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.834399264935834,
+      "minAnsi": 4.843488536888253,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0.179 0.01 276.4)",
       "foreground": "oklch(0.689 0.175 245.4)",
@@ -1407,6 +1667,11 @@
     "name": "Bluloco Dark",
     "slug": "bluloco-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.6429594705314825,
+      "minAnsi": 3.3816564098969817,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.293 0.016 264.3)",
       "foreground": "oklch(0.806 0.017 259.4)",
@@ -1434,6 +1699,11 @@
     "name": "Bluloco Light",
     "slug": "bluloco-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 10.816784394191304,
+      "minAnsi": 2.303514790146454,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.982 0 0)",
       "foreground": "oklch(0.348 0.013 267.2)",
@@ -1461,6 +1731,11 @@
     "name": "Borland",
     "slug": "borland",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.802832815575501,
+      "minAnsi": 4.925520462555745,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.325 0.225 264.1)",
       "foreground": "oklch(0.971 0.188 109.4)",
@@ -1488,6 +1763,11 @@
     "name": "Box",
     "slug": "box",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.948642919560694,
+      "minAnsi": 2.8911886438272014,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.229 0.03 259)",
       "foreground": "oklch(0.867 0.233 129.9)",
@@ -1515,6 +1795,11 @@
     "name": "branch",
     "slug": "branch",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.593893421562631,
+      "minAnsi": 3.3804888513483955,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.269 0.029 47.6)",
       "foreground": "oklch(0.816 0.036 81.2)",
@@ -1542,6 +1827,11 @@
     "name": "Breadog",
     "slug": "breadog",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 11.516984728118752,
+      "minAnsi": 3.551081210057594,
+      "minAnsiSlot": "brightGreen"
+    },
     "colors": {
       "background": "oklch(0.943 0.009 62.6)",
       "foreground": "oklch(0.302 0.02 60.6)",
@@ -1569,6 +1859,11 @@
     "name": "Breeze",
     "slug": "breeze",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.691418971163678,
+      "minAnsi": 2.0799367639426634,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(0.33 0.011 248.2)",
       "foreground": "oklch(0.955 0.002 247.8)",
@@ -1596,6 +1891,11 @@
     "name": "Bright Lights",
     "slug": "bright-lights",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.258212000763624,
+      "minAnsi": 4.949922051401596,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.213 0 0)",
       "foreground": "oklch(0.824 0.031 235.7)",
@@ -1623,6 +1923,11 @@
     "name": "Broadcast",
     "slug": "broadcast",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.901201394892102,
+      "minAnsi": 3.366601690433081,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.289 0 0)",
       "foreground": "oklch(0.912 0.009 67.7)",
@@ -1650,6 +1955,11 @@
     "name": "Brogrammer",
     "slug": "brogrammer",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.38055610561519,
+      "minAnsi": 2.8452502311416352,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(0.187 0 0)",
       "foreground": "oklch(0.891 0.015 264.5)",
@@ -1677,6 +1987,11 @@
     "name": "Builtin Dark",
     "slug": "builtin-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.938659901217408,
+      "minAnsi": 1.9087088049756329,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.792 0 0)",
@@ -1704,6 +2019,11 @@
     "name": "Builtin Light",
     "slug": "builtin-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.8941005847454646,
+      "minAnsiSlot": "brightGreen"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -1731,6 +2051,11 @@
     "name": "Builtin Pastel Dark",
     "slug": "builtin-pastel-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.938659901217408,
+      "minAnsi": 7.565930477694234,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.792 0 0)",
@@ -1758,6 +2083,11 @@
     "name": "Builtin Tango Dark",
     "slug": "builtin-tango-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 3.189857951985112,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -1785,6 +2115,11 @@
     "name": "Builtin Tango Light",
     "slug": "builtin-tango-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7952876128727326,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -1812,6 +2147,11 @@
     "name": "C64",
     "slug": "c64",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 2.2607656244342924,
+      "minAnsi": 1.7528273106950094,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.387 0.146 284.8)",
       "foreground": "oklch(0.577 0.137 289)",
@@ -1839,6 +2179,11 @@
     "name": "Calamity",
     "slug": "calamity",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.278505646168245,
+      "minAnsi": 3.2235122088779002,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.289 0.022 313.3)",
       "foreground": "oklch(0.86 0.017 313.6)",
@@ -1866,6 +2211,11 @@
     "name": "Carbonfox",
     "slug": "carbonfox",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.434104834959708,
+      "minAnsi": 5.44018049973752,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.2 0 0)",
       "foreground": "oklch(0.967 0.006 264.5)",
@@ -1893,6 +2243,11 @@
     "name": "Catppuccin Frappe",
     "slug": "catppuccin-frappe",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.058361993601588,
+      "minAnsi": 4.087013150070628,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.329 0.032 274.8)",
       "foreground": "oklch(0.862 0.053 273.3)",
@@ -1920,6 +2275,11 @@
     "name": "Catppuccin Latte",
     "slug": "catppuccin-latte",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 7.0619995573104415,
+      "minAnsi": 1.9141888968694352,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.958 0.006 264.5)",
       "foreground": "oklch(0.436 0.043 279.3)",
@@ -1947,6 +2307,11 @@
     "name": "Catppuccin Macchiato",
     "slug": "catppuccin-macchiato",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.91891243005997,
+      "minAnsi": 5.194473756643897,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.279 0.035 276.9)",
       "foreground": "oklch(0.871 0.048 273.7)",
@@ -1974,6 +2339,11 @@
     "name": "Catppuccin Mocha",
     "slug": "catppuccin-mocha",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.341133436863977,
+      "minAnsi": 6.177654146691573,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.243 0.03 283.9)",
       "foreground": "oklch(0.879 0.043 272.3)",
@@ -2001,6 +2371,11 @@
     "name": "CGA",
     "slug": "cga",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.039555596643915,
+      "minAnsi": 1.7584621294329432,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.738 0 0)",
@@ -2028,6 +2403,11 @@
     "name": "Chalk",
     "slug": "chalk",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.597623877390692,
+      "minAnsi": 2.385502309081929,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.296 0.003 228.9)",
       "foreground": "oklch(0.878 0.007 208.8)",
@@ -2055,6 +2435,11 @@
     "name": "Chalkboard",
     "slug": "chalkboard",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.717055368088978,
+      "minAnsi": 3.4857732997160817,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.276 0.017 300.5)",
       "foreground": "oklch(0.919 0.022 245.9)",
@@ -2082,6 +2467,11 @@
     "name": "Challenger Deep",
     "slug": "challenger-deep",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.217613990801206,
+      "minAnsi": 4.56276031526616,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.24 0.04 287.4)",
       "foreground": "oklch(0.895 0.025 215.9)",
@@ -2109,6 +2499,11 @@
     "name": "Chester",
     "slug": "chester",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.239111925768343,
+      "minAnsi": 2.927915443263548,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.329 0.027 255.1)",
       "foreground": "oklch(1 0 0)",
@@ -2136,6 +2531,11 @@
     "name": "Ciapre",
     "slug": "ciapre",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.784768448344223,
+      "minAnsi": 1.7944955850844855,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.229 0.022 272.7)",
       "foreground": "oklch(0.717 0.059 96.3)",
@@ -2163,6 +2563,11 @@
     "name": "Citruszest",
     "slug": "citruszest",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.187465865194712,
+      "minAnsi": 5.046160960201738,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.182 0 0)",
       "foreground": "oklch(0.805 0 0)",
@@ -2190,6 +2595,11 @@
     "name": "CLRS",
     "slug": "clrs",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 15.133529408889883,
+      "minAnsi": 1.8120859440085175,
+      "minAnsiSlot": "brightCyan"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.269 0 0)",
@@ -2217,6 +2627,11 @@
     "name": "Cobalt Neon",
     "slug": "cobalt-neon",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.200746748171563,
+      "minAnsi": 1.764991976970595,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.268 0.04 244.2)",
       "foreground": "oklch(0.882 0.176 142.2)",
@@ -2244,6 +2659,11 @@
     "name": "Cobalt Next",
     "slug": "cobalt-next",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.738742024166898,
+      "minAnsi": 4.665202123018976,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.279 0.033 226.4)",
       "foreground": "oklch(0.899 0.018 261.3)",
@@ -2271,6 +2691,11 @@
     "name": "Cobalt Next Dark",
     "slug": "cobalt-next-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.876057625515893,
+      "minAnsi": 5.122564749771748,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.216 0.028 230.2)",
       "foreground": "oklch(0.899 0.018 261.3)",
@@ -2298,6 +2723,11 @@
     "name": "Cobalt Next Minimal",
     "slug": "cobalt-next-minimal",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.876057625515893,
+      "minAnsi": 5.798179209508437,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.216 0.028 230.2)",
       "foreground": "oklch(0.899 0.018 261.3)",
@@ -2325,6 +2755,11 @@
     "name": "Cobalt2",
     "slug": "cobalt2",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.272707504267059,
+      "minAnsi": 2.642557726110494,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.265 0.041 245.8)",
       "foreground": "oklch(1 0 0)",
@@ -2352,6 +2787,11 @@
     "name": "Coffee Theme",
     "slug": "coffee-theme",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 15.98194056409643,
+      "minAnsi": 1.7576534298401374,
+      "minAnsiSlot": "brightCyan"
+    },
     "colors": {
       "background": "oklch(0.909 0.062 83)",
       "foreground": "oklch(0 0 0)",
@@ -2379,6 +2819,11 @@
     "name": "Crayon Pony Fish",
     "slug": "crayon-pony-fish",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 2.762639595886461,
+      "minAnsi": 1.992869950464761,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.152 0.026 20.6)",
       "foreground": "oklch(0.464 0.032 354.6)",
@@ -2406,6 +2851,11 @@
     "name": "Cursor Dark",
     "slug": "cursor-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.428629164208074,
+      "minAnsi": 5.764803105478651,
+      "minAnsiSlot": "green"
+    },
     "colors": {
       "background": "oklch(0.191 0 0)",
       "foreground": "oklch(0.87 0 0)",
@@ -2433,6 +2883,11 @@
     "name": "Cursor Light",
     "slug": "cursor-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 13.814106751785841,
+      "minAnsi": 2.6670308375679537,
+      "minAnsiSlot": "brightGreen"
+    },
     "colors": {
       "background": "oklch(0.964 0 0)",
       "foreground": "oklch(0.265 0 0)",
@@ -2460,6 +2915,11 @@
     "name": "Cutie Pro",
     "slug": "cutie-pro",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.579609455685839,
+      "minAnsi": 6.273312690550735,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.209 0 0)",
       "foreground": "oklch(0.86 0.011 76.6)",
@@ -2487,6 +2947,11 @@
     "name": "Cyberdyne",
     "slug": "cyberdyne",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.148126605437431,
+      "minAnsi": 3.565804895020556,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.222 0.092 279.3)",
       "foreground": "oklch(0.878 0.219 154.5)",
@@ -2514,6 +2979,11 @@
     "name": "Cyberpunk",
     "slug": "cyberpunk",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.357265239330985,
+      "minAnsi": 4.9607825757273964,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.319 0.078 290.5)",
       "foreground": "oklch(0.922 0 0)",
@@ -2541,6 +3011,11 @@
     "name": "Cyberpunk Scarlet Protocol",
     "slug": "cyberpunk-scarlet-protocol",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 4.091109353200948,
+      "minAnsi": 3.62733294554639,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.179 0.01 276.4)",
       "foreground": "oklch(0.591 0.227 14.7)",
@@ -2568,6 +3043,11 @@
     "name": "Dalton Dark",
     "slug": "dalton-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.40226118924566,
+      "minAnsi": 3.333491278285508,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.222 0 0)",
       "foreground": "oklch(0.836 0.004 271.4)",
@@ -2595,6 +3075,11 @@
     "name": "Dark Modern",
     "slug": "dark-modern",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.263829808673044,
+      "minAnsi": 3.1522225087832743,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.239 0 0)",
       "foreground": "oklch(0.845 0 0)",
@@ -2622,6 +3107,11 @@
     "name": "Dark Pastel",
     "slug": "dark-pastel",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 4.1296587927193125,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -2649,6 +3139,11 @@
     "name": "Dark+",
     "slug": "dark-plus",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.38100762286638,
+      "minAnsi": 3.2385726181133854,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.235 0 0)",
       "foreground": "oklch(0.845 0 0)",
@@ -2676,6 +3171,11 @@
     "name": "Darkermatrix",
     "slug": "darkermatrix",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 1.8891474483742787,
+      "minAnsi": 1.4835861328218996,
+      "minAnsiSlot": "brightWhite"
+    },
     "colors": {
       "background": "oklch(0.15 0.01 222.9)",
       "foreground": "oklch(0.366 0.069 126.6)",
@@ -2703,6 +3203,11 @@
     "name": "Darkmatrix",
     "slug": "darkmatrix",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 2.4148124528679924,
+      "minAnsi": 1.9971603474964532,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.15 0.01 222.9)",
       "foreground": "oklch(0.422 0.096 128.1)",
@@ -2730,6 +3235,11 @@
     "name": "Darkside",
     "slug": "darkside",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.11184133931825,
+      "minAnsi": 3.702759687367773,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.256 0.002 247.9)",
       "foreground": "oklch(0.789 0 0)",
@@ -2757,6 +3267,11 @@
     "name": "Dawnfox",
     "slug": "dawnfox",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 6.657280748896968,
+      "minAnsi": 1.8622861946636253,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.97 0.011 71.9)",
       "foreground": "oklch(0.46 0.063 289.6)",
@@ -2784,6 +3299,11 @@
     "name": "Dayfox",
     "slug": "dayfox",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 11.145625973707121,
+      "minAnsi": 3.423765237278193,
+      "minAnsiSlot": "brightCyan"
+    },
     "colors": {
       "background": "oklch(0.963 0.007 67.7)",
       "foreground": "oklch(0.334 0.082 299.6)",
@@ -2811,6 +3331,11 @@
     "name": "Deep",
     "slug": "deep",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.525578239702938,
+      "minAnsi": 3.6900032458893013,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.14 0 0)",
       "foreground": "oklch(0.848 0 0)",
@@ -2838,6 +3363,11 @@
     "name": "Desert",
     "slug": "desert",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.63465434445799,
+      "minAnsi": 3.3887553194646247,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.321 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -2865,6 +3395,11 @@
     "name": "Detuned",
     "slug": "detuned",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.422496589297461,
+      "minAnsi": 4.384187804236253,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.83 0 0)",
@@ -2892,6 +3427,11 @@
     "name": "Dimidium",
     "slug": "dimidium",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.243459202609898,
+      "minAnsi": 3.9850072682445767,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.191 0 0)",
       "foreground": "oklch(0.782 0.004 39.5)",
@@ -2919,6 +3459,11 @@
     "name": "Dimmed Monokai",
     "slug": "dimmed-monokai",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.60660988107443,
+      "minAnsi": 2.7222691485480346,
+      "minAnsiSlot": "brightGreen"
+    },
     "colors": {
       "background": "oklch(0.239 0 0)",
       "foreground": "oklch(0.792 0.004 157.2)",
@@ -2946,6 +3491,11 @@
     "name": "Django",
     "slug": "django",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.715626088537237,
+      "minAnsi": 1.9200420702527614,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.275 0.05 162.3)",
       "foreground": "oklch(0.979 0 0)",
@@ -2973,6 +3523,11 @@
     "name": "Django Reborn Again",
     "slug": "django-reborn-again",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.75252191789214,
+      "minAnsi": 1.8708818052136582,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.215 0.039 162.6)",
       "foreground": "oklch(0.897 0.005 165)",
@@ -3000,6 +3555,11 @@
     "name": "Django Smooth",
     "slug": "django-smooth",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.716509923733199,
+      "minAnsi": 3.039571335883196,
+      "minAnsiSlot": "green"
+    },
     "colors": {
       "background": "oklch(0.391 0.071 152.2)",
       "foreground": "oklch(0.979 0 0)",
@@ -3027,6 +3587,11 @@
     "name": "Dogxi Misty",
     "slug": "dogxi-misty",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.432422229651946,
+      "minAnsi": 4.69287905910325,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.288 0.022 277.5)",
       "foreground": "oklch(0.953 0.007 115.7)",
@@ -3054,6 +3619,11 @@
     "name": "Doom One",
     "slug": "doom-one",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.82001691967415,
+      "minAnsi": 4.754293214763805,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.293 0.016 264.3)",
       "foreground": "oklch(0.813 0.02 263)",
@@ -3081,6 +3651,11 @@
     "name": "Doom Peacock",
     "slug": "doom-peacock",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.040463008158579,
+      "minAnsi": 2.7739983953430367,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.285 0.006 91.6)",
       "foreground": "oklch(0.912 0.028 76.2)",
@@ -3108,6 +3683,11 @@
     "name": "Dot Gov",
     "slug": "dot-gov",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.790012195641419,
+      "minAnsi": 1.9063800181761583,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.291 0.019 258.4)",
       "foreground": "oklch(0.94 0 0)",
@@ -3135,6 +3715,11 @@
     "name": "Dracula",
     "slug": "dracula",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.359134716531573,
+      "minAnsi": 4.531550766258277,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.288 0.022 277.5)",
       "foreground": "oklch(0.978 0.008 106.5)",
@@ -3162,6 +3747,11 @@
     "name": "Dracula+",
     "slug": "dracula-plus",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.105706312919677,
+      "minAnsi": 5.1240051447700266,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.248 0 0)",
       "foreground": "oklch(0.978 0.008 106.5)",
@@ -3189,6 +3779,11 @@
     "name": "Duckbones",
     "slug": "duckbones",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.924986427886736,
+      "minAnsi": 3.8058637916577545,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.176 0.021 275.3)",
       "foreground": "oklch(0.937 0.061 111.5)",
@@ -3216,6 +3811,11 @@
     "name": "Duotone Dark",
     "slug": "duotone-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.5638203903938415,
+      "minAnsi": 3.645325501787195,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.238 0.019 294.1)",
       "foreground": "oklch(0.764 0.134 293.8)",
@@ -3243,6 +3843,11 @@
     "name": "Duskfox",
     "slug": "duskfox",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.86365608062847,
+      "minAnsi": 5.262685221829585,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.26 0.039 287.7)",
       "foreground": "oklch(0.909 0.03 290)",
@@ -3270,6 +3875,11 @@
     "name": "Earthsong",
     "slug": "earthsong",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.475427990413575,
+      "minAnsi": 3.125435442939281,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.267 0.011 73.5)",
       "foreground": "oklch(0.848 0.053 67)",
@@ -3297,6 +3907,11 @@
     "name": "Electron Highlighter",
     "slug": "electron-highlighter",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.100651776346242,
+      "minAnsi": 4.3902870108206224,
+      "minAnsiSlot": "white"
+    },
     "colors": {
       "background": "oklch(0.282 0.039 273.4)",
       "foreground": "oklch(0.773 0.047 261.8)",
@@ -3324,6 +3939,11 @@
     "name": "Elegant",
     "slug": "elegant",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.307474260490578,
+      "minAnsi": 3.6313709940352723,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.29 0.011 271)",
       "foreground": "oklch(0.862 0.007 247.9)",
@@ -3351,6 +3971,11 @@
     "name": "Elemental",
     "slug": "elemental",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 3.80099836701166,
+      "minAnsi": 2.040322350568522,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.247 0.008 95.4)",
       "foreground": "oklch(0.583 0.012 67.6)",
@@ -3378,6 +4003,11 @@
     "name": "Elementary",
     "slug": "elementary",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.442153532069472,
+      "minAnsi": 2.041646504087658,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.209 0 0)",
       "foreground": "oklch(0.952 0 0)",
@@ -3405,6 +4035,11 @@
     "name": "Embark",
     "slug": "embark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.10503538749257,
+      "minAnsi": 3.642765360796553,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(0.24 0.04 287.4)",
       "foreground": "oklch(0.988 0.018 196.9)",
@@ -3432,6 +4067,11 @@
     "name": "Embers Dark",
     "slug": "embers-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.685352943486375,
+      "minAnsi": 1.8100227598035976,
+      "minAnsiSlot": "brightGreen"
+    },
     "colors": {
       "background": "oklch(0.189 0.009 75.1)",
       "foreground": "oklch(0.691 0.018 70.4)",
@@ -3459,6 +4099,11 @@
     "name": "ENCOM",
     "slug": "encom",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.816038646398305,
+      "minAnsi": 2.444,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.648 0.116 182.9)",
@@ -3486,6 +4131,11 @@
     "name": "Espresso",
     "slug": "espresso",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.82113382786086,
+      "minAnsi": 2.907925115204386,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.317 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -3513,6 +4163,11 @@
     "name": "Espresso Libre",
     "slug": "espresso-libre",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.822331199348381,
+      "minAnsi": 2.6767588284314123,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.257 0.017 50.7)",
       "foreground": "oklch(0.741 0.029 67.4)",
@@ -3540,6 +4195,11 @@
     "name": "Everblush",
     "slug": "everblush",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.463678735509065,
+      "minAnsi": 5.87584391665661,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.216 0.012 225.8)",
       "foreground": "oklch(0.888 0 0)",
@@ -3567,6 +4227,11 @@
     "name": "Everforest Dark Hard",
     "slug": "everforest-dark-hard",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.389409238303774,
+      "minAnsi": 4.700885040833118,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0.252 0.009 234.1)",
       "foreground": "oklch(0.83 0.041 86.1)",
@@ -3594,6 +4259,11 @@
     "name": "Everforest Light Med",
     "slug": "everforest-light-med",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 4.655789215480987,
+      "minAnsi": 1.7645371424739247,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.937 0.031 98.9)",
       "foreground": "oklch(0.515 0.021 232.9)",
@@ -3621,6 +4291,11 @@
     "name": "Fahrenheit",
     "slug": "fahrenheit",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 20.447246276133974,
+      "minAnsi": 1.9721182882538013,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.988 0.063 107.5)",
@@ -3648,6 +4323,11 @@
     "name": "Fairyfloss",
     "slug": "fairyfloss",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.656147192335941,
+      "minAnsi": 1.8745525850950375,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.465 0.053 292.5)",
       "foreground": "oklch(0.978 0.008 106.5)",
@@ -3675,6 +4355,11 @@
     "name": "Farmhouse Dark",
     "slug": "farmhouse-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.89900514830556,
+      "minAnsi": 2.176443979144189,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.244 0.014 267)",
       "foreground": "oklch(0.921 0.006 59.6)",
@@ -3702,6 +4387,11 @@
     "name": "Farmhouse Light",
     "slug": "farmhouse-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 12.89900514830556,
+      "minAnsi": 1.757259726600676,
+      "minAnsiSlot": "brightGreen"
+    },
     "colors": {
       "background": "oklch(0.921 0.006 59.6)",
       "foreground": "oklch(0.244 0.014 267)",
@@ -3729,6 +4419,11 @@
     "name": "Fideloper",
     "slug": "fideloper",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.761096476981518,
+      "minAnsi": 2.3656552689423345,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(0.301 0.011 237)",
       "foreground": "oklch(0.891 0.008 293.9)",
@@ -3756,6 +4451,11 @@
     "name": "Firefly Traditional",
     "slug": "firefly-traditional",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 19.261973035868383,
+      "minAnsi": 3.8611990287320728,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.97 0 0)",
@@ -3783,6 +4483,11 @@
     "name": "Firefox Dev",
     "slug": "firefox-dev",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 5.7427252530694535,
+      "minAnsi": 2.5351482722551846,
+      "minAnsiSlot": "brightCyan"
+    },
     "colors": {
       "background": "oklch(0.171 0.004 229.1)",
       "foreground": "oklch(0.642 0.038 251)",
@@ -3810,6 +4515,11 @@
     "name": "Firewatch",
     "slug": "firewatch",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.354799503682964,
+      "minAnsi": 3.8883243379757633,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.245 0.014 272.8)",
       "foreground": "oklch(0.712 0.025 266.8)",
@@ -3837,6 +4547,11 @@
     "name": "Fish Tank",
     "slug": "fish-tank",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.269820457575744,
+      "minAnsi": 2.515732324823122,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.271 0.034 279)",
       "foreground": "oklch(0.956 0.019 273.2)",
@@ -3864,6 +4579,11 @@
     "name": "Flat",
     "slug": "flat",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.101124628561992,
+      "minAnsi": 1.8835598420354975,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.247 0.069 249.3)",
       "foreground": "oklch(0.724 0.191 148.8)",
@@ -3891,6 +4611,11 @@
     "name": "Flatland",
     "slug": "flatland",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.350259892661535,
+      "minAnsi": 2.983224496524538,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.238 0.005 248)",
       "foreground": "oklch(0.873 0.046 233.1)",
@@ -3918,6 +4643,11 @@
     "name": "Flexoki Dark",
     "slug": "flexoki-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.979773058854278,
+      "minAnsi": 2.8533476149486487,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(0.17 0.002 17.3)",
       "foreground": "oklch(0.846 0.014 102.1)",
@@ -3945,6 +4675,11 @@
     "name": "Flexoki Light",
     "slug": "flexoki-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 18.623142284944873,
+      "minAnsi": 1.9997046436301846,
+      "minAnsiSlot": "brightBlack"
+    },
     "colors": {
       "background": "oklch(0.99 0.016 95.2)",
       "foreground": "oklch(0.17 0.002 17.3)",
@@ -3972,6 +4707,11 @@
     "name": "Floraverse",
     "slug": "floraverse",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.72480043817595,
+      "minAnsi": 1.9532504412357568,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.164 0.017 290.2)",
       "foreground": "oklch(0.862 0.034 88.1)",
@@ -3999,6 +4739,11 @@
     "name": "Forest Blue",
     "slug": "forest-blue",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.245458131110349,
+      "minAnsi": 2.421347169146018,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.183 0.024 215.4)",
       "foreground": "oklch(0.887 0.019 70.2)",
@@ -4026,6 +4771,11 @@
     "name": "Framer",
     "slug": "framer",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 4.216767253166575,
+      "minAnsi": 6.0089274371800805,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.178 0 0)",
       "foreground": "oklch(0.569 0 0)",
@@ -4053,6 +4803,11 @@
     "name": "Front End Delight",
     "slug": "front-end-delight",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.605132393579298,
+      "minAnsi": 2.3161944434553474,
+      "minAnsiSlot": "green"
+    },
     "colors": {
       "background": "oklch(0.226 0.003 247.9)",
       "foreground": "oklch(0.748 0 0)",
@@ -4080,6 +4835,11 @@
     "name": "Fun Forrest",
     "slug": "fun-forrest",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.231694781477739,
+      "minAnsi": 2.557323542402356,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.205 0.046 65.5)",
       "foreground": "oklch(0.817 0.117 92.2)",
@@ -4107,6 +4867,11 @@
     "name": "Galaxy",
     "slug": "galaxy",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.883842395618611,
+      "minAnsi": 2.661171519469546,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.274 0.032 256.3)",
       "foreground": "oklch(1 0 0)",
@@ -4134,6 +4899,11 @@
     "name": "Galizur",
     "slug": "galizur",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.92405646818393,
+      "minAnsi": 2.52341646176751,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.177 0.019 220.9)",
       "foreground": "oklch(0.942 0.029 248.1)",
@@ -4161,6 +4931,11 @@
     "name": "Ghostty Default Style Dark",
     "slug": "ghostty-default-style-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.999227678845402,
+      "minAnsi": 3.362407270681048,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.293 0.016 264.3)",
       "foreground": "oklch(1 0 0)",
@@ -4188,6 +4963,11 @@
     "name": "GitHub",
     "slug": "github",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 9.724390698748637,
+      "minAnsi": 1.7500957400041959,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0.967 0 0)",
       "foreground": "oklch(0.364 0 0)",
@@ -4215,6 +4995,11 @@
     "name": "GitHub Dark",
     "slug": "github-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.095203207234266,
+      "minAnsi": 3.5371506775963657,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.182 0.009 264.3)",
       "foreground": "oklch(0.663 0.018 250.9)",
@@ -4242,6 +5027,11 @@
     "name": "GitHub Dark Colorblind",
     "slug": "github-dark-colorblind",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.261031969575138,
+      "minAnsi": 7.491836480293032,
+      "minAnsiSlot": "green"
+    },
     "colors": {
       "background": "oklch(0.176 0.014 258.4)",
       "foreground": "oklch(0.857 0.014 248)",
@@ -4269,6 +5059,11 @@
     "name": "GitHub Dark Default",
     "slug": "github-dark-default",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.016082890827004,
+      "minAnsi": 7.4497929930639835,
+      "minAnsiSlot": "green"
+    },
     "colors": {
       "background": "oklch(0.176 0.014 258.4)",
       "foreground": "oklch(0.943 0.011 243.7)",
@@ -4296,6 +5091,11 @@
     "name": "GitHub Dark Dimmed",
     "slug": "github-dark-dimmed",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.601990586445604,
+      "minAnsi": 5.2593014228844295,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.271 0.015 256.8)",
       "foreground": "oklch(0.783 0.024 248.1)",
@@ -4323,6 +5123,11 @@
     "name": "GitHub Dark High Contrast",
     "slug": "github-dark-high-contrast",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 17.57358905641591,
+      "minAnsi": 9.20247817686318,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.154 0.009 264.3)",
       "foreground": "oklch(0.963 0.005 247.9)",
@@ -4350,6 +5155,11 @@
     "name": "GitHub Light Colorblind",
     "slug": "github-light-colorblind",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 14.652157369459891,
+      "minAnsi": 3.235284115220877,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.279 0.013 253)",
@@ -4377,6 +5187,11 @@
     "name": "GitHub Light Default",
     "slug": "github-light-default",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 15.797619425332647,
+      "minAnsi": 3.235284115220877,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.254 0.011 254)",
@@ -4404,6 +5219,11 @@
     "name": "GitHub Light High Contrast",
     "slug": "github-light-high-contrast",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 18.911466369919406,
+      "minAnsi": 3.6066342162960927,
+      "minAnsiSlot": "brightCyan"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.177 0.011 260.6)",
@@ -4431,6 +5251,11 @@
     "name": "GitLab Dark",
     "slug": "gitlab-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.974840721943796,
+      "minAnsi": 4.288462047023658,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0.273 0.01 303.8)",
       "foreground": "oklch(1 0 0)",
@@ -4458,6 +5283,11 @@
     "name": "GitLab Dark Grey",
     "slug": "gitlab-dark-grey",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.909984431773273,
+      "minAnsi": 4.556266451930614,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0.252 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -4485,6 +5315,11 @@
     "name": "GitLab Light",
     "slug": "gitlab-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 12.684668567771666,
+      "minAnsi": 4.875209096305248,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0.987 0.007 286.3)",
       "foreground": "oklch(0.309 0 0)",
@@ -4512,6 +5347,11 @@
     "name": "Glacier",
     "slug": "glacier",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 18.976350018147606,
+      "minAnsi": 2.4372245185839745,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.174 0.012 242.5)",
       "foreground": "oklch(1 0 0)",
@@ -4539,6 +5379,11 @@
     "name": "Grape",
     "slug": "grape",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.847286081822569,
+      "minAnsi": 3.0025008281247483,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.203 0.03 292.7)",
       "foreground": "oklch(0.703 0.003 286.3)",
@@ -4566,6 +5411,11 @@
     "name": "Grass",
     "slug": "grass",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 4.890282728037497,
+      "minAnsi": 1.8163650295143616,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.501 0.125 151.7)",
       "foreground": "oklch(0.95 0.095 98.2)",
@@ -4593,6 +5443,11 @@
     "name": "Grey Green",
     "slug": "grey-green",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.600600680657527,
+      "minAnsi": 3.9553687462970113,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.252 0.055 162.5)",
       "foreground": "oklch(1 0 0)",
@@ -4620,6 +5475,11 @@
     "name": "Gruber Darker",
     "slug": "gruber-darker",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.965255158215777,
+      "minAnsi": 4.522507826699491,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.209 0 0)",
       "foreground": "oklch(0.919 0 0)",
@@ -4647,6 +5507,11 @@
     "name": "Gruvbox Dark",
     "slug": "gruvbox-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.74706817440964,
+      "minAnsi": 2.6942006289764127,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.277 0 0)",
       "foreground": "oklch(0.894 0.057 89.2)",
@@ -4674,6 +5539,11 @@
     "name": "Gruvbox Dark Hard",
     "slug": "gruvbox-dark-hard",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.95176123994368,
+      "minAnsi": 2.996207163429576,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.241 0.005 219.7)",
       "foreground": "oklch(0.894 0.057 89.2)",
@@ -4701,6 +5571,11 @@
     "name": "Gruvbox Light",
     "slug": "gruvbox-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 10.21974550734294,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.956 0.056 96.2)",
       "foreground": "oklch(0.344 0.007 48.5)",
@@ -4728,6 +5603,11 @@
     "name": "Gruvbox Light Hard",
     "slug": "gruvbox-light-hard",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 10.529783804658695,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.966 0.039 100.9)",
       "foreground": "oklch(0.344 0.007 48.5)",
@@ -4755,6 +5635,11 @@
     "name": "Gruvbox Material",
     "slug": "gruvbox-material",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.070986340601117,
+      "minAnsi": 4.05697671141115,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.241 0.005 219.7)",
       "foreground": "oklch(0.811 0.057 81.2)",
@@ -4782,6 +5667,11 @@
     "name": "Gruvbox Material Dark",
     "slug": "gruvbox-material-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.156664666774935,
+      "minAnsi": 4.700629435816308,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.277 0 0)",
       "foreground": "oklch(0.811 0.057 81.2)",
@@ -4809,6 +5699,11 @@
     "name": "Gruvbox Material Light",
     "slug": "gruvbox-material-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 7.385612446038595,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.956 0.056 96.2)",
       "foreground": "oklch(0.426 0.05 51.9)",
@@ -4836,6 +5731,11 @@
     "name": "Guezwhoz",
     "slug": "guezwhoz",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.942746828644987,
+      "minAnsi": 4.756351522702039,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.231 0 0)",
       "foreground": "oklch(0.885 0 0)",
@@ -4863,6 +5763,11 @@
     "name": "Hacktober",
     "slug": "hacktober",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.125078595062687,
+      "minAnsi": 2.6392882012686116,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.191 0 0)",
       "foreground": "oklch(0.836 0 0)",
@@ -4890,6 +5795,11 @@
     "name": "Hardcore",
     "slug": "hardcore",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.163977871523068,
+      "minAnsi": 3.65293820151869,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.182 0 0)",
       "foreground": "oklch(0.706 0 0)",
@@ -4917,6 +5827,11 @@
     "name": "Harper",
     "slug": "harper",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.410955179933248,
+      "minAnsi": 6.222091885349799,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.067 0 0)",
       "foreground": "oklch(0.72 0.011 81.8)",
@@ -4944,6 +5859,11 @@
     "name": "Havn Daggry",
     "slug": "havn-daggry",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 8.148195918236711,
+      "minAnsi": 1.9637061003022214,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.982 0.003 264.5)",
       "foreground": "oklch(0.42 0.083 269.5)",
@@ -4971,6 +5891,11 @@
     "name": "Havn Skumring",
     "slug": "havn-skumring",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.161914123850126,
+      "minAnsi": 4.083171817254882,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.198 0.027 270.7)",
       "foreground": "oklch(0.892 0.023 272)",
@@ -4998,6 +5923,11 @@
     "name": "HaX0R Blue",
     "slug": "hax0r-blue",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.938850149710262,
+      "minAnsi": 8.50346924609034,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.121 0.041 261.8)",
       "foreground": "oklch(0.738 0.157 236.3)",
@@ -5025,6 +5955,11 @@
     "name": "HaX0R Gr33N",
     "slug": "hax0r-gr33n",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.841199156356613,
+      "minAnsi": 9.390074925552794,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.149 0.043 140.9)",
       "foreground": "oklch(0.661 0.219 142.3)",
@@ -5052,6 +5987,11 @@
     "name": "HaX0R R3D",
     "slug": "hax0r-r3d",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 2.756135861744877,
+      "minAnsi": 2.7287710521046282,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.156 0.06 27.7)",
       "foreground": "oklch(0.482 0.191 28.5)",
@@ -5079,6 +6019,11 @@
     "name": "Heeler",
     "slug": "heeler",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.302796925075487,
+      "minAnsi": 3.9819301718588416,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.265 0.071 282.7)",
       "foreground": "oklch(0.994 0 0)",
@@ -5106,6 +6051,11 @@
     "name": "Highway",
     "slug": "highway",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.552626888705587,
+      "minAnsi": 1.9736076403036666,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.253 0.006 286)",
       "foreground": "oklch(0.946 0 0)",
@@ -5133,6 +6083,11 @@
     "name": "Hipster Green",
     "slug": "hipster-green",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.016200138054561,
+      "minAnsi": 2.2796548460723143,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0.154 0.016 75.5)",
       "foreground": "oklch(0.743 0.177 130.7)",
@@ -5160,6 +6115,11 @@
     "name": "Hivacruz",
     "slug": "hivacruz",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.348066049215886,
+      "minAnsi": 2.7358525149149737,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.262 0.042 248.5)",
       "foreground": "oklch(0.926 0.01 17.3)",
@@ -5187,6 +6147,11 @@
     "name": "Homebrew",
     "slug": "homebrew",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.303999999999998,
+      "minAnsi": 1.8270002567023051,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.866 0.295 142.5)",
@@ -5214,6 +6179,11 @@
     "name": "Hopscotch",
     "slug": "hopscotch",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.922862329946787,
+      "minAnsi": 1.9198229617709017,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.294 0.019 329.7)",
       "foreground": "oklch(0.777 0.006 334)",
@@ -5241,6 +6211,11 @@
     "name": "Hopscotch.256",
     "slug": "hopscotch-256",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.922862329946787,
+      "minAnsi": 3.3763238959414608,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.294 0.019 329.7)",
       "foreground": "oklch(0.777 0.006 334)",
@@ -5268,6 +6243,11 @@
     "name": "Horizon",
     "slug": "horizon",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.609755119696096,
+      "minAnsi": 4.803410184690108,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.237 0.016 274.1)",
       "foreground": "oklch(0.881 0.004 236.5)",
@@ -5295,6 +6275,11 @@
     "name": "Horizon Bright",
     "slug": "horizon-bright",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 16.169317016587108,
+      "minAnsi": 1.7804293458175173,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.965 0.015 33.1)",
       "foreground": "oklch(0.204 0.014 285.1)",
@@ -5322,6 +6307,11 @@
     "name": "Hot Dog Stand",
     "slug": "hot-dog-stand",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 4.203122533935382,
+      "minAnsi": 3.9397305912370046,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.611 0.22 29.8)",
       "foreground": "oklch(1 0 0)",
@@ -5349,6 +6339,11 @@
     "name": "Hot Dog Stand (Mustard)",
     "slug": "hot-dog-stand-mustard",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 19.684018666596657,
+      "minAnsi": 3.9397305912370046,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.971 0.184 109.4)",
       "foreground": "oklch(0 0 0)",
@@ -5376,6 +6371,11 @@
     "name": "Hurtado",
     "slug": "hurtado",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.167515597833736,
+      "minAnsi": 3.456016012905084,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.891 0 0)",
@@ -5403,6 +6403,11 @@
     "name": "Hybrid",
     "slug": "hybrid",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.324062360375843,
+      "minAnsi": 2.1947354930287886,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.204 0.004 264.5)",
       "foreground": "oklch(0.791 0.006 170.4)",
@@ -5430,6 +6435,11 @@
     "name": "IBM 5153 CGA",
     "slug": "ibm-5153-cga",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.70632091649946,
+      "minAnsi": 1.8547009332170838,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.191 0 0)",
       "foreground": "oklch(0.851 0 0)",
@@ -5457,6 +6467,11 @@
     "name": "IBM 5153 CGA (Black)",
     "slug": "ibm-5153-cga-black",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.040228030240003,
+      "minAnsi": 1.7971044637833282,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.82 0 0)",
@@ -5484,6 +6499,11 @@
     "name": "IC Green PPL",
     "slug": "ic-green-ppl",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.827225506508844,
+      "minAnsi": 3.7210464701369617,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.293 0 0)",
       "foreground": "oklch(0.94 0.033 139.7)",
@@ -5511,6 +6531,11 @@
     "name": "IC Orange PPL",
     "slug": "ic-orange-ppl",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.177019711731324,
+      "minAnsi": 2.776456575756782,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.269 0 0)",
       "foreground": "oklch(0.873 0.107 74.6)",
@@ -5538,6 +6563,11 @@
     "name": "Iceberg Dark",
     "slug": "iceberg-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.603558844665839,
+      "minAnsi": 6.059976604928213,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.211 0.018 275)",
       "foreground": "oklch(0.834 0.013 276.1)",
@@ -5565,6 +6595,11 @@
     "name": "Iceberg Light",
     "slug": "iceberg-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 9.655044494507733,
+      "minAnsi": 1.0981360061729746,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.934 0.004 271.4)",
       "foreground": "oklch(0.342 0.037 275.9)",
@@ -5592,6 +6627,11 @@
     "name": "Idea",
     "slug": "idea",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.260353274094703,
+      "minAnsi": 1.089792329672652,
+      "minAnsiSlot": "brightWhite"
+    },
     "colors": {
       "background": "oklch(0.244 0 0)",
       "foreground": "oklch(0.748 0 0)",
@@ -5619,6 +6659,11 @@
     "name": "Idle Toes",
     "slug": "idle-toes",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.82113382786086,
+      "minAnsi": 3.0948288927602916,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.317 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -5646,6 +6691,11 @@
     "name": "IR Black",
     "slug": "ir-black",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 18.592447937756635,
+      "minAnsi": 7.378729175710199,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.958 0 0)",
@@ -5673,6 +6723,11 @@
     "name": "IRIX Console",
     "slug": "irix-console",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 17.47362420993011,
+      "minAnsi": 2.508064209720709,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.154 0 0)",
       "foreground": "oklch(0.961 0 0)",
@@ -5700,6 +6755,11 @@
     "name": "IRIX Terminal",
     "slug": "irix-terminal",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 17.352083942454144,
+      "minAnsi": 2.276830533343979,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.173 0.12 264.1)",
       "foreground": "oklch(0.961 0 0)",
@@ -5727,6 +6787,11 @@
     "name": "iTerm2 Dark Background",
     "slug": "iterm2-dark-background",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.422496589297461,
+      "minAnsi": 2.091912595931719,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.83 0 0)",
@@ -5754,6 +6819,11 @@
     "name": "iTerm2 Default",
     "slug": "iterm2-default",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 2.1297478518898183,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -5781,6 +6851,11 @@
     "name": "iTerm2 Light Background",
     "slug": "iterm2-light-background",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7541341704031068,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -5808,6 +6883,11 @@
     "name": "iTerm2 Pastel Dark Background",
     "slug": "iterm2-pastel-dark-background",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.422496589297461,
+      "minAnsi": 8.746080804146642,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.83 0 0)",
@@ -5835,6 +6915,11 @@
     "name": "iTerm2 Smoooooth",
     "slug": "iterm2-smoooooth",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.860973833303843,
+      "minAnsi": 2.2992902909975608,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.212 0.013 258.4)",
       "foreground": "oklch(0.895 0 0)",
@@ -5862,6 +6947,11 @@
     "name": "iTerm2 Solarized Dark",
     "slug": "iterm2-solarized-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 4.747877839876171,
+      "minAnsi": 2.789627547583178,
+      "minAnsiSlot": "brightGreen"
+    },
     "colors": {
       "background": "oklch(0.267 0.049 219.8)",
       "foreground": "oklch(0.654 0.02 205.3)",
@@ -5889,6 +6979,11 @@
     "name": "iTerm2 Solarized Light",
     "slug": "iterm2-solarized-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 4.129605890896795,
+      "minAnsi": 2.4789959188576267,
+      "minAnsiSlot": "brightCyan"
+    },
     "colors": {
       "background": "oklch(0.974 0.026 90.1)",
       "foreground": "oklch(0.568 0.029 221.9)",
@@ -5916,6 +7011,11 @@
     "name": "iTerm2 Tango Dark",
     "slug": "iterm2-tango-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 4.105495243097395,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -5943,6 +7043,11 @@
     "name": "iTerm2 Tango Light",
     "slug": "iterm2-tango-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7589311345907752,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -5970,6 +7075,11 @@
     "name": "Jackie Brown",
     "slug": "jackie-brown",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.761676622349576,
+      "minAnsi": 1.8880956497869026,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0.247 0.027 46)",
       "foreground": "oklch(0.866 0.166 88.9)",
@@ -5997,6 +7107,11 @@
     "name": "Japanesque",
     "slug": "japanesque",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.359981327860599,
+      "minAnsi": 2.1319328673578264,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(0.235 0 0)",
       "foreground": "oklch(0.971 0.013 102)",
@@ -6024,6 +7139,11 @@
     "name": "Jellybeans",
     "slug": "jellybeans",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.924656375487373,
+      "minAnsi": 5.247114925613579,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.182 0 0)",
       "foreground": "oklch(0.901 0 0)",
@@ -6051,6 +7171,11 @@
     "name": "JetBrains Darcula",
     "slug": "jetbrains-darcula",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.260353274094703,
+      "minAnsi": 2.5263016552037088,
+      "minAnsiSlot": "green"
+    },
     "colors": {
       "background": "oklch(0.244 0 0)",
       "foreground": "oklch(0.748 0 0)",
@@ -6078,6 +7203,11 @@
     "name": "Jubi",
     "slug": "jubi",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.278499933441514,
+      "minAnsi": 2.836661760683309,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.288 0.016 259.8)",
       "foreground": "oklch(0.858 0.023 237.7)",
@@ -6105,6 +7235,11 @@
     "name": "Kanagawa Dragon",
     "slug": "kanagawa-dragon",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.757897010440683,
+      "minAnsi": 5.20986364962469,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.203 0.003 17.4)",
       "foreground": "oklch(0.832 0.007 145.5)",
@@ -6132,6 +7267,11 @@
     "name": "Kanagawa Lotus",
     "slug": "kanagawa-lotus",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 6.18561286722523,
+      "minAnsi": 2.6961088191135745,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0.936 0.063 101.6)",
       "foreground": "oklch(0.452 0.026 285.3)",
@@ -6159,6 +7299,11 @@
     "name": "Kanagawa Wave",
     "slug": "kanagawa-wave",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.26343080332848,
+      "minAnsi": 3.218025386691309,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.243 0.017 285.1)",
       "foreground": "oklch(0.876 0.039 99.1)",
@@ -6186,6 +7331,11 @@
     "name": "Kanagawabones",
     "slug": "kanagawabones",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.373953362086501,
+      "minAnsi": 4.674151702669178,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.243 0.017 285.1)",
       "foreground": "oklch(0.879 0.039 99.1)",
@@ -6213,6 +7363,11 @@
     "name": "Kanso Ink",
     "slug": "kanso-ink",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.729013943415868,
+      "minAnsi": 5.1882351630502175,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.204 0.013 264.2)",
       "foreground": "oklch(0.832 0.005 165)",
@@ -6240,6 +7395,11 @@
     "name": "Kanso Mist",
     "slug": "kanso-mist",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.075942806509774,
+      "minAnsi": 4.3888586458090595,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.268 0.014 261.7)",
       "foreground": "oklch(0.832 0.005 165)",
@@ -6267,6 +7427,11 @@
     "name": "Kanso Pearl",
     "slug": "kanso-pearl",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 13.450395855946788,
+      "minAnsi": 2.86622271752278,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0.958 0.003 84.6)",
       "foreground": "oklch(0.268 0.014 261.7)",
@@ -6294,6 +7459,11 @@
     "name": "Kanso Zen",
     "slug": "kanso-zen",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.582424142032995,
+      "minAnsi": 5.600919201333923,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.161 0.013 248.5)",
       "foreground": "oklch(0.832 0.005 165)",
@@ -6321,6 +7491,11 @@
     "name": "Kibble",
     "slug": "kibble",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 17.866133591756054,
+      "minAnsi": 2.7522766186617584,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.169 0.013 122.7)",
       "foreground": "oklch(0.976 0 0)",
@@ -6348,6 +7523,11 @@
     "name": "Kitty Default",
     "slug": "kitty-default",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.461102578439387,
+      "minAnsi": 3.5861553235963606,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.898 0 0)",
@@ -6375,6 +7555,11 @@
     "name": "Kitty Low Contrast",
     "slug": "kitty-low-contrast",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.63465434445799,
+      "minAnsi": 2.157611092341805,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.321 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -6402,6 +7587,11 @@
     "name": "Kolorit",
     "slug": "kolorit",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.670431939489694,
+      "minAnsi": 5.8016740392948085,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.223 0.009 317.7)",
       "foreground": "oklch(0.945 0.003 17.2)",
@@ -6429,6 +7619,11 @@
     "name": "Konsolas",
     "slug": "konsolas",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.437324452164141,
+      "minAnsi": 1.790002483544427,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.122 0 0)",
       "foreground": "oklch(0.817 0.008 17.3)",
@@ -6456,6 +7651,11 @@
     "name": "Kurokula",
     "slug": "kurokula",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.086706945791647,
+      "minAnsi": 4.025378356397241,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.195 0.002 197)",
       "foreground": "oklch(0.865 0.026 59.9)",
@@ -6483,6 +7683,11 @@
     "name": "Lab Fox",
     "slug": "lab-fox",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.579770974464187,
+      "minAnsi": 1.8209701792863637,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(0.301 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -6510,6 +7715,11 @@
     "name": "Laser",
     "slug": "laser",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 5.467379042591636,
+      "minAnsi": 5.266182758914931,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0.155 0.03 247.7)",
       "foreground": "oklch(0.665 0.299 331.6)",
@@ -6537,6 +7747,11 @@
     "name": "Later This Evening",
     "slug": "later-this-evening",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 5.311567916009271,
+      "minAnsi": 1.7892578426663424,
+      "minAnsiSlot": "white"
+    },
     "colors": {
       "background": "oklch(0.252 0 0)",
       "foreground": "oklch(0.67 0 0)",
@@ -6564,6 +7779,11 @@
     "name": "Lavandula",
     "slug": "lavandula",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 4.186173978306482,
+      "minAnsi": 1.9806839109135272,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.102 0.056 294)",
       "foreground": "oklch(0.548 0.024 300.8)",
@@ -6591,6 +7811,11 @@
     "name": "Light Owl",
     "slug": "light-owl",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 9.880546554670078,
+      "minAnsi": 1.9698200780183888,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0.988 0 0)",
       "foreground": "oklch(0.377 0.034 286.9)",
@@ -6618,6 +7843,11 @@
     "name": "Liquid Carbon",
     "slug": "liquid-carbon",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.113477468370681,
+      "minAnsi": 3.5933185810680217,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.309 0 0)",
       "foreground": "oklch(0.8 0.021 196.7)",
@@ -6645,6 +7875,11 @@
     "name": "Liquid Carbon Transparent",
     "slug": "liquid-carbon-transparent",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.318514984564993,
+      "minAnsi": 5.717461028726613,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.8 0.021 196.7)",
@@ -6672,6 +7907,11 @@
     "name": "Lovelace",
     "slug": "lovelace",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.143077935691124,
+      "minAnsi": 3.5731138219092697,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(0.241 0.018 275.2)",
       "foreground": "oklch(0.994 0 0)",
@@ -6699,6 +7939,11 @@
     "name": "Man Page",
     "slug": "man-page",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 18.63449957390289,
+      "minAnsi": 1.746832493323516,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.956 0.109 102.6)",
       "foreground": "oklch(0 0 0)",
@@ -6726,6 +7971,11 @@
     "name": "Mariana",
     "slug": "mariana",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.17315831400962,
+      "minAnsi": 3.362507076953814,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.355 0.02 248.4)",
       "foreground": "oklch(0.899 0.016 262.7)",
@@ -6753,6 +8003,11 @@
     "name": "Material",
     "slug": "material",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 13.07567402495151,
+      "minAnsi": 1.8513565192760821,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0.937 0 0)",
       "foreground": "oklch(0.256 0.002 106.5)",
@@ -6780,6 +8035,11 @@
     "name": "Material Dark",
     "slug": "material-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.487679129242336,
+      "minAnsi": 1.7666483386118776,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.256 0.002 106.5)",
       "foreground": "oklch(0.922 0 0)",
@@ -6807,6 +8067,11 @@
     "name": "Material Darker",
     "slug": "material-darker",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.629422591616345,
+      "minAnsi": 5.155211008020823,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.248 0 0)",
       "foreground": "oklch(0.988 0.018 196.9)",
@@ -6834,6 +8099,11 @@
     "name": "Material Design Colors",
     "slug": "material-design-colors",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.843006590335344,
+      "minAnsi": 4.103729106434181,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.262 0.015 226.7)",
       "foreground": "oklch(0.938 0.005 228.8)",
@@ -6861,6 +8131,11 @@
     "name": "Material Ocean",
     "slug": "material-ocean",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.153036408356529,
+      "minAnsi": 6.027638935261423,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.18 0.019 274.6)",
       "foreground": "oklch(0.665 0.023 273.9)",
@@ -6888,6 +8163,11 @@
     "name": "Mathias",
     "slug": "mathias",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.938659901217408,
+      "minAnsi": 4.1296587927193125,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.792 0 0)",
@@ -6915,6 +8195,11 @@
     "name": "Matrix",
     "slug": "matrix",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 2.7341061213046127,
+      "minAnsi": 2.1230093292775423,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.205 0.016 218.3)",
       "foreground": "oklch(0.473 0.068 145.7)",
@@ -6942,6 +8227,11 @@
     "name": "Matte Black",
     "slug": "matte-black",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.079026358071443,
+      "minAnsi": 2.0040940574500588,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.182 0 0)",
       "foreground": "oklch(0.802 0 0)",
@@ -6969,6 +8259,11 @@
     "name": "Medallion",
     "slug": "medallion",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.76600262805789,
+      "minAnsi": 3.3313326482129932,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.213 0.03 96.5)",
       "foreground": "oklch(0.81 0.06 98.9)",
@@ -6996,6 +8291,11 @@
     "name": "Melange Dark",
     "slug": "melange-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.807387917777396,
+      "minAnsi": 4.772352822083565,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.268 0.008 59.3)",
       "foreground": "oklch(0.916 0.018 64.9)",
@@ -7023,6 +8323,11 @@
     "name": "Melange Light",
     "slug": "melange-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 8.296780692978805,
+      "minAnsi": 1.143608204672927,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.958 0 0)",
       "foreground": "oklch(0.398 0.028 49.4)",
@@ -7050,6 +8355,11 @@
     "name": "Mellifluous",
     "slug": "mellifluous",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.449926988251232,
+      "minAnsi": 3.113042083214476,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0.218 0 0)",
       "foreground": "oklch(0.888 0 0)",
@@ -7077,6 +8387,11 @@
     "name": "Mellow",
     "slug": "mellow",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.793901902326235,
+      "minAnsi": 7.137414070144248,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.201 0.002 286.2)",
       "foreground": "oklch(0.833 0.009 301.3)",
@@ -7104,6 +8419,11 @@
     "name": "Miasma",
     "slug": "miasma",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.816782470109812,
+      "minAnsi": 2.296006786476582,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.252 0 0)",
       "foreground": "oklch(0.809 0.025 106.9)",
@@ -7131,6 +8451,11 @@
     "name": "Midnight In Mojave",
     "slug": "midnight-in-mojave",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.67115667431794,
+      "minAnsi": 4.570605294259279,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.235 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -7158,6 +8483,11 @@
     "name": "Mirage",
     "slug": "mirage",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.995198775446447,
+      "minAnsi": 7.030176879732231,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.27 0.036 257.1)",
       "foreground": "oklch(0.759 0.024 252.2)",
@@ -7185,6 +8515,11 @@
     "name": "Misterioso",
     "slug": "misterioso",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.22772465949827,
+      "minAnsi": 2.0136112777163815,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.333 0.025 253.2)",
       "foreground": "oklch(0.91 0.001 106.4)",
@@ -7212,6 +8547,11 @@
     "name": "Modus Operandi",
     "slug": "modus-operandi",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 7.000313923192387,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -7239,6 +8579,11 @@
     "name": "Modus Operandi Tinted",
     "slug": "modus-operandi-tinted",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 19.66440576437239,
+      "minAnsi": 6.555095879220985,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.977 0.01 81.8)",
       "foreground": "oklch(0 0 0)",
@@ -7266,6 +8611,11 @@
     "name": "Modus Vivendi",
     "slug": "modus-vivendi",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 7.033137350809865,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -7293,6 +8643,11 @@
     "name": "Modus Vivendi Tinted",
     "slug": "modus-vivendi-tinted",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 19.14841760827243,
+      "minAnsi": 6.413021480459339,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.171 0.029 279.7)",
       "foreground": "oklch(1 0 0)",
@@ -7320,6 +8675,11 @@
     "name": "Molokai",
     "slug": "molokai",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.758151339882987,
+      "minAnsi": 3.0992432360783924,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.182 0 0)",
       "foreground": "oklch(0.792 0 0)",
@@ -7347,6 +8707,11 @@
     "name": "Mona Lisa",
     "slug": "mona-lisa",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.694253636827321,
+      "minAnsi": 2.4101140129278913,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.16 0.013 359.8)",
       "foreground": "oklch(0.883 0.132 92.5)",
@@ -7374,6 +8739,11 @@
     "name": "Monokai Classic",
     "slug": "monokai-classic",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.686788462138944,
+      "minAnsi": 3.9268476458761508,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.274 0.011 114.8)",
       "foreground": "oklch(0.995 0.018 113.3)",
@@ -7401,6 +8771,11 @@
     "name": "Monokai Pro",
     "slug": "monokai-pro",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.792654363958263,
+      "minAnsi": 4.936796222167998,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.29 0.008 317.7)",
       "foreground": "oklch(0.991 0.003 106.4)",
@@ -7428,6 +8803,11 @@
     "name": "Monokai Pro Light",
     "slug": "monokai-pro-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 13.975573957112271,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.971 0.007 39.5)",
       "foreground": "oklch(0.268 0.013 320.6)",
@@ -7455,6 +8835,11 @@
     "name": "Monokai Pro Light Sun",
     "slug": "monokai-pro-light-sun",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 13.332623545205923,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.957 0.015 64.3)",
       "foreground": "oklch(0.271 0.024 320.1)",
@@ -7482,6 +8867,11 @@
     "name": "Monokai Pro Machine",
     "slug": "monokai-pro-machine",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.974613609909985,
+      "minAnsi": 4.902730566835759,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.306 0.016 229.6)",
       "foreground": "oklch(0.99 0.014 180.7)",
@@ -7509,6 +8899,11 @@
     "name": "Monokai Pro Octagon",
     "slug": "monokai-pro-octagon",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.458299554012848,
+      "minAnsi": 4.987836152714678,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.29 0.029 278.9)",
       "foreground": "oklch(0.955 0.009 188.1)",
@@ -7536,6 +8931,11 @@
     "name": "Monokai Pro Ristretto",
     "slug": "monokai-pro-ristretto",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.678374839673454,
+      "minAnsi": 5.35197457474938,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.272 0.011 17.8)",
       "foreground": "oklch(0.97 0.015 7.5)",
@@ -7563,6 +8963,11 @@
     "name": "Monokai Pro Spectrum",
     "slug": "monokai-pro-spectrum",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.380315292688463,
+      "minAnsi": 5.306193260414424,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.252 0 0)",
       "foreground": "oklch(0.967 0.02 305.3)",
@@ -7590,6 +8995,11 @@
     "name": "Monokai Remastered",
     "slug": "monokai-remastered",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.858423328500182,
+      "minAnsi": 4.668582442464516,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.154 0 0)",
       "foreground": "oklch(0.885 0 0)",
@@ -7617,6 +9027,11 @@
     "name": "Monokai Soda",
     "slug": "monokai-soda",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.946069785556245,
+      "minAnsi": 4.153720118535801,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.218 0 0)",
       "foreground": "oklch(0.818 0.022 109.8)",
@@ -7644,6 +9059,11 @@
     "name": "Monokai Vivid",
     "slug": "monokai-vivid",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 17.793529016500525,
+      "minAnsi": 2.901063352451498,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.182 0 0)",
       "foreground": "oklch(0.982 0 0)",
@@ -7671,6 +9091,11 @@
     "name": "Monospace Dark",
     "slug": "monospace-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.234515770436655,
+      "minAnsi": 6.156660025847598,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.195 0.018 259.7)",
       "foreground": "oklch(0.75 0.024 254.4)",
@@ -7698,6 +9123,11 @@
     "name": "Monospace Light",
     "slug": "monospace-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 7.266353531891272,
+      "minAnsi": 4.505357332424551,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.976 0.009 264.5)",
       "foreground": "oklch(0.439 0.034 258.4)",
@@ -7725,6 +9155,11 @@
     "name": "Moonfly",
     "slug": "moonfly",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.659933999239652,
+      "minAnsi": 6.340238803392663,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.134 0 0)",
       "foreground": "oklch(0.798 0 0)",
@@ -7752,6 +9187,11 @@
     "name": "N0Tch2K",
     "slug": "n0tch2k",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.084168958953755,
+      "minAnsi": 2.7708877609388116,
+      "minAnsiSlot": "green"
+    },
     "colors": {
       "background": "oklch(0.252 0 0)",
       "foreground": "oklch(0.706 0 0)",
@@ -7779,6 +9219,11 @@
     "name": "Neobones Dark",
     "slug": "neobones-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.720184438248431,
+      "minAnsi": 5.2426063355364,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0.207 0.019 235.2)",
       "foreground": "oklch(0.86 0.018 170)",
@@ -7806,6 +9251,11 @@
     "name": "Neobones Light",
     "slug": "neobones-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 12.00210015017332,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.938 0.013 149.2)",
       "foreground": "oklch(0.282 0.043 134.8)",
@@ -7833,6 +9283,11 @@
     "name": "Neon",
     "slug": "neon",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.412025090407829,
+      "minAnsi": 1.8277614021550688,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.2 0.009 264.4)",
       "foreground": "oklch(0.904 0.155 193.2)",
@@ -7860,6 +9315,11 @@
     "name": "Neopolitan",
     "slug": "neopolitan",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.19996616356344,
+      "minAnsi": 1.8439469394618435,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.247 0.017 58.8)",
       "foreground": "oklch(1 0 0)",
@@ -7887,6 +9347,11 @@
     "name": "Neutron",
     "slug": "neutron",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.633660688662903,
+      "minAnsi": 2.981583346060887,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.235 0.008 264.4)",
       "foreground": "oklch(0.932 0.01 273.4)",
@@ -7914,6 +9379,11 @@
     "name": "Night Lion V1",
     "slug": "night-lion-v1",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.938659901217408,
+      "minAnsi": 3.112959094998821,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.792 0 0)",
@@ -7941,6 +9411,11 @@
     "name": "Night Lion V2",
     "slug": "night-lion-v2",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.338407013867828,
+      "minAnsi": 2.657553969968964,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.205 0 0)",
       "foreground": "oklch(0.792 0 0)",
@@ -7968,6 +9443,11 @@
     "name": "Night Owl",
     "slug": "night-owl",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.53940404990579,
+      "minAnsi": 5.258898207615183,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.193 0.045 244)",
       "foreground": "oklch(0.898 0.02 260.2)",
@@ -7995,6 +9475,11 @@
     "name": "Night Owlish Light",
     "slug": "night-owlish-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 10.224415580610703,
+      "minAnsi": 1.763208306837443,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.377 0.034 286.9)",
@@ -8022,6 +9507,11 @@
     "name": "Nightfox",
     "slug": "nightfox",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.0612149558544,
+      "minAnsi": 3.641362087864303,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.253 0.029 255.2)",
       "foreground": "oklch(0.851 0.002 247.8)",
@@ -8049,6 +9539,11 @@
     "name": "Niji",
     "slug": "niji",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 18.295244886897216,
+      "minAnsi": 3.8619377765509926,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.195 0.002 197)",
       "foreground": "oklch(1 0 0)",
@@ -8076,6 +9571,11 @@
     "name": "No Clown Fiesta",
     "slug": "no-clown-fiesta",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.551821344102843,
+      "minAnsi": 4.623111343449321,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.173 0 0)",
       "foreground": "oklch(0.91 0.004 271.4)",
@@ -8103,6 +9603,11 @@
     "name": "No Clown Fiesta Light",
     "slug": "no-clown-fiesta-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 13.964447543611657,
+      "minAnsi": 1.1114261503387803,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.91 0 0)",
       "foreground": "oklch(0.196 0 0)",
@@ -8130,6 +9635,11 @@
     "name": "Nocturnal Winter",
     "slug": "nocturnal-winter",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.366059343122442,
+      "minAnsi": 4.817923666381618,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.165 0.021 283.9)",
       "foreground": "oklch(0.923 0.001 17.2)",
@@ -8157,6 +9667,11 @@
     "name": "Nord",
     "slug": "nord",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.245243340706116,
+      "minAnsi": 3.0529785210102194,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.324 0.023 264.2)",
       "foreground": "oklch(0.899 0.016 262.7)",
@@ -8184,6 +9699,11 @@
     "name": "Nord Light",
     "slug": "nord-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 7.522127784995569,
+      "minAnsi": 1.8996402873179057,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.933 0.01 261.8)",
       "foreground": "oklch(0.402 0.029 266.5)",
@@ -8211,6 +9731,11 @@
     "name": "Nord Wave",
     "slug": "nord-wave",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.919405742162793,
+      "minAnsi": 3.9360445553453185,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.248 0 0)",
       "foreground": "oklch(0.899 0.016 262.7)",
@@ -8238,6 +9763,11 @@
     "name": "Nordfox",
     "slug": "nordfox",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.925159685601855,
+      "minAnsi": 3.0529785210102194,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.324 0.023 264.2)",
       "foreground": "oklch(0.851 0.002 247.8)",
@@ -8265,6 +9795,11 @@
     "name": "Novel",
     "slug": "novel",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 10.38876302397345,
+      "minAnsi": 2.602952294010411,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0.888 0.032 99.3)",
       "foreground": "oklch(0.287 0.037 22.2)",
@@ -8292,6 +9827,11 @@
     "name": "novmbr",
     "slug": "novmbr",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.596459173796818,
+      "minAnsi": 3.4332338892382444,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.238 0.012 44.5)",
       "foreground": "oklch(0.792 0.024 61.1)",
@@ -8319,6 +9859,11 @@
     "name": "Nvim Dark",
     "slug": "nvim-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.992604952689101,
+      "minAnsi": 11.62803481704881,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.2 0.011 268.2)",
       "foreground": "oklch(0.914 0.011 274.9)",
@@ -8346,6 +9891,11 @@
     "name": "Nvim Light",
     "slug": "nvim-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 13.992604952689101,
+      "minAnsi": 4.38830879526678,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.914 0.011 274.9)",
       "foreground": "oklch(0.2 0.011 268.2)",
@@ -8373,6 +9923,11 @@
     "name": "Obsidian",
     "slug": "obsidian",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.463511117836331,
+      "minAnsi": 1.9096858460763608,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.303 0.012 222.4)",
       "foreground": "oklch(0.848 0 0)",
@@ -8400,6 +9955,11 @@
     "name": "Ocean",
     "slug": "ocean",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.210109398318694,
+      "minAnsi": 1.7728586167803841,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.467 0.179 263.8)",
       "foreground": "oklch(1 0 0)",
@@ -8427,6 +9987,11 @@
     "name": "Oceanic Material",
     "slug": "oceanic-material",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.208078041725516,
+      "minAnsi": 1.8762051225776182,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.261 0.017 229.8)",
       "foreground": "oklch(0.833 0.022 268.4)",
@@ -8454,6 +10019,11 @@
     "name": "Oceanic Next",
     "slug": "oceanic-next",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.38226331693684,
+      "minAnsi": 4.426151819457613,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.279 0.033 226.4)",
       "foreground": "oklch(0.822 0.014 262.4)",
@@ -8481,6 +10051,11 @@
     "name": "Ollie",
     "slug": "ollie",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 4.954611624675583,
+      "minAnsi": 2.3398842060925027,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.251 0.008 297.3)",
       "foreground": "oklch(0.653 0.049 280.9)",
@@ -8508,6 +10083,11 @@
     "name": "One Dark Two",
     "slug": "one-dark-two",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.334143005151907,
+      "minAnsi": 5.305273709224045,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.263 0.013 258.4)",
       "foreground": "oklch(0.925 0 0)",
@@ -8535,6 +10115,11 @@
     "name": "One Double Dark",
     "slug": "one-double-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.465097902118544,
+      "minAnsi": 4.511665445871898,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.293 0.016 264.3)",
       "foreground": "oklch(0.902 0.009 258.3)",
@@ -8562,6 +10147,11 @@
     "name": "One Double Light",
     "slug": "one-double-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 10.849451259037943,
+      "minAnsi": 2.2053403905397357,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.985 0 0)",
       "foreground": "oklch(0.35 0.016 275.6)",
@@ -8589,6 +10179,11 @@
     "name": "One Half Dark",
     "slug": "one-half-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.478412941103713,
+      "minAnsi": 4.380661260730335,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.293 0.016 264.3)",
       "foreground": "oklch(0.903 0.008 260.7)",
@@ -8616,6 +10211,11 @@
     "name": "One Half Light",
     "slug": "one-half-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 10.863393658010082,
+      "minAnsi": 1.8993201372831612,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.985 0 0)",
       "foreground": "oklch(0.35 0.014 274.5)",
@@ -8643,6 +10243,11 @@
     "name": "Onenord",
     "slug": "onenord",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.25659652805605,
+      "minAnsi": 3.908267949467851,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.324 0.023 264.2)",
       "foreground": "oklch(0.933 0.01 261.8)",
@@ -8670,6 +10275,11 @@
     "name": "Onenord Light",
     "slug": "onenord-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 11.753443309657749,
+      "minAnsi": 1.960773395813948,
+      "minAnsiSlot": "brightCyan"
+    },
     "colors": {
       "background": "oklch(0.979 0.003 264.5)",
       "foreground": "oklch(0.324 0.023 264.2)",
@@ -8697,6 +10307,11 @@
     "name": "Operator Mono Dark",
     "slug": "operator-mono-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.505178272829403,
+      "minAnsi": 3.4289982280025533,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.213 0 0)",
       "foreground": "oklch(0.831 0.013 141.8)",
@@ -8724,6 +10339,11 @@
     "name": "Overnight Slumber",
     "slug": "overnight-slumber",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.77413845803145,
+      "minAnsi": 7.449058975558719,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.206 0.039 263.2)",
       "foreground": "oklch(0.862 0.007 247.9)",
@@ -8751,6 +10371,11 @@
     "name": "owl",
     "slug": "owl",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.386836704362713,
+      "minAnsi": 2.0261237240353873,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.294 0.006 0.4)",
       "foreground": "oklch(0.901 0 0)",
@@ -8778,6 +10403,11 @@
     "name": "Oxocarbon",
     "slug": "oxocarbon",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.434104834959708,
+      "minAnsi": 5.582387546659929,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0.2 0 0)",
       "foreground": "oklch(0.967 0.006 264.5)",
@@ -8805,6 +10435,11 @@
     "name": "Pale Night Hc",
     "slug": "pale-night-hc",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.218254940110127,
+      "minAnsi": 3.4895700916505707,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.381 0.026 273.4)",
       "foreground": "oklch(0.845 0 0)",
@@ -8832,6 +10467,11 @@
     "name": "Pandora",
     "slug": "pandora",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.386273222738254,
+      "minAnsi": 2.70101622647231,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.249 0.071 269.3)",
       "foreground": "oklch(0.91 0 0)",
@@ -8859,6 +10499,11 @@
     "name": "Paraiso Dark",
     "slug": "paraiso-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 5.884989370345183,
+      "minAnsi": 2.946392098596513,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.263 0.038 328.6)",
       "foreground": "oklch(0.703 0.007 53.4)",
@@ -8886,6 +10531,11 @@
     "name": "Paul Millr",
     "slug": "paul-millr",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 18.758462357639324,
+      "minAnsi": 4.258308763379725,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.961 0 0)",
@@ -8913,6 +10563,11 @@
     "name": "Pencil Dark",
     "slug": "pencil-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.256150521367877,
+      "minAnsi": 2.134569969193749,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.248 0 0)",
       "foreground": "oklch(0.958 0 0)",
@@ -8940,6 +10595,11 @@
     "name": "Pencil Light",
     "slug": "pencil-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 8.89758745422114,
+      "minAnsi": 1.8000751461131685,
+      "minAnsiSlot": "brightGreen"
+    },
     "colors": {
       "background": "oklch(0.958 0 0)",
       "foreground": "oklch(0.379 0 0)",
@@ -8967,6 +10627,11 @@
     "name": "Peppermint",
     "slug": "peppermint",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.551608808593013,
+      "minAnsi": 5.477832594172877,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.833 0 0)",
@@ -8994,6 +10659,11 @@
     "name": "Phala Green Dark",
     "slug": "phala-green-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 17.192967582604293,
+      "minAnsi": 2.0041481377565944,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.917 0.23 125)",
@@ -9021,6 +10691,11 @@
     "name": "Piatto Light",
     "slug": "piatto-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 10.207985564813495,
+      "minAnsi": 3.3777555423987504,
+      "minAnsiSlot": "brightGreen"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.375 0 0)",
@@ -9048,6 +10723,11 @@
     "name": "Pierre Dark",
     "slug": "pierre-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 19.466519025872614,
+      "minAnsi": 4.8256228680752455,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.129 0 0)",
       "foreground": "oklch(0.988 0 0)",
@@ -9075,6 +10755,11 @@
     "name": "Pierre Light",
     "slug": "pierre-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 20.144005124323062,
+      "minAnsi": 2.143605535002515,
+      "minAnsiSlot": "brightCyan"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.129 0 0)",
@@ -9102,6 +10787,11 @@
     "name": "Pnevma",
     "slug": "pnevma",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.04905582259089,
+      "minAnsi": 3.773370334704558,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.226 0 0)",
       "foreground": "oklch(0.858 0 0)",
@@ -9129,6 +10819,11 @@
     "name": "Poimandres",
     "slug": "poimandres",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.461852439701996,
+      "minAnsi": 4.847321037417616,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.236 0.02 267.8)",
       "foreground": "oklch(0.751 0.048 277.1)",
@@ -9156,6 +10851,11 @@
     "name": "Poimandres Darker",
     "slug": "poimandres-darker",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.05391830376466,
+      "minAnsi": 5.231935091581677,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.204 0.016 284.9)",
       "foreground": "oklch(0.751 0.048 277.1)",
@@ -9183,6 +10883,11 @@
     "name": "Poimandres Storm",
     "slug": "poimandres-storm",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.356688691112879,
+      "minAnsi": 4.129391604797894,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.289 0.024 264.1)",
       "foreground": "oklch(0.751 0.048 277.1)",
@@ -9210,6 +10915,11 @@
     "name": "Poimandres White",
     "slug": "poimandres-white",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 2.6755931412786236,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.997 0.001 286.4)",
       "foreground": "oklch(0.699 0.049 277)",
@@ -9237,6 +10947,11 @@
     "name": "Popping And Locking",
     "slug": "popping-and-locking",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.758172497859183,
+      "minAnsi": 3.19836776044365,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.216 0.016 279.4)",
       "foreground": "oklch(0.894 0.057 89.2)",
@@ -9264,6 +10979,11 @@
     "name": "Powershell",
     "slug": "powershell",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.020509235779741,
+      "minAnsi": 1.8069630733148705,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.272 0.095 259.3)",
       "foreground": "oklch(0.973 0.001 286.4)",
@@ -9291,6 +11011,11 @@
     "name": "Primary",
     "slug": "primary",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.846133950253248,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -9318,6 +11043,11 @@
     "name": "Pro",
     "slug": "pro",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 18.758462357639324,
+      "minAnsi": 2.1233846988883243,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.961 0 0)",
@@ -9345,6 +11075,11 @@
     "name": "Pro Light",
     "slug": "pro-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 17.581691183046004,
+      "minAnsi": 1.8107564747142557,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.213 0 0)",
@@ -9372,6 +11107,11 @@
     "name": "Purple Rain",
     "slug": "purple-rain",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 17.009044216336548,
+      "minAnsi": 3.419143255584005,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.228 0.11 292.4)",
       "foreground": "oklch(0.99 0.008 73.7)",
@@ -9399,6 +11139,11 @@
     "name": "Purplepeter",
     "slug": "purplepeter",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.919124689259478,
+      "minAnsi": 6.013488481454252,
+      "minAnsiSlot": "brightPurple"
+    },
     "colors": {
       "background": "oklch(0.267 0.086 295.4)",
       "foreground": "oklch(0.938 0.026 297.9)",
@@ -9426,6 +11171,11 @@
     "name": "Rapture",
     "slug": "rapture",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.239434034482036,
+      "minAnsi": 5.539149438155462,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.229 0.03 247.3)",
       "foreground": "oklch(0.838 0.04 271.4)",
@@ -9453,6 +11203,11 @@
     "name": "Raycast Dark",
     "slug": "raycast-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 17.40432753274219,
+      "minAnsi": 3.7403436061563577,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.218 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -9480,6 +11235,11 @@
     "name": "Raycast Light",
     "slug": "raycast-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 2.0527520433423008,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -9507,6 +11267,11 @@
     "name": "Rebecca",
     "slug": "rebecca",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.248141083660046,
+      "minAnsi": 4.535856617188583,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.297 0.047 281.4)",
       "foreground": "oklch(0.929 0.01 299.2)",
@@ -9534,6 +11299,11 @@
     "name": "Red Alert",
     "slug": "red-alert",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.259262636372943,
+      "minAnsi": 2.13003691601782,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.388 0.115 24.9)",
       "foreground": "oklch(1 0 0)",
@@ -9561,6 +11331,11 @@
     "name": "Red Planet",
     "slug": "red-planet",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.9322520180450375,
+      "minAnsi": 2.009464569074746,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.252 0 0)",
       "foreground": "oklch(0.779 0.054 94.2)",
@@ -9588,6 +11363,11 @@
     "name": "Red Sands",
     "slug": "red-sands",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.064777615087849,
+      "minAnsi": 1.8146520910097659,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.396 0.12 28.4)",
       "foreground": "oklch(0.839 0.048 88.3)",
@@ -9615,6 +11395,11 @@
     "name": "Relaxed",
     "slug": "relaxed",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.085253934930217,
+      "minAnsi": 2.4968042890653295,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.348 0.019 264.3)",
       "foreground": "oklch(0.885 0 0)",
@@ -9642,6 +11427,11 @@
     "name": "Retro",
     "slug": "retro",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.131978314215707,
+      "minAnsi": 6.131978314215707,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.616 0.204 142.4)",
@@ -9669,6 +11459,11 @@
     "name": "Retro Legends",
     "slug": "retro-legends",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.237276805572264,
+      "minAnsi": 4.072864638260987,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.159 0 0)",
       "foreground": "oklch(0.825 0.245 142.9)",
@@ -9696,6 +11491,11 @@
     "name": "Rippedcasts",
     "slug": "rippedcasts",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.159028077509387,
+      "minAnsi": 2.399531884329739,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.289 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -9723,6 +11523,11 @@
     "name": "Rose Pine",
     "slug": "rose-pine",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.388874563413934,
+      "minAnsi": 3.3844729603705237,
+      "minAnsiSlot": "green"
+    },
     "colors": {
       "background": "oklch(0.213 0.026 291.1)",
       "foreground": "oklch(0.909 0.03 290)",
@@ -9750,6 +11555,11 @@
     "name": "Rose Pine Dawn",
     "slug": "rose-pine-dawn",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 6.657280748896968,
+      "minAnsi": 1.0975949529306095,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.97 0.011 71.9)",
       "foreground": "oklch(0.46 0.063 289.6)",
@@ -9777,6 +11587,11 @@
     "name": "Rose Pine Moon",
     "slug": "rose-pine-moon",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.86365608062847,
+      "minAnsi": 4.2917619544933325,
+      "minAnsiSlot": "green"
+    },
     "colors": {
       "background": "oklch(0.26 0.039 287.7)",
       "foreground": "oklch(0.909 0.03 290)",
@@ -9804,6 +11619,11 @@
     "name": "Rouge 2",
     "slug": "rouge-2",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.951602240413291,
+      "minAnsi": 2.2199150694626915,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.218 0.037 280.5)",
       "foreground": "oklch(0.717 0.01 279.6)",
@@ -9831,6 +11651,11 @@
     "name": "Royal",
     "slug": "royal",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 2.344317840825611,
+      "minAnsi": 2.3451310575567703,
+      "minAnsiSlot": "white"
+    },
     "colors": {
       "background": "oklch(0.153 0.03 311.7)",
       "foreground": "oklch(0.426 0.052 296)",
@@ -9858,6 +11683,11 @@
     "name": "Ryuuko",
     "slug": "ryuuko",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.050443066375967,
+      "minAnsi": 2.1494132766980996,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.336 0.022 235.3)",
       "foreground": "oklch(0.943 0 0)",
@@ -9885,6 +11715,11 @@
     "name": "Sakura",
     "slug": "sakura",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.900875593125184,
+      "minAnsi": 3.4860996084218416,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.198 0.023 305.1)",
       "foreground": "oklch(0.724 0.171 327.5)",
@@ -9912,6 +11747,11 @@
     "name": "Scarlet Protocol",
     "slug": "scarlet-protocol",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 3.722686705931152,
+      "minAnsi": 3.3006754326442884,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.23 0.074 287.2)",
       "foreground": "oklch(0.591 0.227 14.7)",
@@ -9939,6 +11779,11 @@
     "name": "Sea Shells",
     "slug": "sea-shells",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.063584268094104,
+      "minAnsi": 1.8838589698587347,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.184 0.022 237.4)",
       "foreground": "oklch(0.806 0.072 70)",
@@ -9966,6 +11811,11 @@
     "name": "Seafoam Pastel",
     "slug": "seafoam-pastel",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.002648131351295,
+      "minAnsi": 2.239137355390117,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.311 0.021 201)",
       "foreground": "oklch(0.909 0.033 145.3)",
@@ -9993,6 +11843,11 @@
     "name": "SeedFlip Abyss",
     "slug": "seedflip-abyss",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.536212085927929,
+      "minAnsi": 5.3902549732184895,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.123 0.027 281.7)",
       "foreground": "oklch(0.912 0.022 286)",
@@ -10020,6 +11875,11 @@
     "name": "SeedFlip Amethyst",
     "slug": "seedflip-amethyst",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 17.41793666081968,
+      "minAnsi": 1.4148225725009902,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.977 0.002 67.8)",
       "foreground": "oklch(0.193 0.069 300.4)",
@@ -10047,6 +11907,11 @@
     "name": "SeedFlip Canopy",
     "slug": "seedflip-canopy",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.557596566165074,
+      "minAnsi": 4.808989972669291,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.195 0.013 169.9)",
       "foreground": "oklch(0.946 0 0)",
@@ -10074,6 +11939,11 @@
     "name": "SeedFlip Carbon",
     "slug": "seedflip-carbon",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 20.119467064985724,
+      "minAnsi": 1.4201145053585909,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.985 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -10101,6 +11971,11 @@
     "name": "SeedFlip Coral",
     "slug": "seedflip-coral",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 16.857588663262874,
+      "minAnsi": 1.4115336199566344,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.231 0 0)",
@@ -10128,6 +12003,11 @@
     "name": "SeedFlip Ember",
     "slug": "seedflip-ember",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.91088278219183,
+      "minAnsi": 5.2446309800109665,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.145 0 0)",
       "foreground": "oklch(0.946 0 0)",
@@ -10155,6 +12035,11 @@
     "name": "SeedFlip Glacier",
     "slug": "seedflip-glacier",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 17.062933971317335,
+      "minAnsi": 1.4499487730975231,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.984 0.003 247.9)",
       "foreground": "oklch(0.208 0.04 265.8)",
@@ -10182,6 +12067,11 @@
     "name": "SeedFlip Inkwell",
     "slug": "seedflip-inkwell",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.64436712791649,
+      "minAnsi": 5.335962454984181,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.145 0 0)",
       "foreground": "oklch(0.921 0.008 73.7)",
@@ -10209,6 +12099,11 @@
     "name": "SeedFlip Ivory",
     "slug": "seedflip-ivory",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 15.537529558868556,
+      "minAnsi": 1.4115336199566344,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.26 0.06 251.3)",
@@ -10236,6 +12131,11 @@
     "name": "SeedFlip Nightfall",
     "slug": "seedflip-nightfall",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.565974491498903,
+      "minAnsi": 5.232225084839507,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.147 0.011 285)",
       "foreground": "oklch(0.92 0.004 286.3)",
@@ -10263,6 +12163,11 @@
     "name": "SeedFlip Phosphor",
     "slug": "seedflip-phosphor",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.64757704069159,
+      "minAnsi": 5.181976866215178,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.154 0 0)",
       "foreground": "oklch(0.932 0.126 144.5)",
@@ -10290,6 +12195,11 @@
     "name": "SeedFlip Pulse",
     "slug": "seedflip-pulse",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 18.733663902900595,
+      "minAnsi": 4.904182567407399,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.182 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -10317,6 +12227,11 @@
     "name": "SeedFlip Ultraviolet",
     "slug": "seedflip-ultraviolet",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.0221059320603,
+      "minAnsi": 5.430870724668883,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.115 0.058 311)",
       "foreground": "oklch(0.919 0.029 303.1)",
@@ -10344,6 +12259,11 @@
     "name": "SeedFlip Voltage",
     "slug": "seedflip-voltage",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 17.37272426550883,
+      "minAnsi": 5.2446309800109665,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.145 0 0)",
       "foreground": "oklch(0.955 0 0)",
@@ -10371,6 +12291,11 @@
     "name": "SeedFlip Wavelength",
     "slug": "seedflip-wavelength",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.016082890827004,
+      "minAnsi": 5.004239886748117,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.176 0.014 258.4)",
       "foreground": "oklch(0.943 0.011 243.7)",
@@ -10398,6 +12323,11 @@
     "name": "Selenized Black",
     "slug": "selenized-black",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.049775236144459,
+      "minAnsi": 4.793224199856737,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.209 0 0)",
       "foreground": "oklch(0.786 0 0)",
@@ -10425,6 +12355,11 @@
     "name": "Selenized Dark",
     "slug": "selenized-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.070714842078603,
+      "minAnsi": 3.714015544132306,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.332 0.051 219.6)",
       "foreground": "oklch(0.784 0.017 196.8)",
@@ -10452,6 +12387,11 @@
     "name": "Selenized Light",
     "slug": "selenized-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 5.368789066610502,
+      "minAnsi": 1.1533436464304379,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.964 0.033 91.7)",
       "foreground": "oklch(0.5 0.026 217.9)",
@@ -10479,6 +12419,11 @@
     "name": "Seoulbones Dark",
     "slug": "seoulbones-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.4228523951217955,
+      "minAnsi": 3.454928793150346,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.413 0 0)",
       "foreground": "oklch(0.898 0 0)",
@@ -10506,6 +12451,11 @@
     "name": "Seoulbones Light",
     "slug": "seoulbones-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 5.75486124007544,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.913 0 0)",
       "foreground": "oklch(0.45 0 0)",
@@ -10533,6 +12483,11 @@
     "name": "Seti",
     "slug": "seti",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.807341305446808,
+      "minAnsi": 3.253769633312443,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.182 0.003 248)",
       "foreground": "oklch(0.848 0.005 179.7)",
@@ -10560,6 +12515,11 @@
     "name": "Shades Of Purple",
     "slug": "shades-of-purple",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.092165121757127,
+      "minAnsi": 2.948324833991461,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.253 0.065 282)",
       "foreground": "oklch(1 0 0)",
@@ -10587,6 +12547,11 @@
     "name": "Shaman",
     "slug": "shaman",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 2.4412048193974893,
+      "minAnsi": 2.4412048193974893,
+      "minAnsiSlot": "white"
+    },
     "colors": {
       "background": "oklch(0.16 0.029 216.7)",
       "foreground": "oklch(0.432 0.026 196.2)",
@@ -10614,6 +12579,11 @@
     "name": "Slate",
     "slug": "slate",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.341918037634301,
+      "minAnsi": 2.02361972704601,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.252 0 0)",
       "foreground": "oklch(0.708 0.115 219.9)",
@@ -10641,6 +12611,11 @@
     "name": "Sleepy Hollow",
     "slug": "sleepy-hollow",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.997767716208966,
+      "minAnsi": 3.3168617734467447,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.183 0.004 286)",
       "foreground": "oklch(0.702 0.028 44.6)",
@@ -10668,6 +12643,11 @@
     "name": "Smyck",
     "slug": "smyck",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.077909234705352,
+      "minAnsi": 3.14840256472224,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.222 0 0)",
       "foreground": "oklch(0.976 0 0)",
@@ -10695,6 +12675,11 @@
     "name": "Snazzy",
     "slug": "snazzy",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.772605398339516,
+      "minAnsi": 4.699429687603196,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.243 0.019 280.4)",
       "foreground": "oklch(0.941 0.008 114.2)",
@@ -10722,6 +12707,11 @@
     "name": "Snazzy Soft",
     "slug": "snazzy-soft",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.432422229651946,
+      "minAnsi": 4.69287905910325,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.288 0.022 277.5)",
       "foreground": "oklch(0.953 0.007 115.7)",
@@ -10749,6 +12739,11 @@
     "name": "Soft Server",
     "slug": "soft-server",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 5.879429518296938,
+      "minAnsi": 3.2630057380542925,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.267 0.003 197)",
       "foreground": "oklch(0.707 0.012 189.7)",
@@ -10776,6 +12771,11 @@
     "name": "Solarized Darcula",
     "slug": "solarized-darcula",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.334558680660561,
+      "minAnsi": 2.231211230420756,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.367 0.004 247.9)",
       "foreground": "oklch(0.878 0.007 208.8)",
@@ -10803,6 +12803,11 @@
     "name": "Solarized Dark Higher Contrast",
     "slug": "solarized-dark-higher-contrast",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.986231218796952,
+      "minAnsi": 3.1249182198659002,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.218 0.04 221.1)",
       "foreground": "oklch(0.787 0.041 198.3)",
@@ -10830,6 +12835,11 @@
     "name": "Solarized Dark Patched",
     "slug": "solarized-dark-patched",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 4.292316518586955,
+      "minAnsi": 2.4203347306846625,
+      "minAnsiSlot": "brightGreen"
+    },
     "colors": {
       "background": "oklch(0.218 0.04 221.1)",
       "foreground": "oklch(0.593 0.021 204.8)",
@@ -10857,6 +12867,11 @@
     "name": "Solarized Osaka Night",
     "slug": "solarized-osaka-night",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.586955488631288,
+      "minAnsi": 6.459598504862066,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.226 0.021 280.5)",
       "foreground": "oklch(0.846 0.061 274.8)",
@@ -10884,6 +12899,11 @@
     "name": "Sonokai",
     "slug": "sonokai",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.482533479806625,
+      "minAnsi": 4.520821168756997,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.302 0.011 271)",
       "foreground": "oklch(0.913 0.001 286.4)",
@@ -10911,6 +12931,11 @@
     "name": "Spacedust",
     "slug": "spacedust",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.541950548199733,
+      "minAnsi": 2.1740694075162947,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.222 0.028 219.9)",
       "foreground": "oklch(0.94 0.061 111.5)",
@@ -10938,6 +12963,11 @@
     "name": "Spacegray",
     "slug": "spacegray",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.81333937048496,
+      "minAnsi": 2.951986272858967,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.26 0.018 266.3)",
       "foreground": "oklch(0.782 0.017 266.3)",
@@ -10965,6 +12995,11 @@
     "name": "Spacegray Bright",
     "slug": "spacegray-bright",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.2072193118411,
+      "minAnsi": 2.942947011543349,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.302 0.023 270.6)",
       "foreground": "oklch(0.964 0 0)",
@@ -10992,6 +13027,11 @@
     "name": "Spacegray Eighties",
     "slug": "spacegray-eighties",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.181159560092757,
+      "minAnsi": 4.194744394376575,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0.252 0 0)",
       "foreground": "oklch(0.788 0.017 95.3)",
@@ -11019,6 +13059,11 @@
     "name": "Spacegray Eighties Dull",
     "slug": "spacegray-eighties-dull",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.309085578355408,
+      "minAnsi": 3.0356889444505972,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.252 0 0)",
       "foreground": "oklch(0.826 0.014 93)",
@@ -11046,6 +13091,11 @@
     "name": "Spiderman",
     "slug": "spiderman",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.184335675121535,
+      "minAnsi": 2.100683552485315,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.229 0.004 229)",
       "foreground": "oklch(0.916 0 0)",
@@ -11073,6 +13123,11 @@
     "name": "Spring",
     "slug": "spring",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 8.462734156064165,
+      "minAnsi": 1.8096338111861874,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.42 0.002 106.5)",
@@ -11100,6 +13155,11 @@
     "name": "Square",
     "slug": "square",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.660552557276896,
+      "minAnsi": 2.6436825037748144,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.218 0 0)",
       "foreground": "oklch(0.744 0.001 106.4)",
@@ -11127,6 +13187,11 @@
     "name": "Squirrelsong Dark",
     "slug": "squirrelsong-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 5.2777803385124376,
+      "minAnsi": 2.5998690630068184,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.294 0.026 54.2)",
       "foreground": "oklch(0.704 0.037 61.5)",
@@ -11154,6 +13219,11 @@
     "name": "Srcery",
     "slug": "srcery",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.317294396222751,
+      "minAnsi": 3.7256622149750083,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.223 0.004 84.6)",
       "foreground": "oklch(0.938 0.053 82.9)",
@@ -11181,6 +13251,11 @@
     "name": "Starlight",
     "slug": "starlight",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.522910417680388,
+      "minAnsi": 4.00029384939123,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.26 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -11208,6 +13283,11 @@
     "name": "Sublette",
     "slug": "sublette",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.660461971394787,
+      "minAnsi": 4.501947279840205,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.267 0.031 270.8)",
       "foreground": "oklch(0.85 0.004 247.9)",
@@ -11235,6 +13315,11 @@
     "name": "Subliminal",
     "slug": "subliminal",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.433021582474693,
+      "minAnsi": 3.8836571842058842,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.293 0.017 266.4)",
       "foreground": "oklch(0.87 0 0)",
@@ -11262,6 +13347,11 @@
     "name": "Sugarplum",
     "slug": "sugarplum",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.685816665804914,
+      "minAnsi": 5.0298091929605615,
+      "minAnsiSlot": "white"
+    },
     "colors": {
       "background": "oklch(0.222 0.098 275)",
       "foreground": "oklch(0.725 0.167 326.4)",
@@ -11289,6 +13379,11 @@
     "name": "Sundried",
     "slug": "sundried",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.676827770199447,
+      "minAnsi": 2.2853991383298307,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.211 0.003 17.4)",
       "foreground": "oklch(0.836 0 0)",
@@ -11316,6 +13411,11 @@
     "name": "Sunset Drive",
     "slug": "sunset-drive",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.442942518787937,
+      "minAnsi": 4.922417664339642,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.174 0.023 283.8)",
       "foreground": "oklch(0.951 0.023 286)",
@@ -11343,6 +13443,11 @@
     "name": "Symfonic",
     "slug": "symfonic",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 4.3325819930115825,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -11370,6 +13475,11 @@
     "name": "Synthwave",
     "slug": "synthwave",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.730931171766903,
+      "minAnsi": 5.445853667182818,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.881 0.024 104.3)",
@@ -11397,6 +13507,11 @@
     "name": "Synthwave Alpha",
     "slug": "synthwave-alpha",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.582969904906374,
+      "minAnsi": 2.027201120274542,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.243 0.041 303.2)",
       "foreground": "oklch(0.957 0.02 106.8)",
@@ -11424,6 +13539,11 @@
     "name": "Synthwave Everything",
     "slug": "synthwave-everything",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.324266084774642,
+      "minAnsi": 3.5924708673024863,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.27 0.045 300.7)",
       "foreground": "oklch(0.954 0.003 308.4)",
@@ -11451,6 +13571,11 @@
     "name": "Tango Adapted",
     "slug": "tango-adapted",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7728242657985633,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -11478,6 +13603,11 @@
     "name": "Tango Half Adapted",
     "slug": "tango-half-adapted",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7459296405192763,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -11505,6 +13635,11 @@
     "name": "Tearout",
     "slug": "tearout",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.295737558769867,
+      "minAnsi": 3.56188855262931,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0.336 0.022 126)",
       "foreground": "oklch(0.884 0.061 68.5)",
@@ -11532,6 +13667,11 @@
     "name": "Teerb",
     "slug": "teerb",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.81167442210102,
+      "minAnsi": 5.486634636507461,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.269 0 0)",
       "foreground": "oklch(0.858 0 0)",
@@ -11559,6 +13699,11 @@
     "name": "Terafox",
     "slug": "terafox",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 13.051867566503034,
+      "minAnsi": 3.465125748737453,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.252 0.022 210.6)",
       "foreground": "oklch(0.934 0.004 197.1)",
@@ -11586,6 +13731,11 @@
     "name": "Terminal Basic",
     "slug": "terminal-basic",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.7775640487086088,
+      "minAnsiSlot": "brightCyan"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -11613,6 +13763,11 @@
     "name": "Terminal Basic Dark",
     "slug": "terminal-basic-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.72383121302713,
+      "minAnsi": 2.8602520349675142,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.234 0.002 145.5)",
       "foreground": "oklch(1 0 0)",
@@ -11640,6 +13795,11 @@
     "name": "Thayer Bright",
     "slug": "thayer-bright",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.932465003618038,
+      "minAnsi": 2.7560749420902746,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.229 0.004 229)",
       "foreground": "oklch(0.979 0 0)",
@@ -11667,6 +13827,11 @@
     "name": "The Hulk",
     "slug": "the-hulk",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.252014407932334,
+      "minAnsi": 1.9171854932336487,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.229 0.004 229)",
       "foreground": "oklch(0.773 0 0)",
@@ -11694,6 +13859,11 @@
     "name": "Tinacious Design Dark",
     "slug": "tinacious-design-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.62116497814062,
+      "minAnsi": 4.835816637339798,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.235 0.017 285)",
       "foreground": "oklch(0.854 0.051 285.3)",
@@ -11721,6 +13891,11 @@
     "name": "Tinacious Design Light",
     "slug": "tinacious-design-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 15.814194778398958,
+      "minAnsi": 1.8078987379182248,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.981 0.009 286.2)",
       "foreground": "oklch(0.235 0.017 285)",
@@ -11748,6 +13923,11 @@
     "name": "TokyoNight",
     "slug": "tokyonight",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.586955488631288,
+      "minAnsi": 6.459598504862066,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.226 0.021 280.5)",
       "foreground": "oklch(0.846 0.061 274.8)",
@@ -11775,6 +13955,11 @@
     "name": "TokyoNight Day",
     "slug": "tokyonight-day",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 4.524626461068713,
+      "minAnsi": 1.0683271955280342,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.914 0.007 277.2)",
       "foreground": "oklch(0.512 0.156 264.1)",
@@ -11802,6 +13987,11 @@
     "name": "TokyoNight Moon",
     "slug": "tokyonight-moon",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.258978159440368,
+      "minAnsi": 4.611378263479609,
+      "minAnsiSlot": "white"
+    },
     "colors": {
       "background": "oklch(0.267 0.034 279)",
       "foreground": "oklch(0.869 0.049 271.2)",
@@ -11829,6 +14019,11 @@
     "name": "TokyoNight Night",
     "slug": "tokyonight-night",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.586955488631288,
+      "minAnsi": 6.459598504862066,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.226 0.021 280.5)",
       "foreground": "oklch(0.846 0.061 274.8)",
@@ -11856,6 +14051,11 @@
     "name": "TokyoNight Storm",
     "slug": "tokyonight-storm",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.022797368046596,
+      "minAnsi": 5.505232212499105,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.282 0.036 274.7)",
       "foreground": "oklch(0.846 0.061 274.8)",
@@ -11883,6 +14083,11 @@
     "name": "Tomorrow",
     "slug": "tomorrow",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 8.462734156064165,
+      "minAnsi": 1.8630433291508341,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.42 0.002 106.5)",
@@ -11910,6 +14115,11 @@
     "name": "Tomorrow Night",
     "slug": "tomorrow-night",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.802581130534,
+      "minAnsi": 4.455907574271388,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.238 0.005 248)",
       "foreground": "oklch(0.83 0.004 157.2)",
@@ -11937,6 +14147,11 @@
     "name": "Tomorrow Night Blue",
     "slug": "tomorrow-night-blue",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.315423933501545,
+      "minAnsi": 7.73855958107012,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.267 0.092 256.2)",
       "foreground": "oklch(1 0 0)",
@@ -11964,6 +14179,11 @@
     "name": "Tomorrow Night Bright",
     "slug": "tomorrow-night-bright",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 17.455715087925668,
+      "minAnsi": 5.043889156185626,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.937 0 0)",
@@ -11991,6 +14211,11 @@
     "name": "Tomorrow Night Burns",
     "slug": "tomorrow-night-burns",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.189429486456223,
+      "minAnsi": 2.087171779793005,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.196 0 0)",
       "foreground": "oklch(0.748 0.02 230.8)",
@@ -12018,6 +14243,11 @@
     "name": "Tomorrow Night Eighties",
     "slug": "tomorrow-night-eighties",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.57577203782333,
+      "minAnsi": 4.586348251671749,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.297 0 0)",
       "foreground": "oklch(0.845 0 0)",
@@ -12045,6 +14275,11 @@
     "name": "Toy Chest",
     "slug": "toy-chest",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.12514029490876,
+      "minAnsi": 1.843454967804912,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.327 0.044 252.9)",
       "foreground": "oklch(0.759 0.177 154.1)",
@@ -12072,6 +14307,11 @@
     "name": "traffic",
     "slug": "traffic",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.492577249349715,
+      "minAnsi": 2.113054016108762,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.29 0.01 242)",
       "foreground": "oklch(0.8 0.035 60)",
@@ -12099,6 +14339,11 @@
     "name": "Treehouse",
     "slug": "treehouse",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 3.3711625379246564,
+      "minAnsi": 2.437084401192714,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.213 0 0)",
       "foreground": "oklch(0.533 0.039 82.7)",
@@ -12126,6 +14371,11 @@
     "name": "Twilight",
     "slug": "twilight",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 17.989775991412532,
+      "minAnsi": 1.9703046715158683,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.191 0 0)",
       "foreground": "oklch(0.989 0.055 107.4)",
@@ -12153,6 +14403,11 @@
     "name": "Ubuntu",
     "slug": "ubuntu",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.132233235942888,
+      "minAnsi": 2.6703044473030277,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.223 0.071 342.5)",
       "foreground": "oklch(0.949 0.003 106.5)",
@@ -12180,6 +14435,11 @@
     "name": "Ultra Dark",
     "slug": "ultra-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 7.3383170961873185,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -12207,6 +14467,11 @@
     "name": "Ultra Violent",
     "slug": "ultra-violent",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.357224924929971,
+      "minAnsi": 4.051063468277669,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.27 0.005 219.6)",
       "foreground": "oklch(0.811 0 0)",
@@ -12234,6 +14499,11 @@
     "name": "Under The Sea",
     "slug": "under-the-sea",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 19.212197278249175,
+      "minAnsi": 2.4230908129799236,
+      "minAnsiSlot": "white"
+    },
     "colors": {
       "background": "oklch(0.165 0.027 217.6)",
       "foreground": "oklch(1 0 0)",
@@ -12261,6 +14531,11 @@
     "name": "Unikitty",
     "slug": "unikitty",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 9.377538846094247,
+      "minAnsi": 1.7705259390552852,
+      "minAnsiSlot": "brightYellow"
+    },
     "colors": {
       "background": "oklch(0.788 0.165 341)",
       "foreground": "oklch(0.15 0 0)",
@@ -12288,6 +14563,11 @@
     "name": "urban",
     "slug": "urban",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 5.843439340558473,
+      "minAnsi": 1.819986830276663,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.309 0.02 297.7)",
       "foreground": "oklch(0.747 0.035 49.2)",
@@ -12315,6 +14595,11 @@
     "name": "Urple",
     "slug": "urple",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 4.306866255422723,
+      "minAnsi": 2.279660237886026,
+      "minAnsiSlot": "purple"
+    },
     "colors": {
       "background": "oklch(0.226 0.015 285.1)",
       "foreground": "oklch(0.603 0.052 302.8)",
@@ -12342,6 +14627,11 @@
     "name": "Vague",
     "slug": "vague",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.581186263208878,
+      "minAnsi": 5.298736117887128,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.192 0.002 286.2)",
       "foreground": "oklch(0.848 0 0)",
@@ -12369,6 +14659,11 @@
     "name": "Vaughn",
     "slug": "vaughn",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.58140024072453,
+      "minAnsi": 2.0616588151758917,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.284 0.078 282.2)",
       "foreground": "oklch(0.89 0.022 106.8)",
@@ -12396,6 +14691,11 @@
     "name": "Vercel",
     "slug": "vercel",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 18.230259212984933,
+      "minAnsi": 4.082538788719744,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.173 0 0)",
       "foreground": "oklch(0.985 0 0)",
@@ -12423,6 +14723,11 @@
     "name": "Vesper",
     "slug": "vesper",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 19.028110547666497,
+      "minAnsi": 7.276577801701197,
+      "minAnsiSlot": "white"
+    },
     "colors": {
       "background": "oklch(0.173 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -12450,6 +14755,11 @@
     "name": "Vibrant Ink",
     "slug": "vibrant-ink",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 2.444,
+      "minAnsiSlot": "brightBlue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(1 0 0)",
@@ -12477,6 +14787,11 @@
     "name": "Vimbones",
     "slug": "vimbones",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 10.526673507558153,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.946 0.05 107.3)",
       "foreground": "oklch(0.329 0 0)",
@@ -12504,6 +14819,11 @@
     "name": "Violet Dark",
     "slug": "violet-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 4.189220737359681,
+      "minAnsi": 2.9727791091037665,
+      "minAnsiSlot": "brightRed"
+    },
     "colors": {
       "background": "oklch(0.231 0.004 264.5)",
       "foreground": "oklch(0.593 0.021 204.8)",
@@ -12531,6 +14851,11 @@
     "name": "Violet Light",
     "slug": "violet-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 5.335951445041022,
+      "minAnsi": 2.858219229105977,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.967 0.033 91.7)",
       "foreground": "oklch(0.503 0.028 223)",
@@ -12558,6 +14883,11 @@
     "name": "Violite",
     "slug": "violite",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 14.606541287543338,
+      "minAnsi": 5.124584655833913,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.249 0.049 296.9)",
       "foreground": "oklch(0.963 0.007 219.6)",
@@ -12585,6 +14915,11 @@
     "name": "Warm Neon",
     "slug": "warm-neon",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.678634147244857,
+      "minAnsi": 1.85039566330447,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.372 0 0)",
       "foreground": "oklch(0.848 0.067 149.6)",
@@ -12612,6 +14947,11 @@
     "name": "Wez",
     "slug": "wez",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.015715656764469,
+      "minAnsi": 3.557585470026421,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0 0 0)",
       "foreground": "oklch(0.767 0 0)",
@@ -12639,6 +14979,11 @@
     "name": "Whimsy",
     "slug": "whimsy",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.911844163669688,
+      "minAnsi": 4.683836383729729,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.287 0.035 286.4)",
       "foreground": "oklch(0.772 0.054 288.7)",
@@ -12666,6 +15011,11 @@
     "name": "Wild Cherry",
     "slug": "wild-cherry",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 15.800135652275895,
+      "minAnsi": 3.082915872408531,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.222 0.031 308.4)",
       "foreground": "oklch(0.964 0.034 208)",
@@ -12693,6 +15043,11 @@
     "name": "Wilmersdorf",
     "slug": "wilmersdorf",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.28688211956369,
+      "minAnsi": 4.2254933570537805,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.289 0.015 269.2)",
       "foreground": "oklch(0.827 0 0)",
@@ -12720,6 +15075,11 @@
     "name": "Wombat",
     "slug": "wombat",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 12.835889125683005,
+      "minAnsi": 6.069440212997957,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.205 0 0)",
       "foreground": "oklch(0.889 0.016 90.2)",
@@ -12747,6 +15107,11 @@
     "name": "Wryan",
     "slug": "wryan",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 6.6437742847642784,
+      "minAnsi": 2.4654380362095925,
+      "minAnsiSlot": "blue"
+    },
     "colors": {
       "background": "oklch(0.173 0 0)",
       "foreground": "oklch(0.681 0.009 106.6)",
@@ -12774,6 +15139,11 @@
     "name": "Xcode Dark",
     "slug": "xcode-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 10.74075405420282,
+      "minAnsi": 4.926427134221313,
+      "minAnsiSlot": "cyan"
+    },
     "colors": {
       "background": "oklch(0.286 0.011 278.2)",
       "foreground": "oklch(0.904 0.001 286.4)",
@@ -12801,6 +15171,11 @@
     "name": "Xcode Dark hc",
     "slug": "xcode-dark-hc",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 16.409700712545998,
+      "minAnsi": 7.164334445585376,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.241 0.01 285.7)",
       "foreground": "oklch(1 0 0)",
@@ -12828,6 +15203,11 @@
     "name": "Xcode Light",
     "slug": "xcode-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 15.133529408889883,
+      "minAnsi": 1.4808153836317437,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0.269 0 0)",
@@ -12855,6 +15235,11 @@
     "name": "Xcode Light hc",
     "slug": "xcode-light-hc",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 21,
+      "minAnsi": 1.4808153836317437,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(1 0 0)",
       "foreground": "oklch(0 0 0)",
@@ -12882,6 +15267,11 @@
     "name": "Xcode WWDC",
     "slug": "xcode-wwdc",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 11.367411063502368,
+      "minAnsi": 2.4802130228261756,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.294 0.019 272.1)",
       "foreground": "oklch(0.931 0.004 271.4)",
@@ -12909,6 +15299,11 @@
     "name": "Zenbones",
     "slug": "zenbones",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 10.605791939903588,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.948 0.004 39.5)",
       "foreground": "oklch(0.326 0.017 234.4)",
@@ -12936,6 +15331,11 @@
     "name": "Zenbones Dark",
     "slug": "zenbones-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.166992692840367,
+      "minAnsi": 5.148083003418225,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0.216 0.006 56)",
       "foreground": "oklch(0.793 0.013 236.7)",
@@ -12963,6 +15363,11 @@
     "name": "Zenbones Light",
     "slug": "zenbones-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 10.605791939903588,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.948 0.004 39.5)",
       "foreground": "oklch(0.326 0.017 234.4)",
@@ -12990,6 +15395,11 @@
     "name": "Zenburn",
     "slug": "zenburn",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 7.598464114749242,
+      "minAnsi": 1.803190077291759,
+      "minAnsiSlot": "red"
+    },
     "colors": {
       "background": "oklch(0.368 0 0)",
       "foreground": "oklch(0.89 0.022 106.8)",
@@ -13017,6 +15427,11 @@
     "name": "Zenburned",
     "slug": "zenburned",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 8.247013993858703,
+      "minAnsi": 3.0521629235417307,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0.372 0 0)",
       "foreground": "oklch(0.923 0.031 81.8)",
@@ -13044,6 +15459,11 @@
     "name": "Zenwritten Dark",
     "slug": "zenwritten-dark",
     "isDark": true,
+    "contrast": {
+      "fgOnBg": 9.158101920932046,
+      "minAnsi": 5.175562388137477,
+      "minAnsiSlot": "yellow"
+    },
     "colors": {
       "background": "oklch(0.213 0 0)",
       "foreground": "oklch(0.792 0 0)",
@@ -13071,6 +15491,11 @@
     "name": "Zenwritten Light",
     "slug": "zenwritten-light",
     "isDark": false,
+    "contrast": {
+      "fgOnBg": 10.572181156861216,
+      "minAnsi": 1,
+      "minAnsiSlot": "black"
+    },
     "colors": {
       "background": "oklch(0.949 0 0)",
       "foreground": "oklch(0.329 0 0)",

--- a/data/themes.json
+++ b/data/themes.json
@@ -13,7 +13,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/0x96f.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#262427",
@@ -215,7 +215,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/12-bit Rainbow.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#040404",
@@ -417,7 +417,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/3024 Day.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f7f7f7",
@@ -619,7 +619,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/3024 Night.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#090300",
@@ -821,7 +821,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aardvark Blue.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#102040",
@@ -1024,7 +1024,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Abernathy.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#111416",
@@ -1228,7 +1228,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adventure.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#040404",
@@ -1430,7 +1430,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adventure Time.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1f1d45",
@@ -1632,7 +1632,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adwaita.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -1834,7 +1834,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Adwaita Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d1d20",
@@ -2037,7 +2037,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Afterglow.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#212121",
@@ -2241,7 +2241,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aizen Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1a1a1a",
@@ -2442,7 +2442,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aizen Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f0f2f6",
@@ -2644,7 +2644,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Alabaster.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f7f7f7",
@@ -2845,7 +2845,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Alien Blood.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0f1610",
@@ -3047,7 +3047,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Andromeda.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#262a33",
@@ -3247,7 +3247,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Apple Classic.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2c2b2b",
@@ -3450,7 +3450,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Apple System Colors.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1e1e1e",
@@ -3652,7 +3652,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Apple System Colors Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#feffff",
@@ -3855,7 +3855,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Arcoiris.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#201f1e",
@@ -4057,7 +4057,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ardoise.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1e1e1e",
@@ -4259,7 +4259,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Argonaut.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0e1019",
@@ -4463,7 +4463,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Arthur.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1c1c1c",
@@ -4664,7 +4664,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atelier Sulphurpool.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#202746",
@@ -4867,7 +4867,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atom.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#161719",
@@ -5071,7 +5071,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atom One Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#21252b",
@@ -5274,7 +5274,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Atom One Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f9f9f9",
@@ -5477,7 +5477,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aura.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#15141b",
@@ -5679,7 +5679,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Aurora.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#23262e",
@@ -5883,7 +5883,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ayu.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0b0e14",
@@ -6084,7 +6084,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ayu Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f8f9fa",
@@ -6287,7 +6287,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ayu Mirage.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1f2430",
@@ -6490,7 +6490,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Banana Blueberry.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#191323",
@@ -6692,7 +6692,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Batman.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1b1d1e",
@@ -6894,7 +6894,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Belafonte Day.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#d5ccba",
@@ -7095,7 +7095,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Belafonte Night.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#20111b",
@@ -7297,7 +7297,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Birds Of Paradise.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2a1f1d",
@@ -7501,7 +7501,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -7705,7 +7705,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Bathory).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -7909,7 +7909,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Burzum).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -8113,7 +8113,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Dark Funeral).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -8317,7 +8317,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Gorgoroth).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -8521,7 +8521,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Immortal).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -8725,7 +8725,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Khold).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -8929,7 +8929,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Marduk).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -9133,7 +9133,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Mayhem).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -9337,7 +9337,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Nile).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -9540,7 +9540,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Black Metal (Venom).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -9744,7 +9744,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blazer.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0d1926",
@@ -9946,7 +9946,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blue Berry Pie.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1c0c28",
@@ -10146,7 +10146,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blue Dolphin.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#006984",
@@ -10347,7 +10347,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Blue Matrix.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#101116",
@@ -10549,7 +10549,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Bluloco Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282c34",
@@ -10751,7 +10751,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Bluloco Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f9f9f9",
@@ -10954,7 +10954,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Borland.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0000a4",
@@ -11157,7 +11157,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Box.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#141d2b",
@@ -11360,7 +11360,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/branch.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#32221a",
@@ -11563,7 +11563,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Breadog.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f1ebe6",
@@ -11765,7 +11765,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Breeze.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#31363b",
@@ -11968,7 +11968,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Bright Lights.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#191919",
@@ -12172,7 +12172,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Broadcast.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2b2b2b",
@@ -12374,7 +12374,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Brogrammer.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#131313",
@@ -12576,7 +12576,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -12778,7 +12778,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -12981,7 +12981,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Pastel Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -13185,7 +13185,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Tango Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -13388,7 +13388,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Builtin Tango Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -13589,7 +13589,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/C64.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#40318d",
@@ -13791,7 +13791,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Calamity.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2f2833",
@@ -13994,7 +13994,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Carbonfox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#161616",
@@ -14197,7 +14197,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Frappe.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#303446",
@@ -14399,7 +14399,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Latte.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#eff1f5",
@@ -14602,7 +14602,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Macchiato.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#24273a",
@@ -14807,7 +14807,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Catppuccin Mocha.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1e1e2e",
@@ -15008,7 +15008,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/CGA.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -15209,7 +15209,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Chalk.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2b2d2e",
@@ -15413,7 +15413,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Chalkboard.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#29262f",
@@ -15616,7 +15616,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Challenger Deep.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1e1c31",
@@ -15818,7 +15818,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Chester.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2c3643",
@@ -16019,7 +16019,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ciapre.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#191c27",
@@ -16222,7 +16222,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Citruszest.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -16424,7 +16424,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/CLRS.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -16627,7 +16627,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Neon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#142838",
@@ -16831,7 +16831,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Next.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#162c35",
@@ -17034,7 +17034,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Next Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0b1c24",
@@ -17238,7 +17238,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt Next Minimal.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0b1c24",
@@ -17440,7 +17440,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cobalt2.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#132738",
@@ -17642,7 +17642,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Coffee Theme.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f5deb3",
@@ -17843,7 +17843,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Crayon Pony Fish.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#150707",
@@ -18047,7 +18047,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cursor Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#141414",
@@ -18250,7 +18250,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cursor Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f3f3f3",
@@ -18454,7 +18454,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cutie Pro.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#181818",
@@ -18657,7 +18657,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cyberdyne.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#151144",
@@ -18860,7 +18860,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cyberpunk.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#332a57",
@@ -19062,7 +19062,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Cyberpunk Scarlet Protocol.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#101116",
@@ -19265,7 +19265,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dalton Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1b1b1b",
@@ -19468,7 +19468,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dark Modern.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1f1f1f",
@@ -19671,7 +19671,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dark Pastel.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -19874,7 +19874,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dark+.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1e1e1e",
@@ -20075,7 +20075,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Darkermatrix.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#070c0e",
@@ -20276,7 +20276,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Darkmatrix.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#070c0e",
@@ -20478,7 +20478,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Darkside.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222324",
@@ -20679,7 +20679,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dawnfox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#faf4ed",
@@ -20882,7 +20882,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dayfox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f6f2ee",
@@ -21085,7 +21085,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Deep.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#090909",
@@ -21288,7 +21288,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Desert.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#333333",
@@ -21491,7 +21491,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Detuned.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -21693,7 +21693,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dimidium.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#141414",
@@ -21895,7 +21895,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dimmed Monokai.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1f1f1f",
@@ -22098,7 +22098,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Django.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0b2f20",
@@ -22300,7 +22300,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Django Reborn Again.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#051f14",
@@ -22503,7 +22503,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Django Smooth.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#245032",
@@ -22706,7 +22706,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dogxi Misty.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282a36",
@@ -22908,7 +22908,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Doom One.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282c34",
@@ -23110,7 +23110,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Doom Peacock.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2b2a27",
@@ -23312,7 +23312,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dot Gov.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#262c35",
@@ -23516,7 +23516,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dracula.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282a36",
@@ -23720,7 +23720,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Dracula+.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#212121",
@@ -23923,7 +23923,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Duckbones.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0e101a",
@@ -24126,7 +24126,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Duotone Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1f1d27",
@@ -24330,7 +24330,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Duskfox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#232136",
@@ -24532,7 +24532,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Earthsong.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#292520",
@@ -24734,7 +24734,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Electron Highlighter.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#23283d",
@@ -24936,7 +24936,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Elegant.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#292b31",
@@ -25137,7 +25137,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Elemental.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#22211d",
@@ -25339,7 +25339,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Elementary.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#181818",
@@ -25542,7 +25542,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Embark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1e1c31",
@@ -25743,7 +25743,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Embers Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#16130f",
@@ -25943,7 +25943,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/ENCOM.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -26146,7 +26146,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Espresso.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#323232",
@@ -26346,7 +26346,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Espresso Libre.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2a211c",
@@ -26550,7 +26550,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Everblush.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#141b1e",
@@ -26753,7 +26753,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Everforest Dark Hard.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1e2326",
@@ -26955,7 +26955,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Everforest Light Med.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#efebd4",
@@ -27158,7 +27158,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fahrenheit.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -27358,7 +27358,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fairyfloss.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#5a5475",
@@ -27560,7 +27560,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Farmhouse Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d2027",
@@ -27762,7 +27762,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Farmhouse Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#e8e4e1",
@@ -27963,7 +27963,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fideloper.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#292f33",
@@ -28166,7 +28166,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Firefly Traditional.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -28366,7 +28366,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Firefox Dev.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0e1011",
@@ -28567,7 +28567,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Firewatch.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1e2027",
@@ -28769,7 +28769,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fish Tank.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#232537",
@@ -28970,7 +28970,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flat.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#002240",
@@ -29172,7 +29172,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flatland.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d1f21",
@@ -29374,7 +29374,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flexoki Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#100f0f",
@@ -29576,7 +29576,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Flexoki Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fffcf0",
@@ -29778,7 +29778,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Floraverse.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0e0d15",
@@ -29981,7 +29981,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Forest Blue.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#051519",
@@ -30183,7 +30183,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Framer.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#111111",
@@ -30384,7 +30384,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Front End Delight.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1b1c1d",
@@ -30586,7 +30586,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Fun Forrest.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#251200",
@@ -30788,7 +30788,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Galaxy.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d2837",
@@ -30990,7 +30990,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Galizur.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#071317",
@@ -31194,7 +31194,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ghostty Default Style Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282c34",
@@ -31396,7 +31396,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f4f4f4",
@@ -31598,7 +31598,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#101216",
@@ -31802,7 +31802,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark Colorblind.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0d1117",
@@ -32006,7 +32006,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark Default.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0d1117",
@@ -32209,7 +32209,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark Dimmed.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#22272e",
@@ -32413,7 +32413,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Dark High Contrast.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0a0c10",
@@ -32617,7 +32617,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Light Colorblind.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -32821,7 +32821,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Light Default.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -33025,7 +33025,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitHub Light High Contrast.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -33229,7 +33229,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitLab Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#28262b",
@@ -33433,7 +33433,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitLab Dark Grey.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -33636,7 +33636,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/GitLab Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fafaff",
@@ -33838,7 +33838,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Glacier.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0c1115",
@@ -34039,7 +34039,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Grape.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#171423",
@@ -34240,7 +34240,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Grass.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#13773d",
@@ -34444,7 +34444,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Grey Green.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#002a1a",
@@ -34647,7 +34647,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruber Darker.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#181818",
@@ -34850,7 +34850,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282828",
@@ -35053,7 +35053,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Dark Hard.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d2021",
@@ -35256,7 +35256,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fbf1c7",
@@ -35459,7 +35459,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Light Hard.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f9f5d7",
@@ -35662,7 +35662,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Material.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d2021",
@@ -35866,7 +35866,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Material Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282828",
@@ -36069,7 +36069,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Gruvbox Material Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fbf1c7",
@@ -36272,7 +36272,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Guezwhoz.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d1d1d",
@@ -36475,7 +36475,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hacktober.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#141414",
@@ -36677,7 +36677,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hardcore.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -36880,7 +36880,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Harper.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#010101",
@@ -37082,7 +37082,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Havn Daggry.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f8f9fb",
@@ -37285,7 +37285,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Havn Skumring.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#111522",
@@ -37487,7 +37487,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/HaX0R Blue.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#010515",
@@ -37689,7 +37689,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/HaX0R Gr33N.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#020f01",
@@ -37891,7 +37891,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/HaX0R R3D.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#200101",
@@ -38094,7 +38094,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Heeler.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#211f46",
@@ -38296,7 +38296,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Highway.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222225",
@@ -38497,7 +38497,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hipster Green.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#100b05",
@@ -38700,7 +38700,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hivacruz.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#132638",
@@ -38903,7 +38903,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Homebrew.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -39104,7 +39104,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hopscotch.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#322931",
@@ -39305,7 +39305,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hopscotch.256.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#322931",
@@ -39508,7 +39508,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Horizon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1c1e26",
@@ -39710,7 +39710,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Horizon Bright.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fdf0ed",
@@ -39912,7 +39912,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hot Dog Stand.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ea3323",
@@ -40115,7 +40115,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hot Dog Stand (Mustard).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffff54",
@@ -40318,7 +40318,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hurtado.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -40520,7 +40520,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Hybrid.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#161719",
@@ -40722,7 +40722,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IBM 5153 CGA.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#141414",
@@ -40924,7 +40924,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IBM 5153 CGA (Black).json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -41127,7 +41127,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IC Green PPL.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2c2c2c",
@@ -41329,7 +41329,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IC Orange PPL.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#262626",
@@ -41534,7 +41534,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Iceberg Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#161821",
@@ -41736,7 +41736,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Iceberg Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#e8e9ec",
@@ -41937,7 +41937,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Idea.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#202020",
@@ -42140,7 +42140,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Idle Toes.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#323232",
@@ -42344,7 +42344,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IR Black.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -42546,7 +42546,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IRIX Console.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0c0c0c",
@@ -42749,7 +42749,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/IRIX Terminal.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000043",
@@ -42951,7 +42951,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Dark Background.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -43153,7 +43153,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Default.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -43355,7 +43355,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Light Background.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -43559,7 +43559,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Pastel Dark Background.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -43761,7 +43761,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Smoooooth.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#15191f",
@@ -43963,7 +43963,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Solarized Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#002b36",
@@ -44166,7 +44166,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Solarized Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fdf6e3",
@@ -44370,7 +44370,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Tango Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -44573,7 +44573,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/iTerm2 Tango Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -44775,7 +44775,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Jackie Brown.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2c1d16",
@@ -44977,7 +44977,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Japanesque.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1e1e1e",
@@ -45182,7 +45182,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Jellybeans.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -45383,7 +45383,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/JetBrains Darcula.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#202020",
@@ -45584,7 +45584,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Jubi.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#262b33",
@@ -45789,7 +45789,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawa Dragon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#181616",
@@ -45991,7 +45991,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawa Lotus.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f2ecbc",
@@ -46196,7 +46196,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawa Wave.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1f1f28",
@@ -46401,7 +46401,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanagawabones.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1f1f28",
@@ -46605,7 +46605,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Ink.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#14171d",
@@ -46808,7 +46808,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Mist.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#22262d",
@@ -47011,7 +47011,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Pearl.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f2f1ef",
@@ -47215,7 +47215,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kanso Zen.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#090e13",
@@ -47417,7 +47417,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kibble.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0e100a",
@@ -47620,7 +47620,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kitty Default.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -47822,7 +47822,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kitty Low Contrast.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#333333",
@@ -48025,7 +48025,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kolorit.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d1a1e",
@@ -48227,7 +48227,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Konsolas.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#060606",
@@ -48431,7 +48431,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Kurokula.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#141515",
@@ -48633,7 +48633,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Lab Fox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2e2e2e",
@@ -48834,7 +48834,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Laser.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#030d18",
@@ -49035,7 +49035,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Later This Evening.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -49236,7 +49236,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Lavandula.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#050014",
@@ -49437,7 +49437,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Light Owl.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fbfbfb",
@@ -49639,7 +49639,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Liquid Carbon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#303030",
@@ -49842,7 +49842,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Liquid Carbon Transparent.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -50045,7 +50045,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Lovelace.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d1f28",
@@ -50247,7 +50247,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Man Page.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fef49c",
@@ -50450,7 +50450,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mariana.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#343d46",
@@ -50653,7 +50653,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#eaeaea",
@@ -50856,7 +50856,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#232322",
@@ -51060,7 +51060,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Darker.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#212121",
@@ -51264,7 +51264,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Design Colors.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d262a",
@@ -51466,7 +51466,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Material Ocean.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0f111a",
@@ -51669,7 +51669,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mathias.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -51870,7 +51870,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Matrix.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0f191c",
@@ -52072,7 +52072,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Matte Black.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -52274,7 +52274,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Medallion.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d1908",
@@ -52478,7 +52478,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Melange Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#292522",
@@ -52680,7 +52680,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Melange Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f1f1f1",
@@ -52884,7 +52884,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mellifluous.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1a1a1a",
@@ -53088,7 +53088,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mellow.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#161617",
@@ -53290,7 +53290,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Miasma.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -53493,7 +53493,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Midnight In Mojave.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1e1e1e",
@@ -53694,7 +53694,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mirage.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1b2738",
@@ -53895,7 +53895,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Misterioso.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2d3743",
@@ -54098,7 +54098,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Operandi.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -54301,7 +54301,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Operandi Tinted.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fbf7f0",
@@ -54504,7 +54504,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Vivendi.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -54707,7 +54707,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Modus Vivendi Tinted.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0d0e1c",
@@ -54909,7 +54909,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Molokai.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -55111,7 +55111,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Mona Lisa.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#120b0d",
@@ -55315,7 +55315,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Classic.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#272822",
@@ -55519,7 +55519,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2d2a2e",
@@ -55722,7 +55722,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#faf4f2",
@@ -55925,7 +55925,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Light Sun.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f8efe7",
@@ -56129,7 +56129,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Machine.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#273136",
@@ -56333,7 +56333,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Octagon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282a3a",
@@ -56537,7 +56537,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Ristretto.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2c2525",
@@ -56741,7 +56741,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Pro Spectrum.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -56945,7 +56945,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Remastered.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0c0c0c",
@@ -57148,7 +57148,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Soda.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1a1a1a",
@@ -57351,7 +57351,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monokai Vivid.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -57553,7 +57553,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monospace Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#10151d",
@@ -57755,7 +57755,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Monospace Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f4f7fd",
@@ -57958,7 +57958,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Moonfly.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#080808",
@@ -58159,7 +58159,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/N0Tch2K.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -58363,7 +58363,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neobones Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0f191f",
@@ -58565,7 +58565,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neobones Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#e5ede6",
@@ -58767,7 +58767,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#14161a",
@@ -58969,7 +58969,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neopolitan.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#271f19",
@@ -59172,7 +59172,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Neutron.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1c1e22",
@@ -59375,7 +59375,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Lion V1.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -59576,7 +59576,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Lion V2.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#171717",
@@ -59780,7 +59780,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Owl.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#011627",
@@ -59983,7 +59983,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Night Owlish Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -60187,7 +60187,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nightfox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#192330",
@@ -60390,7 +60390,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Niji.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#141515",
@@ -60594,7 +60594,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/No Clown Fiesta.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#101010",
@@ -60797,7 +60797,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/No Clown Fiesta Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#e1e1e1",
@@ -61000,7 +61000,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nocturnal Winter.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0d0d17",
@@ -61204,7 +61204,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nord.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2e3440",
@@ -61407,7 +61407,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nord Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#e5e9f0",
@@ -61612,7 +61612,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nord Wave.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#212121",
@@ -61816,7 +61816,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nordfox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2e3440",
@@ -62018,7 +62018,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Novel.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#dfdbc3",
@@ -62221,7 +62221,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/novmbr.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#241d1a",
@@ -62425,7 +62425,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nvim Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#14161b",
@@ -62629,7 +62629,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Nvim Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#e0e2ea",
@@ -62830,7 +62830,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Obsidian.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#283033",
@@ -63031,7 +63031,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ocean.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#224fbc",
@@ -63233,7 +63233,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Oceanic Material.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1c262b",
@@ -63437,7 +63437,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Oceanic Next.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#162c35",
@@ -63638,7 +63638,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ollie.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222125",
@@ -63843,7 +63843,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Dark Two.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#21252b",
@@ -64046,7 +64046,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Double Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282c34",
@@ -64248,7 +64248,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Double Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fafafa",
@@ -64452,7 +64452,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Half Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282c34",
@@ -64655,7 +64655,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/One Half Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fafafa",
@@ -64860,7 +64860,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Onenord.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2e3440",
@@ -65063,7 +65063,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Onenord Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f7f8fa",
@@ -65266,7 +65266,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Operator Mono Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#191919",
@@ -65470,7 +65470,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Overnight Slumber.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0e1729",
@@ -65673,7 +65673,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/owl.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2f2b2c",
@@ -65876,7 +65876,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Oxocarbon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#161616",
@@ -66078,7 +66078,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pale Night Hc.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#3e4251",
@@ -66280,7 +66280,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pandora.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#141e43",
@@ -66480,7 +66480,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Paraiso Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2f1e2e",
@@ -66683,7 +66683,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Paul Millr.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -66885,7 +66885,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pencil Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#212121",
@@ -67086,7 +67086,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pencil Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f1f1f1",
@@ -67290,7 +67290,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Peppermint.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -67493,7 +67493,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Phala Green Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -67696,7 +67696,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Piatto Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -67899,7 +67899,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pierre Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#070707",
@@ -68101,7 +68101,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pierre Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -68305,7 +68305,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pnevma.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1c1c1c",
@@ -68508,7 +68508,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1a1e28",
@@ -68711,7 +68711,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres Darker.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#16161e",
@@ -68913,7 +68913,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres Storm.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#252b37",
@@ -69114,7 +69114,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Poimandres White.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fefeff",
@@ -69317,7 +69317,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Popping And Locking.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#181921",
@@ -69519,7 +69519,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Powershell.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#052454",
@@ -69721,7 +69721,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Primary.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -69923,7 +69923,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pro.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -70125,7 +70125,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Pro Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -70328,7 +70328,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Purple Rain.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#21084a",
@@ -70531,7 +70531,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Purplepeter.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2a1a4a",
@@ -70734,7 +70734,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rapture.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#111e2a",
@@ -70937,7 +70937,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Raycast Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1a1a1a",
@@ -71139,7 +71139,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Raycast Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -71342,7 +71342,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rebecca.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#292a44",
@@ -71544,7 +71544,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Red Alert.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#762423",
@@ -71746,7 +71746,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Red Planet.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -71946,7 +71946,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Red Sands.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#7a251e",
@@ -72148,7 +72148,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Relaxed.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#353a44",
@@ -72350,7 +72350,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Retro.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -72554,7 +72554,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Retro Legends.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0d0d0d",
@@ -72756,7 +72756,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rippedcasts.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2b2b2b",
@@ -72961,7 +72961,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rose Pine.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#191724",
@@ -73163,7 +73163,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rose Pine Dawn.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#faf4ed",
@@ -73368,7 +73368,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rose Pine Moon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#232136",
@@ -73569,7 +73569,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Rouge 2.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#17182b",
@@ -73770,7 +73770,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Royal.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#100815",
@@ -73973,7 +73973,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ryuuko.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2c3941",
@@ -74174,7 +74174,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sakura.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#18131e",
@@ -74376,7 +74376,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Scarlet Protocol.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1c153d",
@@ -74578,7 +74578,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sea Shells.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#09141b",
@@ -74781,7 +74781,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seafoam Pastel.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#243435",
@@ -74984,7 +74984,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Abyss.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#050510",
@@ -75186,7 +75186,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Amethyst.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f8f7f6",
@@ -75389,7 +75389,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Canopy.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0f1714",
@@ -75592,7 +75592,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Carbon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fafafa",
@@ -75794,7 +75794,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Coral.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -75997,7 +75997,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Ember.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0a0a0a",
@@ -76199,7 +76199,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Glacier.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f8fafc",
@@ -76403,7 +76403,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Inkwell.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0a0a0a",
@@ -76605,7 +76605,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Ivory.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -76808,7 +76808,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Nightfall.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0a0a0f",
@@ -77011,7 +77011,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Phosphor.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0c0c0c",
@@ -77214,7 +77214,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Pulse.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#121212",
@@ -77417,7 +77417,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Ultraviolet.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0b0014",
@@ -77620,7 +77620,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Voltage.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0a0a0a",
@@ -77823,7 +77823,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/SeedFlip Wavelength.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0d1117",
@@ -78025,7 +78025,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Selenized Black.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#181818",
@@ -78226,7 +78226,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Selenized Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#103c48",
@@ -78426,7 +78426,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Selenized Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fbf3db",
@@ -78628,7 +78628,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seoulbones Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#4b4b4b",
@@ -78829,7 +78829,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seoulbones Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#e2e2e2",
@@ -79032,7 +79032,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Seti.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#111213",
@@ -79234,7 +79234,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Shades Of Purple.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1e1d40",
@@ -79435,7 +79435,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Shaman.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#001015",
@@ -79636,7 +79636,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Slate.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -79837,7 +79837,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sleepy Hollow.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#121214",
@@ -80040,7 +80040,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Smyck.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1b1b1b",
@@ -80243,7 +80243,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Snazzy.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1e1f29",
@@ -80446,7 +80446,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Snazzy Soft.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282a36",
@@ -80648,7 +80648,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Soft Server.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#242626",
@@ -80850,7 +80850,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Darcula.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#3d3f41",
@@ -81053,7 +81053,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Dark Higher Contrast.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#001e27",
@@ -81255,7 +81255,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Dark Patched.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#001e27",
@@ -81459,7 +81459,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Solarized Osaka Night.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1a1b26",
@@ -81662,7 +81662,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sonokai.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2c2e34",
@@ -81864,7 +81864,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacedust.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0a1e24",
@@ -82066,7 +82066,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#20242d",
@@ -82269,7 +82269,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray Bright.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2a2e3a",
@@ -82471,7 +82471,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray Eighties.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -82674,7 +82674,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spacegray Eighties Dull.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222222",
@@ -82877,7 +82877,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spiderman.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1b1d1e",
@@ -83078,7 +83078,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Spring.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -83280,7 +83280,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Square.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1a1a1a",
@@ -83480,7 +83480,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Squirrelsong Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#372920",
@@ -83683,7 +83683,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Srcery.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1c1b19",
@@ -83886,7 +83886,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Starlight.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#242424",
@@ -84088,7 +84088,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sublette.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#202535",
@@ -84291,7 +84291,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Subliminal.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282c35",
@@ -84492,7 +84492,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sugarplum.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#111147",
@@ -84695,7 +84695,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sundried.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1a1818",
@@ -84898,7 +84898,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Sunset Drive.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#0f0f1a",
@@ -85101,7 +85101,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Symfonic.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -85304,7 +85304,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Synthwave.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -85506,7 +85506,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Synthwave Alpha.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#241b30",
@@ -85709,7 +85709,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Synthwave Everything.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2a2139",
@@ -85912,7 +85912,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tango Adapted.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -86115,7 +86115,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tango Half Adapted.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -86318,7 +86318,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tearout.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#34392d",
@@ -86521,7 +86521,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Teerb.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#262626",
@@ -86725,7 +86725,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Terafox.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#152528",
@@ -86927,7 +86927,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Terminal Basic.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -87129,7 +87129,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Terminal Basic Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d1e1d",
@@ -87331,7 +87331,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Thayer Bright.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1b1d1e",
@@ -87532,7 +87532,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/The Hulk.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1b1d1e",
@@ -87735,7 +87735,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tinacious Design Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d1d26",
@@ -87937,7 +87937,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tinacious Design Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f8f8ff",
@@ -88141,7 +88141,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1a1b26",
@@ -88343,7 +88343,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Day.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#e1e2e7",
@@ -88547,7 +88547,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Moon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#222436",
@@ -88751,7 +88751,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Night.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1a1b26",
@@ -88954,7 +88954,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/TokyoNight Storm.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#24283b",
@@ -89156,7 +89156,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -89360,7 +89360,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1d1f21",
@@ -89565,7 +89565,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Blue.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#002451",
@@ -89770,7 +89770,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Bright.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -89972,7 +89972,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Burns.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#151515",
@@ -90176,7 +90176,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Tomorrow Night Eighties.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#2d2d2d",
@@ -90376,7 +90376,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Toy Chest.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#24364b",
@@ -90578,7 +90578,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/traffic.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#272c30",
@@ -90779,7 +90779,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Treehouse.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#191919",
@@ -90982,7 +90982,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Twilight.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#141414",
@@ -91184,7 +91184,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ubuntu.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#300a24",
@@ -91388,7 +91388,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ultra Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -91590,7 +91590,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Ultra Violent.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#242728",
@@ -91792,7 +91792,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Under The Sea.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#011116",
@@ -91993,7 +91993,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Unikitty.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ff8cd9",
@@ -92194,7 +92194,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/urban.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#312e39",
@@ -92395,7 +92395,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Urple.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1b1b23",
@@ -92599,7 +92599,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vague.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#141415",
@@ -92801,7 +92801,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vaughn.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#25234f",
@@ -93004,7 +93004,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vercel.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#101010",
@@ -93208,7 +93208,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vesper.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#101010",
@@ -93410,7 +93410,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vibrant Ink.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -93613,7 +93613,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Vimbones.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f0f0ca",
@@ -93814,7 +93814,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Violet Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1c1d1f",
@@ -94014,7 +94014,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Violet Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#fcf4dc",
@@ -94217,7 +94217,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Violite.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#241c36",
@@ -94417,7 +94417,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Warm Neon.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#404040",
@@ -94620,7 +94620,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wez.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#000000",
@@ -94821,7 +94821,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Whimsy.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#29283b",
@@ -95024,7 +95024,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wild Cherry.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1f1726",
@@ -95227,7 +95227,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wilmersdorf.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#282b33",
@@ -95431,7 +95431,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wombat.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#171717",
@@ -95632,7 +95632,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Wryan.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#101010",
@@ -95835,7 +95835,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#292a30",
@@ -96039,7 +96039,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Dark hc.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1f1f24",
@@ -96241,7 +96241,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -96443,7 +96443,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode Light hc.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#ffffff",
@@ -96645,7 +96645,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Xcode WWDC.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#292c36",
@@ -96848,7 +96848,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenbones.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f0edec",
@@ -97051,7 +97051,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenbones Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#1c1917",
@@ -97254,7 +97254,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenbones Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#f0edec",
@@ -97457,7 +97457,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenburn.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#3f3f3f",
@@ -97661,7 +97661,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenburned.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#404040",
@@ -97864,7 +97864,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenwritten Dark.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#191919",
@@ -98067,7 +98067,7 @@
     "source": "iterm2-color-schemes",
     "sourceUrl": "https://github.com/mbadolato/iTerm2-Color-Schemes/blob/a2c7b60293a81d82767893d89bc7599342c04cbf/windowsterminal/Zenwritten Light.json",
     "upstreamSha": "a2c7b60293a81d82767893d89bc7599342c04cbf",
-    "updatedAt": "2026-04-21T01:55:56.860Z",
+    "updatedAt": "2026-04-21T02:02:19.058Z",
     "colors": {
       "background": {
         "hex": "#eeeeee",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -80,6 +80,7 @@ function toSlim(theme: TerminalColorTheme): SlimTheme {
     name: theme.name,
     slug: theme.slug,
     isDark: theme.isDark,
+    contrast: theme.contrast,
     colors: slimColors,
   };
 }

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -10,7 +10,22 @@ import ShowcaseDashboard from './ShowcaseDashboard.astro';
   <div class="showcase-head">
     <span class="eyebrow">Preview</span>
     <h1 class="theme-name" data-theme-name>—</h1>
-    <p class="theme-meta" data-theme-meta>—</p>
+    <p class="theme-meta">
+      <span data-theme-meta>—</span>
+      <!-- WCAG tier comes from theme.contrast.fgOnBg only. Explicitly labeled
+           'fg' so users don't assume the rating covers ANSI slots. -->
+      <span
+        class="wcag-badge"
+        data-wcag-badge
+        title="Foreground vs background WCAG 2.x contrast. Does not certify ANSI slot legibility."
+        hidden
+      >
+        <span data-wcag-level>—</span>
+        <span class="wcag-sep" aria-hidden="true">·</span>
+        <span class="wcag-slot">fg</span>
+        <span data-wcag-ratio>—</span>
+      </span>
+    </p>
   </div>
   <div class="showcase-stack">
     <ShowcasePalette />
@@ -45,6 +60,37 @@ import ShowcaseDashboard from './ShowcaseDashboard.astro';
   .showcase-head .theme-meta {
     margin: 0;
     font-size: 0.82rem;
+    color: color-mix(in oklch, var(--fg) 60%, transparent);
+    display: flex;
+    gap: 0.55rem;
+    align-items: baseline;
+    flex-wrap: wrap;
+  }
+  .wcag-badge {
+    display: inline-flex;
+    gap: 0.3rem;
+    align-items: baseline;
+    padding: 0.08rem 0.5rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    font-size: 0.72rem;
+    font-variant-numeric: tabular-nums;
+    font-family: var(--font-mono);
+    background: color-mix(in oklch, var(--accent) 6%, transparent);
+    color: var(--fg);
+  }
+  .wcag-badge[data-wcag-level='AAA'] {
+    background: color-mix(in oklch, oklch(0.65 0.16 145) 18%, transparent);
+    border-color: oklch(0.65 0.16 145);
+  }
+  .wcag-badge[data-wcag-level='Fail'] {
+    background: color-mix(in oklch, oklch(0.62 0.18 25) 18%, transparent);
+    border-color: oklch(0.62 0.18 25);
+  }
+  .wcag-badge .wcag-sep {
+    opacity: 0.5;
+  }
+  .wcag-badge .wcag-slot {
     color: color-mix(in oklch, var(--fg) 60%, transparent);
   }
 

--- a/site/src/components/ShowcaseController.astro
+++ b/site/src/components/ShowcaseController.astro
@@ -18,6 +18,8 @@
     formatTailwindTheme,
     formatJson,
     formatPermalink,
+    formatRatio,
+    wcagLabel,
     type SlimThemeLike,
   } from '@/lib/formatters';
 
@@ -57,6 +59,17 @@
     const metaEl = showcase.querySelector<HTMLElement>('[data-theme-meta]');
     if (nameEl) nameEl.textContent = theme.name;
     if (metaEl) metaEl.textContent = `${theme.isDark ? 'dark' : 'light'} · ${theme.slug}`;
+
+    const badge = showcase.querySelector<HTMLElement>('[data-wcag-badge]');
+    if (badge && theme.contrast) {
+      const level = wcagLabel(theme.contrast.fgOnBg);
+      badge.dataset.wcagLevel = level;
+      const levelEl = badge.querySelector<HTMLElement>('[data-wcag-level]');
+      const ratioEl = badge.querySelector<HTMLElement>('[data-wcag-ratio]');
+      if (levelEl) levelEl.textContent = level;
+      if (ratioEl) ratioEl.textContent = formatRatio(theme.contrast.fgOnBg);
+      badge.hidden = false;
+    }
 
     for (const [k, v] of Object.entries(theme.colors)) {
       showcase.style.setProperty(toCssVar(k), v);

--- a/site/src/lib/formatters.ts
+++ b/site/src/lib/formatters.ts
@@ -4,7 +4,25 @@ export interface SlimThemeLike {
   name: string;
   slug: string;
   isDark: boolean;
+  contrast?: { fgOnBg: number; minAnsi: number; minAnsiSlot: string };
   colors: Record<string, string>;
+}
+
+/**
+ * Maps a foreground-vs-background contrast ratio to the WCAG 2.x body-text
+ * tier. Mirrors the thresholds used in src/classify.ts so the UI badge and
+ * the tag filters stay in lockstep.
+ */
+export function wcagLabel(fgOnBg: number): 'AAA' | 'AA' | 'AA Large' | 'Fail' {
+  if (fgOnBg >= 7) return 'AAA';
+  if (fgOnBg >= 4.5) return 'AA';
+  if (fgOnBg >= 3) return 'AA Large';
+  return 'Fail';
+}
+
+/** Fixed-precision contrast ratio for badge display, e.g. "8.2:1". */
+export function formatRatio(ratio: number): string {
+  return `${ratio.toFixed(1)}:1`;
 }
 
 function kebab(key: string): string {

--- a/site/src/lib/theme-filter.ts
+++ b/site/src/lib/theme-filter.ts
@@ -18,8 +18,9 @@ export const ALL_TAGS = [
   'light',
   'vibrant',
   'muted',
-  'high-contrast',
-  'low-contrast',
+  'wcag-aaa',
+  'wcag-aa',
+  'ansi-legible',
   'popular',
 ] as const;
 

--- a/site/test/formatters.test.ts
+++ b/site/test/formatters.test.ts
@@ -4,6 +4,8 @@ import {
   formatTailwindTheme,
   formatJson,
   formatPermalink,
+  formatRatio,
+  wcagLabel,
   type SlimThemeLike,
 } from '../src/lib/formatters';
 
@@ -77,5 +79,35 @@ describe('formatPermalink', () => {
     const base = new URL('https://example.com/?theme=old');
     const url = formatPermalink('new', base);
     expect(new URL(url).searchParams.getAll('theme')).toEqual(['new']);
+  });
+});
+
+describe('wcagLabel', () => {
+  it('returns AAA at or above 7:1', () => {
+    expect(wcagLabel(7)).toBe('AAA');
+    expect(wcagLabel(13.36)).toBe('AAA');
+  });
+
+  it('returns AA at or above 4.5:1 but below 7:1', () => {
+    expect(wcagLabel(4.5)).toBe('AA');
+    expect(wcagLabel(6.99)).toBe('AA');
+  });
+
+  it('returns AA Large at or above 3:1 but below 4.5:1', () => {
+    expect(wcagLabel(3)).toBe('AA Large');
+    expect(wcagLabel(4.49)).toBe('AA Large');
+  });
+
+  it('returns Fail below 3:1', () => {
+    expect(wcagLabel(2.99)).toBe('Fail');
+    expect(wcagLabel(1)).toBe('Fail');
+  });
+});
+
+describe('formatRatio', () => {
+  it('formats to one decimal plus ":1"', () => {
+    expect(formatRatio(8.234)).toBe('8.2:1');
+    expect(formatRatio(21)).toBe('21.0:1');
+    expect(formatRatio(3)).toBe('3.0:1');
   });
 });

--- a/site/test/theme-filter.test.ts
+++ b/site/test/theme-filter.test.ts
@@ -62,7 +62,10 @@ describe('theme-filter: matches', () => {
     expect(ALL_TAGS).toContain('dark');
     expect(ALL_TAGS).toContain('light');
     expect(ALL_TAGS).toContain('popular');
-    expect(ALL_TAGS).toHaveLength(7);
+    expect(ALL_TAGS).toContain('wcag-aa');
+    expect(ALL_TAGS).toContain('wcag-aaa');
+    expect(ALL_TAGS).toContain('ansi-legible');
+    expect(ALL_TAGS).toHaveLength(8);
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export interface SlimTheme {
   name: string;
   slug: string;
   isDark: boolean;
+  contrast: Contrast;
   colors: Record<ColorKey, string>;
 }
 


### PR DESCRIPTION
Closes #56. Part 2 of #54.

## Summary
Surfaces the new contrast data (from #58) in the picker UI.

- **Showcase header badge**: tier + fg/bg ratio, e.g. \`AAA · fg 13.4:1\`. Background tinted green for AAA, red for Fail, neutral accent otherwise. Explicitly labeled \`fg\` so users don't assume the rating certifies ANSI slot legibility.
- **Filter chips**: \`ALL_TAGS\` in \`site/src/lib/theme-filter.ts\` swaps the old coarse \`high-contrast\` / \`low-contrast\` chips for \`wcag-aaa\` / \`wcag-aa\` / \`ansi-legible\`. Underlying tags on every theme are unchanged — only the picker's affordances were replaced.
- **\`SlimTheme\`**: now carries \`contrast\` so \`themes-slim.json\` can drive the UI without a second JSON fetch.
- **Formatters**: new \`wcagLabel\` + \`formatRatio\` helpers in \`site/src/lib/formatters.ts\` with 6 new tests covering threshold boundaries.

## Verified via Chrome automation on local preview
- default load (Dracula) → \`AAA · fg 13.4:1\` badge, green tint
- switching to Matrix (a \`wcag-fail\` theme) → \`Fail · fg 2.7:1\` badge, red tint
- clicking the \`wcag-aaa\` filter chip narrows 485 → 410 themes

## Test plan
- [x] \`pnpm lint\` green
- [x] \`pnpm test\` root: 31/31 pass
- [x] \`pnpm -C site test\` site: 30/30 pass (incl. 6 new)
- [x] \`pnpm -C site build\` green
- [x] Visual verification via chrome iframe at 390×844 — badge stays in layout, listbox filters work
- [ ] Awaiting CI: Lighthouse, axe, typecheck, full test suite

## Out of scope
- Popularity data integration (closed as not-planned in #57 after spike found no authoritative source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)