### PR TITLE
feat(site): sticky control band + viewport-fit showcase

### DIFF
--- a/site/src/components/ShowcaseIde.astro
+++ b/site/src/components/ShowcaseIde.astro
@@ -189,9 +189,26 @@
     .ide {
       grid-template-columns: minmax(0, 1fr);
       min-height: 12rem;
+      font-size: 0.68rem;
     }
     .ide-tree {
       display: none;
+    }
+    /* Wrap long code lines at narrow widths instead of scrolling sideways.
+       Modern IDEs wrap by default; `pre-wrap` preserves indentation while
+       letting overflow flow to the next visual line. */
+    .ide-code {
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      padding: 0.55rem 0.7rem;
+    }
+    .ide-code .ln {
+      width: 1.5ch;
+      margin-right: 0.35rem;
+    }
+    .ide-tabs .tab {
+      padding: 0.35rem 0.55rem;
+      font-size: 0.68rem;
     }
   }
 </style>

--- a/site/src/components/ShowcaseReading.astro
+++ b/site/src/components/ShowcaseReading.astro
@@ -160,5 +160,12 @@
     .reading h3 {
       font-size: 1.2rem;
     }
+    /* Prose code blocks — breaking at overflow is fine here (not shell). */
+    .reading pre {
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      padding: 0.65rem 0.8rem;
+      font-size: 0.78em;
+    }
   }
 </style>

--- a/site/src/components/ShowcaseTerminal.astro
+++ b/site/src/components/ShowcaseTerminal.astro
@@ -10,13 +10,13 @@
   </header>
   <pre class="terminal" aria-hidden="true">
 <span class="line"><span class="c-green">user</span>@<span class="c-blue">host</span> <span class="c-bb">~/projects</span> <span class="c-bb">$</span> <span class="c-fg">ls --color=auto</span></span>
-<span class="line"><span class="c-blue">.git/</span>  <span class="c-blue">src/</span>  <span class="c-blue">test/</span>  <span class="c-bg">README.md</span>  <span class="c-bm">package.json</span>  <span class="c-yellow">.env</span>  <span class="c-magenta">Makefile</span></span>
+<span class="line"><span class="c-blue">.git/</span> <span class="c-blue">src/</span> <span class="c-blue">test/</span> <span class="c-bg">README.md</span> <span class="c-bm">package.json</span> <span class="c-yellow">.env</span></span>
 <span class="line"><span class="c-green">user</span>@<span class="c-blue">host</span> <span class="c-bb">~/projects</span> <span class="c-bb">$</span> <span class="c-fg">git status --short</span></span>
 <span class="line"> <span class="c-yellow">M</span> src/convert.ts</span>
 <span class="line"><span class="c-red">??</span> site/public/og-image.png</span>
 <span class="line"><span class="c-green">user</span>@<span class="c-blue">host</span> <span class="c-bb">~/projects</span> <span class="c-bb">$</span> <span class="c-fg">git diff src/convert.ts</span></span>
 <span class="line"><span class="c-bb">diff --git a/src/convert.ts b/src/convert.ts</span></span>
-<span class="line"><span class="c-bb">@@ -22,7 +22,6 @@</span>  <span class="c-bb">function convertHexToColor(hex: string): ColorValue &#123;</span></span>
+<span class="line"><span class="c-bb">@@ -22,7 +22,6 @@ convertHexToColor</span></span>
 <span class="line"><span class="c-red">-  if (ok === undefined) throw new Error('fail');</span></span>
 <span class="line"><span class="c-green">+  // trust culori non-nullable return type</span></span>
 <span class="line"><span class="c-green">user</span>@<span class="c-blue">host</span> <span class="c-bb">~/projects</span> <span class="c-bb">$</span> <span class="c-fg">pnpm test</span></span>
@@ -26,9 +26,9 @@
 <span class="line"> <span class="c-red">✗</span> <span class="c-bg">test/a11y.test.ts</span> <span class="c-red">(1 failing)</span></span>
 <span class="line">   <span class="c-red">→ AssertionError: expected [ ] to equal [ Object ]</span></span>
 <span class="line"><span class="c-green">user</span>@<span class="c-blue">host</span> <span class="c-bb">~/projects</span> <span class="c-bb">$</span> <span class="c-fg">vim src/schema.ts</span></span>
-<span class="line"><span class="c-bb">&#x2500;&#x2500;&#x2500; INSERT &#x2500;&#x2500;&#x2500;</span>                                       <span class="c-bb">3,15  Top</span></span>
+<span class="line"><span class="c-bb">&#x2500;&#x2500; INSERT &#x2500;&#x2500;</span> <span class="c-bb">3,15 Top</span></span>
 <span class="line"><span class="c-magenta">import</span> <span class="c-fg">&#123; z &#125;</span> <span class="c-magenta">from</span> <span class="c-yellow">'zod'</span><span class="c-fg">;</span></span>
-<span class="line"><span class="c-magenta">export const</span> <span class="c-cyan">HexSchema</span> <span class="c-fg">= z.string().regex(</span><span class="c-yellow">/^#[0-9a-fA-F]&#123;6&#125;$/</span><span class="c-fg">);</span></span>
+<span class="line"><span class="c-magenta">export const</span> <span class="c-cyan">Hex</span> <span class="c-fg">= z.string().regex(</span><span class="c-yellow">/#[0-9a-f]&#123;6&#125;/</span><span class="c-fg">);</span></span>
 <span class="line"><span class="c-bb">&#x223c;</span></span>
 <span class="line"><span class="c-green">user</span>@<span class="c-blue">host</span> <span class="c-bb">~/projects</span> <span class="c-bb">$</span> <span class="cursor">▎</span></span></pre>
 </section>
@@ -123,8 +123,12 @@
   }
   @media (max-width: 30rem) {
     .terminal {
-      padding: 0.7rem 0.85rem;
-      font-size: 0.7rem;
+      /* Shell alignment is load-bearing — keep `white-space: pre` and
+         shrink font instead of wrapping. The shortened vim status line
+         (`── INSERT ── 3,15 Top`) is now the widest line. */
+      padding: 0.65rem 0.8rem;
+      font-size: 0.65rem;
+      line-height: 1.5;
     }
   }
 </style>

--- a/site/src/components/ThemeSelector.astro
+++ b/site/src/components/ThemeSelector.astro
@@ -146,9 +146,20 @@ import { ALL_TAGS } from '@/lib/theme-filter';
 
 <style>
   .theme-selector {
-    position: relative;
+    /* Sticky control band — stays pinned to the top of the viewport while
+       the user scrolls the showcase. Respects iOS safe area. */
+    position: sticky;
+    top: 0;
+    z-index: 10;
     display: grid;
     gap: 0.5rem;
+    padding: 0.6rem 0 0.7rem;
+    padding-top: calc(0.6rem + env(safe-area-inset-top, 0px));
+    background: color-mix(in oklch, var(--bg) 92%, transparent);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border);
+    /* `.listbox` is `position: absolute` and anchors here (full-width). */
   }
   /* Astro's `display: grid` below wins over the user-agent `[hidden]` rule
      unless we opt back in explicitly. */


### PR DESCRIPTION
Closes #60.

## Summary
Two mobile-UX wins in one surgical PR (46 insertions / 7 deletions across 4 files):

**(A) Sticky control band.** \`.theme-selector\` now sits at \`position: sticky; top: 0; z-index: 10\` with a backdrop-blurred tinted background and \`env(safe-area-inset-top)\`-aware padding. Prev / theme combobox / next / random / export all stay pinned while the user scrolls through palette → terminal → IDE → reading → dashboard. Works desktop + mobile.

**(B) Zero horizontal scroll inside the showcase.** The three \`<pre>\` blocks were the last remaining sideways-scroll offenders:
- **Terminal** — keeps \`white-space: pre\` (shell alignment is load-bearing) but shrinks to 0.65rem; the two widest lines (vim-status filler and \`@@ … function signature\` diff header) are trimmed; one item dropped from the \`ls\` output.
- **IDE code** — \`white-space: pre-wrap; overflow-wrap: anywhere\` + 0.68rem font; modern IDE wrap convention, line-numbers stay with logical lines.
- **Reading pre** — same pre-wrap treatment.

## Chrome-automation verification (390 × 844 iframe of local preview)

| Check | Before | After |
| --- | --- | --- |
| \`pre.terminal\` width | 511 (overflow) | fits |
| \`pre.ide-code\` width | 631 (overflow) | fits |
| \`pre\` (reading) width | 478 (overflow) | fits |
| Overflowing elements | 3 | **0** |
| \`.theme-selector\` top at scrollY=1500 | -675 (off-screen) | **0** (stuck) |
| Listbox anchor when stuck | n/a | \`top: 88, left: 24, width: 324\` ✓ |

Scroll-test at 0 / 400 / 900 / 1500 / 2500 px: combobox pinned at \`top: 10\` (within sticky padding) from 400 onwards.

## Validation path
- nexus-agents \`consensus_vote\` (higher-order, quickMode): 2/2 non-abstained approve. Architect pre-flagged the Vite media-query reorder trap; all new \`@media (max-width: 30rem)\` blocks are placed after base rules per \`reference_astro_media_query_ordering.md\`.
- \`pnpm lint\` / \`pnpm test\` / \`pnpm -C site test\`: 61/61 green locally.

## Out of scope
- Tablet-specific (48–64rem) tweaks
- Theme-toggle a11y changes
- Playwright regression test for sticky + width-fit (follow-up issue candidate)

## Test plan
- [x] Local build green, tests 61/61 pass
- [x] Iframe at 390×844 shows zero horizontal overflow across all 5 showcase sections
- [x] Sticky band verified at five scroll depths
- [x] Desktop at 1806px shows no regression (nothing overflows, band still sticky)
- [ ] Await CI: Lighthouse ≥ thresholds, axe clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)