### PR TITLE
fix(site): neutralise dark-mode borders, collapse palette on mobile, wrap terminal

### DIFF
--- a/site/src/components/ShowcasePalette.astro
+++ b/site/src/components/ShowcasePalette.astro
@@ -30,11 +30,12 @@ function toCssVar(key: string): string {
 }
 ---
 
-<section class="showcase-palette" aria-label="Full palette">
-  <header>
-    <h2>Palette</h2>
-    <p>20 slots · click any chip to copy its <code>oklch(...)</code> string</p>
-  </header>
+<details class="showcase-palette" open>
+  <summary>
+    <span class="palette-summary-title">Palette</span>
+    <span class="palette-summary-meta">20 slots · click to copy <code>oklch(...)</code></span>
+    <span class="palette-chevron" aria-hidden="true">▾</span>
+  </summary>
   <ul role="list" class="palette-grid">
     {
       SLOTS.map((s) => (
@@ -58,7 +59,21 @@ function toCssVar(key: string): string {
     }
   </ul>
   <output class="palette-toast" role="status" aria-live="polite" data-toast />
-</section>
+</details>
+
+<script>
+  // Mobile-first: start with the 20-swatch palette collapsed so the terminal
+  // mock is above the fold. Respect any user toggle thereafter — we only set
+  // the initial state, we don't fight the user on re-paint.
+  {
+    const mq = window.matchMedia('(max-width: 30rem)');
+    if (mq.matches) {
+      for (const el of document.querySelectorAll<HTMLDetailsElement>('details.showcase-palette')) {
+        el.open = false;
+      }
+    }
+  }
+</script>
 
 <style>
   .showcase-palette {
@@ -67,25 +82,43 @@ function toCssVar(key: string): string {
     background: var(--surface);
     padding: 1rem 1.15rem 1.25rem;
   }
-  .showcase-palette header {
+  .showcase-palette > summary {
+    /* list-style controls the default ▸ marker */
+    list-style: none;
+    cursor: pointer;
     display: flex;
-    justify-content: space-between;
     align-items: baseline;
     gap: 1rem;
     flex-wrap: wrap;
+    margin: 0;
+    padding: 0;
+    /* match the old `<header> { margin-bottom }` so the grid sits correctly
+       when open */
+  }
+  .showcase-palette > summary::-webkit-details-marker {
+    display: none;
+  }
+  .showcase-palette[open] > summary {
     margin-bottom: 0.8rem;
   }
-  .showcase-palette h2 {
-    margin: 0;
+  .palette-summary-title {
     font-size: 0.9rem;
     text-transform: uppercase;
     letter-spacing: 0.1em;
     font-weight: 600;
   }
-  .showcase-palette p {
-    margin: 0;
+  .palette-summary-meta {
     font-size: 0.78rem;
     color: color-mix(in oklch, var(--fg) 65%, transparent);
+  }
+  .palette-chevron {
+    margin-left: auto;
+    font-size: 0.8rem;
+    color: color-mix(in oklch, var(--fg) 60%, transparent);
+    transition: transform 140ms ease;
+  }
+  .showcase-palette[open] > summary .palette-chevron {
+    transform: rotate(180deg);
   }
   .showcase-palette code {
     font-family: var(--font-mono);

--- a/site/src/components/ShowcaseTerminal.astro
+++ b/site/src/components/ShowcaseTerminal.astro
@@ -123,12 +123,17 @@
   }
   @media (max-width: 30rem) {
     .terminal {
-      /* Shell alignment is load-bearing — keep `white-space: pre` and
-         shrink font instead of wrapping. The shortened vim status line
-         (`── INSERT ── 3,15 Top`) is now the widest line. */
+      /* Mobile: wrap shell output instead of rendering a horizontal
+         scrollbar. The mock's longest lines have been pre-trimmed so
+         wrapping is rare but the safety-net is now unconditional — no
+         left/right scrollbar under any theme, any zoom level, any device
+         font substitution. */
       padding: 0.65rem 0.8rem;
       font-size: 0.65rem;
       line-height: 1.5;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      overflow-x: hidden;
     }
   }
 </style>

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -125,7 +125,7 @@ const siteName = 'oklch-terminal-themes';
       --fg: oklch(0.95 0.005 250);
       --accent: oklch(0.75 0.15 260);
       --surface: oklch(1 0 0 / 0.05);
-      --border: oklch(1 1 0 / 0.12);
+      --border: oklch(1 0 0 / 0.12);
       color-scheme: dark;
     }
   }
@@ -136,7 +136,7 @@ const siteName = 'oklch-terminal-themes';
     --fg: oklch(0.95 0.005 250);
     --accent: oklch(0.75 0.15 260);
     --surface: oklch(1 0 0 / 0.05);
-    --border: oklch(1 1 0 / 0.12);
+    --border: oklch(1 0 0 / 0.12);
     color-scheme: dark;
   }
 


### PR DESCRIPTION
Three user-reported papercuts in one surgical PR.

## 1. Dark-mode red-tinted borders → subtle white
\`--border\` in both the \`@media (prefers-color-scheme: dark)\` and the explicit \`[data-site-theme='dark']\` blocks was \`oklch(1 1 0 / 0.12)\` — chroma=1 at hue=0 is extreme red. Composited at 12% alpha over a dark bg, every border, divider, and outline picked up a visible red tint. Changed to \`oklch(1 0 0 / 0.12)\` (pure white, 12% alpha) to mirror the light-mode \`oklch(0 0 0 / 0.12)\` shape.

**Before:** \`theme-selector.borderBottomColor == oklch(1 1 0 / 0.12)\` (red-shifted)
**After:** \`theme-selector.borderBottomColor == oklch(1 0 0 / 0.12)\` (achromatic)

## 2. Palette collapsed by default on mobile
\`ShowcasePalette\` now renders as a \`<details>\` with \`open\` initially, plus a tiny inline \`matchMedia('(max-width: 30rem)')\` check that closes it on first paint at narrow widths. The terminal mock is above the fold on a 390px device. Chevron rotates with \`[open]\`; we don't re-snap on resize, so user toggles stick.

## 3. Terminal wraps on mobile (no horizontal scrollbar ever)
At ≤ 30rem the terminal \`<pre>\` flips to \`white-space: pre-wrap; overflow-wrap: anywhere; overflow-x: hidden\`. PR #61 already trimmed content so no-wrap fit, but that was a content-length assumption — this turns it into a guarantee across themes, zoom levels, and font-substitution paths. IDE code was already wrapping (#61).

## Verification (Chrome iframe at 390×844, dark mode)
- \`theme-selector.borderBottomColor == oklch(1 0 0 / 0.12)\` ✓
- \`details.showcase-palette[open]\` → \`false\` at first paint ✓
- Clicking summary expands → 20 chips render ✓
- \`getComputedStyle(.terminal).whiteSpace == 'pre-wrap'\` ✓
- \`.terminal.scrollWidth === .terminal.clientWidth\` (no horizontal scroll) ✓
- \`.ide-code.scrollWidth === .ide-code.clientWidth\` (no horizontal scroll) ✓
- Zero elements exceed viewport width

## Test plan
- [x] \`pnpm lint\` green
- [x] 61/61 tests pass
- [x] Build green
- [ ] Await CI: Lighthouse, axe, CodeQL

## Out of scope
Removing borders entirely on non-picker regions (the user offered that as an alternative; fixing the red is the cleaner fix and keeps visual separation useful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)