### PR TITLE
docs: align repo docs with what's actually on main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ src/
 ├── types.ts       # Type definitions, COLOR_KEYS (20 keys: bg, fg, cursor, selection, 8 ANSI, 8 bright ANSI)
 ├── schema.ts      # Zod schemas for upstream input and emitted output
 ├── convert.ts     # hex ↔ OKLCH, ΔE2000 round-trip, numeric clamping/rounding
-├── classify.ts    # isDark + tag derivation (dark/light, vibrant/muted, high/low-contrast, popular)
+├── classify.ts    # isDark, WCAG contrast (fg/bg + min non-blend ANSI), tag derivation (dark/light, vibrant/muted, wcag-aaa/aa/aa-large/fail, ansi-legible, popular, legacy high/low-contrast)
 └── slug.ts        # name → kebab-case slug
 
 scripts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,40 +8,52 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added — governance + quality
 
-- AGENTS.md, CODING_STANDARDS.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md — repo governance adapted from nexus-agents v2.2.0 standards. SECURITY.md documents four Scorecard checks intentionally deferred (Fuzzing, CIIBestPractices, Maintained, CodeReview) with rationale.
+- `AGENTS.md`, `CODING_STANDARDS.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md` — repo governance adapted from nexus-agents v2.2.0 standards. `SECURITY.md` documents four Scorecard checks intentionally deferred (Fuzzing, CIIBestPractices, Maintained, CodeReview) with rationale.
 - Prettier, ESLint strict ruleset, markdownlint, commitlint, Husky hooks, gitleaks config, lychee link-check config.
-- `.github/`: CodeQL workflow, OpenSSF Scorecard, link-check workflow, gitleaks workflow (CI-side, in addition to the husky hook), Dependabot config, PR + issue templates, CODEOWNERS, FUNDING.
+- `.github/`: CodeQL workflow, OpenSSF Scorecard, link-check workflow, gitleaks workflow (CI-side in addition to the husky hook), Dependabot config, PR + issue templates, CODEOWNERS, FUNDING.
 - `.editorconfig`, `.gitattributes` for consistent line endings and indentation across editors.
-- `pnpm.overrides` in `package.json` to force patched versions of transitive advisories (`js-yaml >= 4.1.1`, `markdown-it >= 14.1.1`, `smol-toml >= 1.6.1`).
+- `pnpm.overrides` in `package.json` forcing patched versions of transitive advisories (`js-yaml >= 4.1.1`, `markdown-it >= 14.1.1`, `smol-toml >= 1.6.1`).
+
+### Added — classifier and dataset
+
+- **WCAG 2.x contrast data** on every `TerminalColorTheme` (#58). Adds `contrast: { fgOnBg, minAnsi, minAnsiSlot }` and five new tags — `wcag-aaa`, `wcag-aa`, `wcag-aa-large`, `wcag-fail`, `ansi-legible`. Existing `high-contrast` / `low-contrast` tags retained for back-compat. `minAnsi` excludes the slot(s) that conventionally blend with the background (`black` + `brightBlack` on dark themes, `white` + `brightWhite` on light themes) so intentional near-bg slots don't false-flag otherwise well-formed themes. `SlimTheme` also carries `contrast` so the picker can read it without pulling the full dataset.
+- Corpus distribution at the current pinned SHA: 410 AAA, 463 AA, 9 `wcag-fail`, 255 `ansi-legible`.
 
 ### Added — GitHub Pages theme-picker site
 
 - `site/` — Astro 5 project deployed to https://williamzujkowski.github.io/oklch-terminal-themes/ via `.github/workflows/pages.yml`. Dogfoods the npm package via `workspace:*` — no re-parsing of upstream iTerm schemes.
-- **Picker grid**: 485 theme cards (popular-first + alphabetical), responsive CSS grid.
-- **Filters**: search by name/slug + 7 tag chips (dark / light / vibrant / muted / high-contrast / low-contrast / popular). URL state round-trips (`?q=...&tags=...`).
-- **Dual-pane preview**: selecting a card sets `?theme=<slug>` and renders two live mocks painted from the theme's palette — a terminal widget covering all 16 ANSI slots + cursor + fg, and a mini web-page chrome (nav / hero / CTA / success/danger chips / card grid / code block) mapping `blue`→links, `green`→success, `red`→danger, `purple`→accent.
-- **Actions panel**: copy `:root` CSS vars, Tailwind v4 `@theme` block, raw JSON, or shareable permalink. Graceful "Clipboard blocked" toast when the Clipboard API is denied.
-- **Site-chrome dark-mode toggle** (separate from the theme preview). Inline pre-paint script prevents FOUC; explicit preference persists via `localStorage`; OS changes still propagate when no explicit choice has been made.
-- **A11y**: `aria-pressed` tag chips and toggle; `aria-live` filter count; `role="status"` copy toast; descriptive `aria-label`s on interactive affordances; full keyboard tabbing.
-- **Performance**: single static HTML page (no JS bundle — all interactive scripts inlined). Themes-slim data embedded as inline JSON for zero-roundtrip preview lookups.
-- **Side-by-side compare mode** (previously deferred, now shipped). Each card has a hover-revealed "vs" link; clicking sets `?compare=<slug>` alongside `?theme=<slug>` to paint a second preview pane below the primary. Primary pane hosts the ActionsPanel; compare pane is preview-only so copy/share output is unambiguous.
-- **Open Graph + Twitter card meta**, canonical URL, robots directive, and a 1200×630 OKLCH swatch OG image at `/og-image.svg` — shared links in Slack / Discord / iMessage render with title + description + preview image.
-- **Keyboard shortcuts**: `/` focuses search (suppressed when already typing elsewhere), `Esc` clears search or collapses visible preview panes (compare first, then primary), matching back/forward URL behaviour.
-- **Unit tests** for the site library (`theme-filter.ts` + `formatters.ts`) — 25 vitest cases covering filter matching, URL parse/serialise round-trips, CSS/Tailwind/JSON formatters, and permalink construction. Wired into CI.
+- **Combobox picker + live showcase** (#46). The original grid-of-tiles was replaced with a single theme-selector combobox and a live scrolling showcase painted from the active theme's palette: full 20-swatch palette, terminal session, IDE mock with tree / tabs / code / status bar, a blog/reading view with callouts, and a dashboard with stat cards / tables / progress bars.
+- **Search + tag filters** in the listbox. 8 chips: dark / light / vibrant / muted / `wcag-aaa` / `wcag-aa` / `ansi-legible` / popular. URL state round-trips (`?q=...&tags=...`).
+- **WCAG badge** in the showcase header (#59). Shows the tier + fg/bg ratio (`AAA · fg 13.4:1`); green tint for AAA, red for Fail, neutral accent otherwise. Explicitly labels the ratio as `fg` so users don't assume the rating certifies ANSI-slot legibility.
+- **Export menu**: copy `:root` CSS vars, Tailwind v4 `@theme` block, raw JSON, or shareable permalink (`?theme=<slug>`). Graceful "Clipboard blocked" toast when the Clipboard API is denied.
+- **Palette chip copy-to-clipboard**: clicking any of the 20 palette chips copies its `oklch(...)` string, with a status toast.
+- **Site-chrome light / dark toggle** (separate from the theme preview). Inline pre-paint script prevents FOUC; explicit preference persists via `localStorage`; OS changes still propagate when no explicit choice has been made.
+- **Mobile responsive** (#52, #61, #62). Every element fits a 390px viewport without horizontal scroll: showcase containers capped at `min-width: 0` so deep `<pre>` descendants contain their own overflow; IDE tree hidden at ≤ 30rem; palette grid drops to 2 columns; dashboard panels stack; ThemeSelector primary row stacks the combobox above prev / next / random / export. At ≤ 30rem the IDE code and reading `<pre>` switch to `white-space: pre-wrap` and the terminal gets a tight font (content pre-trimmed so no-wrap already fit, but pre-wrap is now an unconditional guarantee).
+- **Sticky control band** (#61). The ThemeSelector is `position: sticky; top: 0` with a backdrop-blurred tint and `env(safe-area-inset-top)`-aware padding, so prev / combobox / next / random / export stay on-screen while the user scrolls through the showcase.
+- **Collapsed palette on mobile** (#62). The palette section is a `<details>` — open by default on desktop, closed on first paint at ≤ 30rem so the terminal mock is above the fold. User toggles persist across re-paints.
+- **Keyboard shortcuts**: `/` opens the listbox, `←` / `→` cycle prev/next theme, `r` picks a random theme, `Esc` closes the listbox.
+- **A11y**: `aria-pressed` tag chips + toggle; `aria-live` filter count; `role="status"` copy toast; descriptive `aria-label`s on interactive affordances; full keyboard tabbing. Lighthouse + axe wired into CI so regressions are caught at PR time.
+- **Performance**: single static HTML page; the controller script is the only JS bundle. Themes-slim data is embedded as inline JSON for zero-roundtrip preview lookups.
+- **Open Graph + Twitter card meta**, canonical URL, robots directive, and a 1200×630 OG image — shared links in Slack / Discord / iMessage render with title + description + preview image.
+- **Unit tests** for the site library (`theme-filter.ts` + `formatters.ts`) — 30 vitest cases covering filter matching, URL parse/serialise round-trips, CSS/Tailwind/JSON formatters, permalink construction, and WCAG label/ratio formatting. Wired into CI.
+
+### Added — release + publish automation
+
+- **OIDC Trusted Publishing** to npm for the root package.
+- **Conventional-Commit-driven GitHub Releases** via commit labels.
+
+### Removed
+
+- **Side-by-side compare mode** (#53). With 485 themes the primary job is discovery (search / filter / random / prev / next), not A/B comparison. Removing it collapsed the dual-slot state machine, removed `?compare=<slug>`, dropped the `c` keyboard shortcut, and simplified the controller by ~160 lines. Permalink format `?theme=<slug>` unchanged.
 
 ### Changed
 
-- CI workflow now runs commitlint (on PRs), ESLint, Prettier format check, markdownlint, typecheck, tests, full build-and-validate pipeline, site build+typecheck, and pnpm audit.
-- Upgraded dev dependencies: eslint 9 → 10, @commitlint/\* 19 → 20, lint-staged 15 → 16, markdownlint-cli2 0.15 → 0.22. Held back: `@types/node` (tracks Node 22 LTS), `vite` (vitest 4 peer constraint), `typescript` (kept on 5.9.x — Astro 5 ecosystem's peer range excludes TS 6).
+- CI workflow now runs commitlint (on PRs), ESLint, Prettier format check, markdownlint, typecheck, tests, full build-and-validate pipeline, site build + typecheck + tests, Lighthouse, axe, and pnpm audit. `CI Success` gate job aggregates all required checks.
+- Dark-mode `--border` fixed (#62): was `oklch(1 1 0 / 0.12)` — chroma=1 at hue=0 is extreme red, giving every border a visible red tint once composited over the dark background. Now `oklch(1 0 0 / 0.12)` (achromatic white at 12% alpha), matching the shape of the light-mode `oklch(0 0 0 / 0.12)` value.
+- Upgraded dev dependencies: eslint 9 → 10, @commitlint/\* 19 → 20, lint-staged 15 → 16, markdownlint-cli2 0.15 → 0.22, vitest 2 → 4, vite 6 → 7, zod 3 → 4. Held back: `@types/node` (tracks Node 22 LTS), `typescript` (kept on 5.9.x — Astro 5 ecosystem's peer range excludes TS 6).
 - Upgraded all GitHub Actions to latest releases and **pinned every `uses:` line by commit SHA** with a `# v<tag>` comment (closes Scorecard PinnedDependenciesID alerts). `pnpm/action-setup` held on v4 — v6 regressed `ERR_PNPM_BROKEN_LOCKFILE` under `--frozen-lockfile` on a single-document YAML lockfile.
 - Dependabot config groups minor/patch npm updates, groups dev-dep majors (ignoring `@types/node` majors — tracks LTS runtime), and groups all action bumps — green CI is the gate, not manual triage of each tag.
-- `lint:md` command uses inline negation globs (`!**/node_modules/**`) instead of markdownlint-cli2's `#` ignore syntax — the latter expanded the full glob first on a workspace-scale \`node_modules\` and hit a 4 GB heap ceiling.
-- Added `ci.yml` job to verify site build + typecheck on every PR. `CI Success` gate job aggregates all required checks.
-
-### Deferred
-
-- **Lighthouse + axe-core automated a11y gate.** Tracked in [issue #18](https://github.com/williamzujkowski/oklch-terminal-themes/issues/18). Manual chrome-automation audit is clean (zero console errors, 1 HTTP resource on first paint, keyboard tabbing + new shortcuts verified) but an automated check in CI would prevent regressions.
-- **Raster OG image.** Current `og-image.svg` renders in modern consumers (Slack, Discord, recent Safari); Twitter + older Facebook crawlers that require PNG/JPG fall back to the text-only card. A rasterised version can be added when an image-generation step is added to the build.
+- `lint:md` command uses inline negation globs (`!**/node_modules/**`) instead of markdownlint-cli2's `#` ignore syntax — the latter expanded the full glob first on a workspace-scale `node_modules` and hit a 4 GB heap ceiling.
 
 ## [0.1.0] — 2026-04-14
 

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -252,10 +252,13 @@ Two upstream files collapsing to the same slug is a silent data-loss bug. `scrip
 | --------------------- | ------ |
 | Line coverage         | ≥ 80%  |
 | Branch coverage       | ≥ 75%  |
-| Conversion / schema   | 100%   |
-| Classifier heuristics | 100%   |
+| Conversion / schema   | ≥ 85%  |
+| Classifier heuristics | ≥ 95%  |
 
-Conversion and schema code is "critical path" — a bug silently ships broken colors to every consumer.
+Conversion and schema code is "critical path" — a bug silently ships broken
+colors to every consumer. The targets above are the minimum we ship; actuals
+are usually a few points higher (run `pnpm test:coverage` to see current
+numbers).
 
 ### 7.2 Test structure (Vitest)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,8 +183,11 @@ Do not break these without an explicit user-facing decision:
 | --------------------- | ------ |
 | Line coverage         | ≥ 80%  |
 | Branch coverage       | ≥ 75%  |
-| Conversion & schema   | 100%   |
-| Classifier heuristics | 100%   |
+| Conversion & schema   | ≥ 85%  |
+| Classifier heuristics | ≥ 95%  |
+
+Current (per `pnpm test:coverage`): line 96%, branch 87%, `convert.ts` 87%/91%
+statements/lines, `classify.ts` 97%/98% statements/lines.
 
 ### Test structure
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Designed for consumption by Astro sites, theme pickers, Tailwind v4 `@theme` blo
 
 **Live demo + picker:** https://williamzujkowski.github.io/oklch-terminal-themes/
 
-Browse all 485 themes, filter by tag, preview on a terminal mock + website mock, copy as CSS variables / Tailwind `@theme` / raw JSON, or compare two themes side-by-side.
+Browse 485 themes via a search + filter combobox, preview each theme live across five UI mocks (palette, terminal, IDE, reading view, dashboard), copy the active theme as CSS variables / Tailwind `@theme` / raw JSON, or share a permalink.
 
 ## Install
 
@@ -73,7 +73,7 @@ interface TerminalColorTheme {
   name: string; // "Dracula"
   slug: string; // "dracula"
   isDark: boolean;
-  tags: string[]; // "dark" | "light" | "vibrant" | "muted" | "high-contrast" | "low-contrast" | "popular"
+  tags: string[]; // see "Tags" below
   source: 'iterm2-color-schemes';
   sourceUrl: string; // deep link to upstream file at pinned SHA
   upstreamSha: string;
@@ -82,10 +82,31 @@ interface TerminalColorTheme {
     ColorKey,
     { hex: string; oklch: { l: number; c: number; h: number }; oklchCss: string }
   >;
+  contrast: {
+    fgOnBg: number; // WCAG 2.x body-text ratio (foreground vs background)
+    minAnsi: number; // worst non-blend ANSI slot vs background
+    minAnsiSlot: ColorKey; // which slot hit `minAnsi`
+  };
 }
 ```
 
 20 color keys per theme: `background`, `foreground`, `cursor`, `selection`, and the 16 ANSI slots (`black`...`white`, `brightBlack`...`brightWhite`).
+
+### Tags
+
+| Tag                              | Meaning                                                                                            |
+| -------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `dark` / `light`                 | derived from OKLCH background lightness                                                            |
+| `vibrant` / `muted`              | average OKLCH chroma across all 20 slots                                                           |
+| `popular`                        | slug matches a well-known family (dracula, nord, solarized, …)                                     |
+| `wcag-aaa`                       | `contrast.fgOnBg ≥ 7`                                                                              |
+| `wcag-aa`                        | `contrast.fgOnBg ≥ 4.5`                                                                            |
+| `wcag-aa-large`                  | `3 ≤ contrast.fgOnBg < 4.5`                                                                        |
+| `wcag-fail`                      | `contrast.fgOnBg < 3`                                                                              |
+| `ansi-legible`                   | `contrast.minAnsi ≥ 3` — every non-blend ANSI slot clears AA-large against the background          |
+| `high-contrast` / `low-contrast` | retained for backwards compatibility with pre-WCAG-tag consumers (`> 10:1` / `< 5:1` respectively) |
+
+`minAnsi` excludes the slot(s) that conventionally blend with the background — `black` + `brightBlack` on dark themes, `white` + `brightWhite` on light themes — so intentional near-bg slots don't false-flag otherwise well-formed themes.
 
 ## How it's built
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@williamzujkowski/oklch-terminal-themes",
   "version": "0.1.0",
-  "description": "Canonical dataset of 450+ terminal color schemes converted to OKLCH — npm package + JSON API for Astro, Svelte, Tailwind v4, and theme pickers.",
+  "description": "Canonical dataset of 485 terminal color schemes converted to OKLCH, with WCAG contrast data per theme — npm package + JSON API for Astro, Svelte, Tailwind v4, and theme pickers.",
   "type": "module",
   "license": "MIT",
   "author": "William Zujkowski",


### PR DESCRIPTION
Closes #64. Part of epic #63 (full-pipeline review).

## Why
Two months of UX iteration (#46, #52, #53, #58, #59, #61, #62) left the prose docs describing a repo that no longer exists. Inventory at the top of #63 — the short version: README still advertised side-by-side compare, the tag list was missing five WCAG tiers, \`TerminalColorTheme\` was missing its \`contrast\` field, the CHANGELOG \`[Unreleased]\` section described the old grid picker and called compare-mode "now shipped", \`package.json\` said "450+" themes (485 today), and CONTRIBUTING + CODING_STANDARDS both quoted "100%" coverage targets we've never actually hit.

## What changes

- **README.md** — rewrite the live-demo paragraph; add a Tags reference table with WCAG-tier thresholds; add \`contrast: { fgOnBg, minAnsi, minAnsiSlot }\` to the schema snippet; spell out the black/white blend-exclusion rule for \`minAnsi\`.
- **AGENTS.md** — extend the \`classify.ts\` one-liner to include WCAG contrast + the new tags.
- **CHANGELOG.md \`[Unreleased]\`** — full rewrite from scratch. Now lists every merged PR since 0.1.0: showcase redesign (#46), mobile responsive (#52), compare removal (#53), WCAG pipeline (#58), WCAG UI (#59), sticky + fluid-fit (#61), red-border / palette-collapse / terminal-wrap (#62). New "Removed" section so the compare drop is explicit.
- **package.json** — "450+" → "485", and call out WCAG contrast data as a feature.
- **CONTRIBUTING.md + CODING_STANDARDS.md** — "100%" conversion/classifier coverage → realistic minimums (\`≥ 85%\` / \`≥ 95%\`) with an inline note that actuals are a few points higher. Run \`pnpm test:coverage\` to see current numbers.

## Explicit non-goals

- No code changes, no JSON regeneration, no new features, no site restyle.

## Verification

- \`pnpm lint:md\` — clean (14 files, 0 errors)
- \`pnpm lint\` — clean
- \`pnpm test\` + \`pnpm -C site test\` — 61/61 pass (unchanged)
- Every feature claim in \`[Unreleased]\` maps to a merged PR (cross-ref PR numbers inline)
- Design-cohesion audit of the deployed site (promised in #63) came back clean, so the second planned PR is cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)