### PR TITLE
fix(security): resolve three CodeQL findings

### DIFF
--- a/scripts/fetch-upstream.ts
+++ b/scripts/fetch-upstream.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
-import { execSync } from 'node:child_process';
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { SourcesConfigSchema, type SourceConfig } from '../src/sources.js';
 
@@ -9,8 +9,18 @@ const UPSTREAM_DIR = join(ROOT, 'upstream');
 const SOURCES_FILE = join(ROOT, 'sources.json');
 const SHAS_FILE = join(ROOT, '.upstream-shas.json');
 
-function sh(cmd: string, cwd: string): string {
-  return execSync(cmd, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] }).trim();
+/**
+ * Run a git command with an explicit argument array. Using `execFileSync`
+ * (no shell) ensures arguments — including absolute paths derived from
+ * `import.meta.url` — are passed verbatim and never interpreted by a shell,
+ * eliminating shell command injection.
+ */
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  }).trim();
 }
 
 function loadSources(): SourceConfig[] {
@@ -28,18 +38,18 @@ function syncSource(source: SourceConfig, pinnedSha: string | undefined): string
   const targetDir = join(UPSTREAM_DIR, source.id);
   if (existsSync(targetDir)) rmSync(targetDir, { recursive: true, force: true });
   const url = `https://github.com/${source.repo}.git`;
-  sh(
-    `git clone --depth 1 --filter=blob:none --sparse --no-checkout ${url} ${source.id}`,
+  git(
+    ['clone', '--depth', '1', '--filter=blob:none', '--sparse', '--no-checkout', url, source.id],
     UPSTREAM_DIR,
   );
-  sh(`git sparse-checkout set ${source.themesPath}`, targetDir);
+  git(['sparse-checkout', 'set', source.themesPath], targetDir);
   if (pinnedSha !== undefined && pinnedSha.length > 0) {
-    sh(`git fetch --depth 1 origin ${pinnedSha}`, targetDir);
-    sh(`git checkout ${pinnedSha}`, targetDir);
+    git(['fetch', '--depth', '1', 'origin', pinnedSha], targetDir);
+    git(['checkout', pinnedSha], targetDir);
   } else {
-    sh('git checkout', targetDir);
+    git(['checkout'], targetDir);
   }
-  return sh('git rev-parse HEAD', targetDir);
+  return git(['rev-parse', 'HEAD'], targetDir);
 }
 
 function main(): void {
@@ -48,7 +58,7 @@ function main(): void {
   const resolved: Record<string, string> = {};
 
   if (!existsSync(UPSTREAM_DIR)) {
-    sh(`mkdir -p ${UPSTREAM_DIR}`, ROOT);
+    mkdirSync(UPSTREAM_DIR, { recursive: true });
   }
 
   for (const source of sources) {

--- a/site/test/a11y.test.ts
+++ b/site/test/a11y.test.ts
@@ -20,11 +20,16 @@ const BLOCKING_IMPACTS = new Set<string>(['serious', 'critical']);
 describe('a11y: built index.html (axe wcag2a + wcag2aa)', () => {
   beforeAll(async () => {
     const raw = await readFile(distIndex, 'utf-8');
-    // Strip all inline <script> contents. jsdom can't safely execute our
+    // Strip all inline <script> elements. jsdom can't safely execute our
     // pre-paint scripts (no matchMedia in the VM context), and scripts have
     // no bearing on WCAG structural a11y anyway — axe checks the DOM, ARIA
     // attributes, color contrast, etc.
-    const sansScripts = raw.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');
+    //
+    // The closing-tag pattern allows optional whitespace inside the tag
+    // (`</script >`) and a self-closing `<script ... />`, so a crafted tag
+    // cannot survive the strip — see CodeQL js/bad-tag-filter and
+    // js/incomplete-multi-character-sanitization.
+    const sansScripts = raw.replace(/<script\b[^>]*?(?:\/>|>[\s\S]*?<\/script\s*>)/gi, '');
     document.open();
     document.write(sansScripts);
     document.close();


### PR DESCRIPTION
Resolves three open CodeQL alerts.

## Alert #75 — js/shell-command-injection-from-environment [medium]
**File:** `scripts/fetch-upstream.ts:13`

The `sh()` helper executed git commands via `execSync`, building a shell command string with interpolated values. The interpolated absolute paths derive from `import.meta.url` (`ROOT` / `UPSTREAM_DIR`), which CodeQL flags as an uncontrolled absolute path that could break out of the intended command if it contained shell metacharacters or whitespace.

**Fix:** Replaced the `sh()` helper with a `git()` helper that uses `execFileSync('git', [...args])` — an explicit argument array with no shell, so every argument (including absolute paths) is passed verbatim. Also replaced the `mkdir -p` shell call with `fs.mkdirSync(dir, { recursive: true })`. No behavior change.

## Alert #71 — js/bad-tag-filter [high]
## Alert #70 — js/incomplete-multi-character-sanitization [high]
**File:** `site/test/a11y.test.ts:27`

The inline-`<script>`-stripping regex was `/<script[^>]*>[\s\S]*?<\/script>/gi`. Its closing-tag pattern `<\/script>` does not match valid HTML closing tags that contain whitespace (`</script >`, `</script\n>`), nor self-closing `<script />` forms, so crafted markup could survive the strip. The opening `<script` also lacked a word boundary.

**Fix:** Tightened the pattern to `/<script\b[^>]*?(?:\/>|>[\s\S]*?<\/script\s*>)/gi`:
- `\b` word boundary so `<scripting>` is not matched
- `\/>` alternative handles self-closing tags
- `<\/script\s*>` allows optional whitespace inside the closing tag

Verified against `<script>`, `<script src=x>...</script >`, `</script\n>`, `<script/>`, `<script src=x />`, and non-script `<scripting>` cases.

## Verification
- `pnpm typecheck` — pass
- `pnpm build` — pass (503 themes built)
- `pnpm test` — pass (31/31)
- site `pnpm test` — pass (30/30)
- site `pnpm test:a11y` — pass (1/1, exercises the modified regex)
- `pnpm lint` — pass
- `prettier --check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)